### PR TITLE
Make email and phone fields clickable in contact details

### DIFF
--- a/dt-assets/js/contact-details.js
+++ b/dt-assets/js/contact-details.js
@@ -848,8 +848,14 @@ jQuery(document).ready(function($) {
         if (field.value){
           allEmptyValues = false
         }
+        let link = _.escape(field.value);
+        if (contact_method == "contact_email") {
+          link = `<a href="mailto:${_.escape(field.value)}">${_.escape(field.value)}</a>`
+        } else if (contact_method == "contact_phone") {
+          link = `<a href="tel:${_.escape(field.value)}">${_.escape(field.value)}</a>`
+        }
         htmlField.append(`<li class="details-list ${_.escape(field.key)}">
-            ${_.escape(field.value)}
+              ${link}
               <img id="${_.escape(field.key)}-verified" class="details-status" ${!field.verified ? 'style="display:none"': ""} src="${contactsDetailsWpApiSettings.template_dir}/dt-assets/images/verified.svg"/>
               <img id="${_.escape(field.key)}-invalid" class="details-status" ${!field.invalid ? 'style="display:none"': ""} src="${contactsDetailsWpApiSettings.template_dir}/dt-assets/images/broken.svg"/>
             </li>


### PR DESCRIPTION
This turns the email and phone fields in the contact details page, to links using the `mailto:` and `tel:` protocols.

The `mailto:` link will be useful for people in media roles, when they need to send someone an email.

The `tel:` link will be useful to multipliers, they will be able to call or SMS contacts quicker.