### PR TITLE
Allow configuration of XML-RPC by use of an environment variable

### DIFF
--- a/dt-core/admin/restrict-site-access.php
+++ b/dt-core/admin/restrict-site-access.php
@@ -66,7 +66,7 @@ function dt_block_xmlrpc_attacks( $methods ) {
     return $methods;
 }
 add_filter( 'xmlrpc_methods', 'dt_block_xmlrpc_attacks' );
-if ( $xmlrpc_enabled === true || strtolower($xmlrpc_enabled) == 'true' ) {
+if ( $xmlrpc_enabled === true || strtolower( $xmlrpc_enabled ) == 'true' ) {
     add_filter( 'xmlrpc_enabled', '__return_true' );
 } else {
     add_filter( 'xmlrpc_enabled', '__return_false' );

--- a/dt-core/admin/restrict-site-access.php
+++ b/dt-core/admin/restrict-site-access.php
@@ -54,6 +54,7 @@ function dt_remove_action_feed() {
 /**
  * Removes pingback and a couple common DOS attacks strategies from header
  */
+$xmlrpc_enabled = getenv( 'XMLRPC_ENABLED' );
 function dt_remove_x_pingback_header( $headers ) {
     unset( $headers['X-Pingback'] );
     return $headers;
@@ -65,7 +66,11 @@ function dt_block_xmlrpc_attacks( $methods ) {
     return $methods;
 }
 add_filter( 'xmlrpc_methods', 'dt_block_xmlrpc_attacks' );
-add_filter( 'xmlrpc_enabled', '__return_false' );
+if ( $xmlrpc_enabled === true || strtolower($xmlrpc_enabled) == 'true' ) {
+    add_filter( 'xmlrpc_enabled', '__return_true' );
+} else {
+    add_filter( 'xmlrpc_enabled', '__return_false' );
+}
 
 /**
  * Removes header clutter


### PR DESCRIPTION
For those wishing to use XML RPC who also understand the risk, this allows setting an environment variable (`XMLRPC_ENABLED=true`) on your server to enable the feature. By default, it is still disabled as was previously the case.

### Test Cases ###
* XMLRPC_ENABLED='true' (string value) (expect: XML-RPC works)
* XMLRPC_ENABLED='false' (string value) (expect: XML-RPC fails)
* XMLRPC_ENABLED not defined (expect: XML-RPC fails)

### HTTP Request for Testing ###
`POST http://my.disciple.tools/xmlrpc.php`
Body:
```
<?xml version="1.0"?>
<methodCall>
   <methodName>wp.getUsers</methodName>
      <params>
         <param>
            <value><int>1</int></value>
            <value><string>admin</string></value>
            <value><string>badpass</string></value>
         </param>
      </params>
</methodCall>
```

### Test Response: XML-RPC enabled ###
```
<?xml version="1.0" encoding="UTF-8"?>
<methodResponse>
    <fault>
        <value>
            <struct>
                <member>
                    <name>faultCode</name>
                    <value>
                        <int>403</int>
                    </value>
                </member>
                <member>
                    <name>faultString</name>
                    <value>
                        <string>Incorrect username or password.</string>
                    </value>
                </member>
            </struct>
        </value>
    </fault>
</methodResponse>
```

### Test Response: XML-RPC disabled ###
```
<?xml version="1.0" encoding="UTF-8"?>
<methodResponse>
    <fault>
        <value>
            <struct>
                <member>
                    <name>faultCode</name>
                    <value>
                        <int>405</int>
                    </value>
                </member>
                <member>
                    <name>faultString</name>
                    <value>
                        <string>XML-RPC services are disabled on this site.</string>
                    </value>
                </member>
            </struct>
        </value>
    </fault>
</methodResponse>
```