### PR TITLE
Fix enqueue scripts bug when using a child theme

### DIFF
--- a/dt-assets/js/shared-functions.js
+++ b/dt-assets/js/shared-functions.js
@@ -10,7 +10,7 @@ jQuery(document).ready(function($) {
     } else {
         ref = window.location.pathname
     }
-    $(`div.top-bar-left ul.menu [href*=${ref.replace(wpApiShare.site_url, '').split('/')[0]}]`).parent().addClass('active');
+    $(`div.top-bar-left ul.menu [href$=${ref.replace(wpApiShare.site_url, '').split('/')[0]+'\\/'}]`).parent().addClass('active');
 })
 
 

--- a/dt-metrics/metrics-contacts.php
+++ b/dt-metrics/metrics-contacts.php
@@ -53,7 +53,7 @@ class Disciple_Tools_Metrics_Contacts extends Disciple_Tools_Metrics_Hooks_Base 
     }
 
     public function scripts() {
-        wp_enqueue_script( 'dt_metrics_project_script', get_stylesheet_directory_uri() . '/dt-metrics/metrics-contacts.js', [
+        wp_enqueue_script( 'dt_metrics_project_script', get_template_directory_uri() . '/dt-metrics/metrics-contacts.js', [
             'moment',
             'jquery',
             'jquery-ui-core',

--- a/dt-metrics/metrics-critical-path.php
+++ b/dt-metrics/metrics-critical-path.php
@@ -52,7 +52,7 @@ class Disciple_Tools_Metrics_Critical_Path extends Disciple_Tools_Metrics_Hooks_
     }
 
     public function scripts() {
-        wp_enqueue_script( 'dt_metrics_project_script', get_stylesheet_directory_uri() . '/dt-metrics/metrics-critical-path.js', [
+        wp_enqueue_script( 'dt_metrics_project_script', get_template_directory_uri() . '/dt-metrics/metrics-critical-path.js', [
             'moment',
             'jquery',
             'jquery-ui-core',

--- a/dt-metrics/metrics-personal.php
+++ b/dt-metrics/metrics-personal.php
@@ -37,7 +37,7 @@ class Disciple_Tools_Metrics_Personal extends Disciple_Tools_Metrics_Hooks_Base
     }
 
     public function scripts() {
-        wp_enqueue_script( 'dt_metrics_personal_script', get_stylesheet_directory_uri() . '/dt-metrics/metrics-personal.js', [
+        wp_enqueue_script( 'dt_metrics_personal_script', get_template_directory_uri() . '/dt-metrics/metrics-personal.js', [
             'jquery',
             'jquery-ui-core',
             'amcharts-core',

--- a/dt-metrics/metrics-prayer.php
+++ b/dt-metrics/metrics-prayer.php
@@ -44,7 +44,7 @@ class Disciple_Tools_Metrics_Prayer extends Disciple_Tools_Metrics_Hooks_Base
     }
 
     public function scripts() {
-        wp_enqueue_script( 'dt_metrics_prayer_script', get_stylesheet_directory_uri() . '/dt-metrics/metrics-prayer.js', [
+        wp_enqueue_script( 'dt_metrics_prayer_script', get_template_directory_uri() . '/dt-metrics/metrics-prayer.js', [
             'jquery',
             'jquery-ui-core',
         ], filemtime( get_theme_file_path() . '/dt-metrics/metrics-prayer.js' ), true );

--- a/dt-metrics/metrics-project.php
+++ b/dt-metrics/metrics-project.php
@@ -53,7 +53,7 @@ class Disciple_Tools_Metrics_Project extends Disciple_Tools_Metrics_Hooks_Base
     public function scripts() {
         wp_register_script( 'amcharts-core', 'https://www.amcharts.com/lib/4/core.js', false, '4' );
         wp_register_script( 'amcharts-charts', 'https://www.amcharts.com/lib/4/charts.js', false, '4' );
-        wp_enqueue_script( 'dt_metrics_project_script', get_stylesheet_directory_uri() . '/dt-metrics/metrics-project.js', [
+        wp_enqueue_script( 'dt_metrics_project_script', get_template_directory_uri() . '/dt-metrics/metrics-project.js', [
             'jquery',
             'jquery-ui-core',
             'amcharts-core',

--- a/dt-metrics/metrics-workers.php
+++ b/dt-metrics/metrics-workers.php
@@ -128,7 +128,7 @@ class Disciple_Tools_Metrics_Users extends Disciple_Tools_Metrics_Hooks_Base
     }
 
     public function scripts() {
-        wp_enqueue_script( 'dt_metrics_workers_script', get_stylesheet_directory_uri() . '/dt-metrics/metrics-workers.js', [
+        wp_enqueue_script( 'dt_metrics_workers_script', get_template_directory_uri() . '/dt-metrics/metrics-workers.js', [
             'jquery',
             'jquery-ui-core',
             'amcharts-core',


### PR DESCRIPTION
get_stylesheet_directory_uri() uses the child theme directory if a child theme is active.  This is not the desired behavior when actually using a child theme.  It results in metrics-personal.js not being properly enqueued, and the Metrics page fails to load.  We should load metrics-personal.js from the parent theme by using get_template_directory_uri() instead to ensure compatibility.