### PR TITLE
Completing child-theme compatibility patch

### DIFF
--- a/dt-assets/js/shared-functions.js
+++ b/dt-assets/js/shared-functions.js
@@ -10,7 +10,7 @@ jQuery(document).ready(function($) {
     } else {
         ref = window.location.pathname
     }
-    $(`div.top-bar-left ul.menu [href*=${ref.replace(wpApiShare.site_url, '').split('/')[0]}]`).parent().addClass('active');
+    $(`div.top-bar-left ul.menu [href$=${ref.replace(wpApiShare.site_url, '').split('/')[0]+'\\/'}]`).parent().addClass('active');
 })
 
 

--- a/dt-core/admin/admin-enqueue-scripts.php
+++ b/dt-core/admin/admin-enqueue-scripts.php
@@ -44,7 +44,7 @@ function dt_people_groups_post_type_scripts() {
     if ( ( ( 'post.php' === $pagenow || 'post-new.php' === $pagenow || 'edit.php' === $pagenow )
         && 'peoplegroups' === get_post_type( $post ) ) || ( isset( $_GET['tab'] ) && $_GET['tab'] === 'people-groups' ) ) {
 
-        wp_enqueue_script( 'dt_peoplegroups_scripts', get_stylesheet_directory_uri() . '/dt-people-groups/people-groups.js', [
+        wp_enqueue_script( 'dt_peoplegroups_scripts', get_template_directory_uri() . '/dt-people-groups/people-groups.js', [
             'jquery',
             'jquery-ui-core',
         ], filemtime( get_template_directory() . '/dt-people-groups/people-groups.js' ), true );
@@ -54,7 +54,7 @@ function dt_people_groups_post_type_scripts() {
                 'nonce' => wp_create_nonce( 'wp_rest' ),
                 'current_user_login' => wp_get_current_user()->user_login,
                 'current_user_id' => get_current_user_id(),
-                'theme_uri' => get_stylesheet_directory_uri(),
+                'theme_uri' => get_template_directory_uri(),
                 'images_uri' => disciple_tools()->admin_img_url,
             )
         );
@@ -72,7 +72,7 @@ function dt_options_scripts() {
             'jquery-ui-core',
         ], filemtime( disciple_tools()->admin_js_path . 'dt-options.js' ), true );
         if ( isset( $_GET["tab"] ) && $_GET["tab"] === 'people-groups' ) {
-            wp_enqueue_script( 'dt_peoplegroups_scripts', get_stylesheet_directory_uri() . '/dt-people-groups/people-groups.js', [
+            wp_enqueue_script( 'dt_peoplegroups_scripts', get_template_directory_uri() . '/dt-people-groups/people-groups.js', [
                 'jquery',
                 'jquery-ui-core',
             ], filemtime( get_template_directory() . '/dt-people-groups/people-groups.js' ), true );
@@ -84,7 +84,7 @@ function dt_options_scripts() {
                 'nonce' => wp_create_nonce( 'wp_rest' ),
                 'current_user_login' => wp_get_current_user()->user_login,
                 'current_user_id' => get_current_user_id(),
-                'theme_uri' => get_stylesheet_directory_uri(),
+                'theme_uri' => get_template_directory_uri(),
                 'images_uri' => disciple_tools()->admin_img_url,
             )
         );

--- a/dt-mapping/globals.php
+++ b/dt-mapping/globals.php
@@ -112,7 +112,7 @@ if ( ! isset( $dt_mapping['url'] ) ) {
         case 'theme':
         case 'disciple_tools':
         default:
-            $dt_mapping['url'] = trailingslashit( get_stylesheet_directory_uri() ) . 'dt-mapping/';
+            $dt_mapping['url'] = trailingslashit( get_template_directory_uri() ) . 'dt-mapping/';
             break;
     }
 }

--- a/dt-metrics/metrics-contacts.js
+++ b/dt-metrics/metrics-contacts.js
@@ -24,14 +24,14 @@ function numberWithCommas(x) {
 
 function project_seeker_path() {
   let chartDiv = jQuery('#chart')
-  let sourceData = dtMetricsProject.data
+  let sourceData = dtMetricsContacts.data
 
   chartDiv.empty().html(`
-    <div class="section-header">${_.escape(window.dtMetricsProject.translations.seeker_path) }</div>
-    <div class="section-subheader">${ _.escape(window.dtMetricsProject.translations.filter_contacts_to_date_range) }</div>
+    <div class="section-header">${_.escape(window.dtMetricsContacts.translations.seeker_path) }</div>
+    <div class="section-subheader">${ _.escape(window.dtMetricsContacts.translations.filter_contacts_to_date_range) }</div>
     <div class="date_range_picker">
         <i class="fi-calendar"></i>&nbsp;
-        <span>${ _.escape(window.dtMetricsProject.translations.all_time) }</span> 
+        <span>${ _.escape(window.dtMetricsContacts.translations.all_time) }</span> 
         <i class="dt_caret down"></i>
     </div>
     <div style="display: inline-block" class="loading-spinner"></div>
@@ -69,7 +69,7 @@ function project_seeker_path() {
 
 
   window.METRICS.setupDatePicker(
-    `${dtMetricsProject.root}dt/v1/metrics/seeker_path/`,
+    `${dtMetricsContacts.root}dt/v1/metrics/seeker_path/`,
     function (data, label, start, end) {
       if ( data ){
         $('.date_range_picker span').html( label );
@@ -81,14 +81,14 @@ function project_seeker_path() {
 
 function project_milestones() {
   let chartDiv = jQuery('#chart')
-  let sourceData = dtMetricsProject.data
+  let sourceData = dtMetricsContacts.data
 
   chartDiv.empty().html(`
-    <div class="section-header">${ _.escape(window.dtMetricsProject.translations.milestones) }</div>
-    <div class="section-subheader">${ _.escape(window.dtMetricsProject.translations.filter_to_date_range) }:</div>
+    <div class="section-header">${ _.escape(window.dtMetricsContacts.translations.milestones) }</div>
+    <div class="section-subheader">${ _.escape(window.dtMetricsContacts.translations.filter_to_date_range) }:</div>
     <div class="date_range_picker">
         <i class="fi-calendar"></i>&nbsp;
-        <span>${ _.escape(window.dtMetricsProject.translations.all_time) }</span> 
+        <span>${ _.escape(window.dtMetricsContacts.translations.all_time) }</span> 
         <i class="dt_caret down"></i>
     </div>
     <div style="display: inline-block" class="loading-spinner"></div>
@@ -125,7 +125,7 @@ function project_milestones() {
   columnTemplate.strokeOpacity = 1;
 
   window.METRICS.setupDatePicker(
-    `${dtMetricsProject.root}dt/v1/metrics/milestones/`,
+    `${dtMetricsContacts.root}dt/v1/metrics/milestones/`,
     function (data, label) {
       if (data) {
         $('.date_range_picker span').html( label );
@@ -140,11 +140,11 @@ function show_sources_overview() {
   let chartDiv = jQuery('#chart')
 
   chartDiv.empty().html(`
-      <span class="section-header">${ _.escape(window.dtMetricsProject.translations.sources) }</span>
-      <div class="section-subheader">${ _.escape(window.dtMetricsProject.translations.filter_contacts_to_date_range) }</div>
+      <span class="section-header">${ _.escape(window.dtMetricsContacts.translations.sources) }</span>
+      <div class="section-subheader">${ _.escape(window.dtMetricsContacts.translations.filter_contacts_to_date_range) }</div>
       <div class="date_range_picker">
           <i class="fi-calendar"></i>&nbsp;
-          <span>${ _.escape(window.dtMetricsProject.translations.all_time) }</span> 
+          <span>${ _.escape(window.dtMetricsContacts.translations.all_time) }</span> 
           <i class="dt_caret down"></i>
       </div>
       <div style="display: inline-block" class="loading-spinner"></div>
@@ -154,7 +154,7 @@ function show_sources_overview() {
     `)
 
   window.METRICS.setupDatePicker(
-    `${window.dtMetricsProject.root}dt/v1/metrics/sources_chart_data/`,
+    `${window.dtMetricsContacts.root}dt/v1/metrics/sources_chart_data/`,
     function (data, label) {
       if ( data ){
         $('.date_range_picker span').html( label );
@@ -166,7 +166,7 @@ function show_sources_overview() {
 
   function draw_data(data, label = "all time") {
     if (!data) {
-      data = window.dtMetricsProject.data.sources
+      data = window.dtMetricsContacts.data.sources
     }
     let chartsDiv = $("#charts").empty()
 
@@ -176,41 +176,41 @@ function show_sources_overview() {
 
     chartDiv.find(".js-loading").remove()
 
-    let filteringOutText = `${_.escape(window.dtMetricsProject.translations.milestones)} ${label}.`;
+    let filteringOutText = `${_.escape(window.dtMetricsContacts.translations.milestones)} ${label}.`;
 
     chartsDiv.append($("<div>").html(`
 
-        <h1>${_.escape(window.dtMetricsProject.translations.sources_all_contacts_by_source_and_status)}</h1>
+        <h1>${_.escape(window.dtMetricsContacts.translations.sources_all_contacts_by_source_and_status)}</h1>
   
-        <p>${filteringOutText} ${_.escape(window.dtMetricsProject.translations.sources_contacts_warning)}</p>
+        <p>${filteringOutText} ${_.escape(window.dtMetricsContacts.translations.sources_contacts_warning)}</p>
   
         <div id="chartdiv1" style="min-height: ${height}"></div>
   
         <hr>
   
-        <h1>${_.escape(window.dtMetricsProject.translations.sources_active_by_seeker_path)}</h1>
+        <h1>${_.escape(window.dtMetricsContacts.translations.sources_active_by_seeker_path)}</h1>
   
-        <p>${ _.escape(window.dtMetricsProject.translations.sources_only_active) } 
+        <p>${ _.escape(window.dtMetricsContacts.translations.sources_only_active) } 
         ${filteringOutText} 
-        ${_.escape(window.dtMetricsProject.translations.sources_contacts_warning)}
+        ${_.escape(window.dtMetricsContacts.translations.sources_contacts_warning)}
         </p>
   
         <div id="chartdiv2" style="min-height: ${height}"></div>
   
         <hr>
   
-        <h1>${_.escape(window.dtMetricsProject.translations.sources_active_milestone)}</h1>
+        <h1>${_.escape(window.dtMetricsContacts.translations.sources_active_milestone)}</h1>
   
-        <p>${_.escape(window.dtMetricsProject.translations.sources_active_status_warning)}
+        <p>${_.escape(window.dtMetricsContacts.translations.sources_active_status_warning)}
         ${filteringOutText} 
-        ${_.escape(window.dtMetricsProject.translations.sources_contacts_warning_milestones)}</p>
+        ${_.escape(window.dtMetricsContacts.translations.sources_contacts_warning_milestones)}</p>
          
-        <p><b>${ _.escape(window.dtMetricsProject.translations.faith_milestone) }:</b> <select class="js-milestone"></select></p>
+        <p><b>${ _.escape(window.dtMetricsContacts.translations.faith_milestone) }:</b> <select class="js-milestone"></select></p>
   
         <div id="chartdiv3" style="min-height: ${height}"></div>
       `))
 
-    let localizedObject = window.dtMetricsProject
+    let localizedObject = window.dtMetricsContacts
 
     // Prepare data
     for (let item of data) {

--- a/dt-metrics/metrics-contacts.php
+++ b/dt-metrics/metrics-contacts.php
@@ -53,7 +53,7 @@ class Disciple_Tools_Metrics_Contacts extends Disciple_Tools_Metrics_Hooks_Base 
     }
 
     public function scripts() {
-        wp_enqueue_script( 'dt_metrics_project_script', get_stylesheet_directory_uri() . '/dt-metrics/metrics-contacts.js', [
+        wp_enqueue_script( 'dt_metrics_project_script', get_template_directory_uri() . '/dt-metrics/metrics-contacts.js', [
             'moment',
             'jquery',
             'jquery-ui-core',

--- a/dt-metrics/metrics-contacts.php
+++ b/dt-metrics/metrics-contacts.php
@@ -53,7 +53,7 @@ class Disciple_Tools_Metrics_Contacts extends Disciple_Tools_Metrics_Hooks_Base 
     }
 
     public function scripts() {
-        wp_enqueue_script( 'dt_metrics_project_script', get_template_directory_uri() . '/dt-metrics/metrics-contacts.js', [
+        wp_enqueue_script( 'dt_metrics_contacts_script', get_template_directory_uri() . '/dt-metrics/metrics-contacts.js', [
             'moment',
             'jquery',
             'jquery-ui-core',
@@ -73,14 +73,13 @@ class Disciple_Tools_Metrics_Contacts extends Disciple_Tools_Metrics_Hooks_Base 
             $milestone_settings[$key] = $option["label"];
         }
         wp_localize_script(
-            'dt_metrics_project_script', 'dtMetricsProject', [
+            'dt_metrics_contacts_script', 'dtMetricsContacts', [
                 'root'               => esc_url_raw( rest_url() ),
-                'theme_uri'          => get_stylesheet_directory_uri(),
+                'theme_uri'          => get_template_directory_uri(),
                 'nonce'              => wp_create_nonce( 'wp_rest' ),
                 'current_user_login' => wp_get_current_user()->user_login,
                 'current_user_id'    => get_current_user_id(),
                 'data'               => $this->data(),
-                'spinner' => '<img src="' .trailingslashit( plugin_dir_url( __DIR__ ) ) . 'ajax-loader.gif" style="height:1em;" />',
                 'sources' => Disciple_Tools_Contacts::list_sources(),
                 'source_names' => $contacts_custom_field_settings['sources']['default'],
                 'overall_status_settings' => $overall_status_settings,

--- a/dt-metrics/metrics-critical-path.php
+++ b/dt-metrics/metrics-critical-path.php
@@ -52,7 +52,7 @@ class Disciple_Tools_Metrics_Critical_Path extends Disciple_Tools_Metrics_Hooks_
     }
 
     public function scripts() {
-        wp_enqueue_script( 'dt_metrics_project_script', get_stylesheet_directory_uri() . '/dt-metrics/metrics-critical-path.js', [
+        wp_enqueue_script( 'dt_metrics_project_script', get_template_directory_uri() . '/dt-metrics/metrics-critical-path.js', [
             'moment',
             'jquery',
             'jquery-ui-core',

--- a/dt-metrics/metrics-critical-path.php
+++ b/dt-metrics/metrics-critical-path.php
@@ -65,7 +65,7 @@ class Disciple_Tools_Metrics_Critical_Path extends Disciple_Tools_Metrics_Hooks_
         wp_localize_script(
             'dt_metrics_project_script', 'dtMetricsProject', [
                 'root'               => esc_url_raw( rest_url() ),
-                'theme_uri'          => get_stylesheet_directory_uri(),
+                'theme_uri'          => get_template_directory_uri(),
                 'nonce'              => wp_create_nonce( 'wp_rest' ),
                 'current_user_login' => wp_get_current_user()->user_login,
                 'current_user_id'    => get_current_user_id(),

--- a/dt-metrics/metrics-personal.php
+++ b/dt-metrics/metrics-personal.php
@@ -37,7 +37,7 @@ class Disciple_Tools_Metrics_Personal extends Disciple_Tools_Metrics_Hooks_Base
     }
 
     public function scripts() {
-        wp_enqueue_script( 'dt_metrics_personal_script', get_stylesheet_directory_uri() . '/dt-metrics/metrics-personal.js', [
+        wp_enqueue_script( 'dt_metrics_personal_script', get_template_directory_uri() . '/dt-metrics/metrics-personal.js', [
             'jquery',
             'jquery-ui-core',
             'amcharts-core',

--- a/dt-metrics/metrics-personal.php
+++ b/dt-metrics/metrics-personal.php
@@ -47,7 +47,7 @@ class Disciple_Tools_Metrics_Personal extends Disciple_Tools_Metrics_Hooks_Base
         wp_localize_script(
             'dt_metrics_personal_script', 'dtMetricsPersonal', [
                 'root' => esc_url_raw( rest_url() ),
-                'theme_uri' => get_stylesheet_directory_uri(),
+                'theme_uri' => get_template_directory_uri(),
                 'nonce' => wp_create_nonce( 'wp_rest' ),
                 'current_user_login' => wp_get_current_user()->user_login,
                 'current_user_id' => get_current_user_id(),

--- a/dt-metrics/metrics-prayer.php
+++ b/dt-metrics/metrics-prayer.php
@@ -52,7 +52,7 @@ class Disciple_Tools_Metrics_Prayer extends Disciple_Tools_Metrics_Hooks_Base
         wp_localize_script(
             'dt_metrics_prayer_script', 'dtMetricsPrayer', [
                 'root' => esc_url_raw( rest_url() ),
-                'theme_uri' => get_stylesheet_directory_uri(),
+                'theme_uri' => get_template_directory_uri(),
                 'nonce' => wp_create_nonce( 'wp_rest' ),
                 'current_user_login' => wp_get_current_user()->user_login,
                 'current_user_id' => get_current_user_id(),

--- a/dt-metrics/metrics-prayer.php
+++ b/dt-metrics/metrics-prayer.php
@@ -44,7 +44,7 @@ class Disciple_Tools_Metrics_Prayer extends Disciple_Tools_Metrics_Hooks_Base
     }
 
     public function scripts() {
-        wp_enqueue_script( 'dt_metrics_prayer_script', get_stylesheet_directory_uri() . '/dt-metrics/metrics-prayer.js', [
+        wp_enqueue_script( 'dt_metrics_prayer_script', get_template_directory_uri() . '/dt-metrics/metrics-prayer.js', [
             'jquery',
             'jquery-ui-core',
         ], filemtime( get_theme_file_path() . '/dt-metrics/metrics-prayer.js' ), true );

--- a/dt-metrics/metrics-project.php
+++ b/dt-metrics/metrics-project.php
@@ -63,7 +63,7 @@ class Disciple_Tools_Metrics_Project extends Disciple_Tools_Metrics_Hooks_Base
         wp_localize_script(
             'dt_metrics_project_script', 'dtMetricsProject', [
                 'root' => esc_url_raw( rest_url() ),
-                'theme_uri' => get_stylesheet_directory_uri(),
+                'theme_uri' => get_template_directory_uri(),
                 'nonce' => wp_create_nonce( 'wp_rest' ),
                 'current_user_login' => wp_get_current_user()->user_login,
                 'current_user_id' => get_current_user_id(),

--- a/dt-metrics/metrics-project.php
+++ b/dt-metrics/metrics-project.php
@@ -53,7 +53,7 @@ class Disciple_Tools_Metrics_Project extends Disciple_Tools_Metrics_Hooks_Base
     public function scripts() {
         wp_register_script( 'amcharts-core', 'https://www.amcharts.com/lib/4/core.js', false, '4' );
         wp_register_script( 'amcharts-charts', 'https://www.amcharts.com/lib/4/charts.js', false, '4' );
-        wp_enqueue_script( 'dt_metrics_project_script', get_stylesheet_directory_uri() . '/dt-metrics/metrics-project.js', [
+        wp_enqueue_script( 'dt_metrics_project_script', get_template_directory_uri() . '/dt-metrics/metrics-project.js', [
             'jquery',
             'jquery-ui-core',
             'amcharts-core',

--- a/dt-metrics/metrics-workers.php
+++ b/dt-metrics/metrics-workers.php
@@ -138,7 +138,7 @@ class Disciple_Tools_Metrics_Users extends Disciple_Tools_Metrics_Hooks_Base
         wp_localize_script(
             'dt_metrics_workers_script', 'dtMetricsUsers', [
                 'root' => esc_url_raw( rest_url() ),
-                'theme_uri' => get_stylesheet_directory_uri(),
+                'theme_uri' => get_template_directory_uri(),
                 'nonce' => wp_create_nonce( 'wp_rest' ),
                 'current_user_login' => wp_get_current_user()->user_login,
                 'current_user_id' => get_current_user_id(),

--- a/dt-metrics/metrics-workers.php
+++ b/dt-metrics/metrics-workers.php
@@ -128,7 +128,7 @@ class Disciple_Tools_Metrics_Users extends Disciple_Tools_Metrics_Hooks_Base
     }
 
     public function scripts() {
-        wp_enqueue_script( 'dt_metrics_workers_script', get_stylesheet_directory_uri() . '/dt-metrics/metrics-workers.js', [
+        wp_enqueue_script( 'dt_metrics_workers_script', get_template_directory_uri() . '/dt-metrics/metrics-workers.js', [
             'jquery',
             'jquery-ui-core',
             'amcharts-core',


### PR DESCRIPTION
Patch is for child theme compatibility. Replaces occurrences of get_stylesheet_directory_uri() with get_template_directory_uri() when used to reference critical scripts or files found in parent directory.