### PR TITLE
Delete post metadata value along with details (from API)

### DIFF
--- a/dt-posts/posts.php
+++ b/dt-posts/posts.php
@@ -1123,7 +1123,14 @@ class Disciple_Tools_Posts
                         return new WP_Error( __FUNCTION__, "missing key on: " . $details_key );
                     }
                     //delete field
+                    $potential_error = delete_post_meta( $post_id, $field["key"] );
+                    if ( is_wp_error( $potential_error ) ){
+                        return $potential_error;
+                    }
                     $potential_error = delete_post_meta( $post_id, $field["key"] . '_details' );
+                    if ( is_wp_error( $potential_error ) ){
+                        return $potential_error;
+                    }
                 } else if ( isset( $field["key"] ) ){
                     //update field
                     $potential_error = self::update_post_contact_method( $post_id, $field["key"], $field );


### PR DESCRIPTION
When attempting to delete a phone number from a contact via the API, I found it was not being deleted. 

POST to `/wp-json/dt-posts/v2/contacts/{id}`
Body:
```
{
  "contact_phone": [{
    "delete": true,
    "key": "contact_phone_123"
  }]
}
```

**Expected**
Should delete phone number so that it is no longer returned from the API. In the database, it should delete metadata records for `contact_phone_123` and `contact_phone_123_details`

**Actual**
Phone number is still returned from the API. In the database, only `contact_phone_123_details` was deleted.

**Fix Description**
When deleting post metadata, this update includes the deletion of both metadata records so that the value is completely deleted.