### PR TITLE
change CRLF to LF endings for gulp sourcemaps using gulp-frep

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,10 +7,11 @@ require('dotenv').config();
 // Most packages are lazy loaded
 var gulp = require('gulp'),
   log = require('fancy-log');
-browserSync = require('browser-sync'),
+  browserSync = require('browser-sync'),
   plugin = require('gulp-load-plugins')(),
   touch = require('gulp-touch-cmd'),
   rename = require('gulp-rename'),
+  frep = require('gulp-frep'),
   merge = require('merge-stream'),
   postcss = require('gulp-postcss'),
   cssnano = require('cssnano');
@@ -84,6 +85,14 @@ const BUILD_DIRS = {
   scripts: 'dt-assets/build/js/',
 };
 
+const patterns = [
+  {
+    // normalize line endings
+    pattern: /\\r\\n/g,
+    replacement: '\\n'
+  }
+];
+
 // GULP FUNCTIONS
 // concat, and minify JavaScript
 gulp.task('scripts', function () {
@@ -103,6 +112,7 @@ gulp.task('scripts', function () {
     .pipe(plugin.uglify())
     .pipe(rename({ suffix: '.min' }))
     .pipe(plugin.sourcemaps.write('.')) // Creates sourcemap for minified JS
+    .pipe(frep(patterns))
     .pipe(gulp.dest(BUILD_DIRS.scripts));
 });
 
@@ -121,6 +131,7 @@ gulp.task('styles', function () {
     .pipe(rename({ suffix: '.min' }))
     .pipe(postcss([cssnano()]))
     .pipe(plugin.sourcemaps.write('.'))
+    .pipe(frep(patterns))
     .pipe(gulp.dest(BUILD_DIRS.styles))
     .pipe(touch());
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3025,6 +3025,12 @@
         }
       }
     },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -3329,6 +3335,21 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ev-emitter/-/ev-emitter-1.1.1.tgz",
       "integrity": "sha512-ipiDYhdQSCZ4hSbX4rMW+XzNKMD1prg/sTvoVmSLkuQ1MVlwjJQQA+sW8tMYR3BLUr9KjodFV4pvzunvRhd33Q=="
+    },
+    "event-stream": {
+      "version": "3.0.20",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.0.20.tgz",
+      "integrity": "sha1-A4u7LqnqkDhbJvvBhU0LU58qvqM=",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.0.3",
+        "pause-stream": "0.0.11",
+        "split": "0.2",
+        "stream-combiner": "~0.0.3",
+        "through": "~2.3.1"
+      }
     },
     "eventemitter3": {
       "version": "1.2.0",
@@ -3842,10 +3863,25 @@
         "map-cache": "^0.2.2"
       }
     },
+    "frep": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/frep/-/frep-0.2.3.tgz",
+      "integrity": "sha1-t1gPpl6mKhz46h73dB3ukqhFj3w=",
+      "dev": true,
+      "requires": {
+        "replacements": "^0.1.1"
+      }
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
     },
     "from2": {
@@ -4970,6 +5006,16 @@
             "extend-shallow": "^1.1.2"
           }
         }
+      }
+    },
+    "gulp-frep": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/gulp-frep/-/gulp-frep-0.1.3.tgz",
+      "integrity": "sha1-TOJ5pTErncNifWKsMJbK0hVq8ec=",
+      "dev": true,
+      "requires": {
+        "event-stream": "~3.0.20",
+        "frep": "~0.2.2"
       }
     },
     "gulp-imagemin": {
@@ -6824,6 +6870,12 @@
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
+    "map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
+      "dev": true
+    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -7750,6 +7802,15 @@
         "pinkie-promise": "^2.0.0"
       }
     },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dev": true,
+      "requires": {
+        "through": "~2.3"
+      }
+    },
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -8638,6 +8699,12 @@
         "remove-trailing-separator": "^1.1.0"
       }
     },
+    "replacements": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/replacements/-/replacements-0.1.3.tgz",
+      "integrity": "sha1-pBUbBBBYV9xYmCMAtfG59evgyR0=",
+      "dev": true
+    },
     "request": {
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
@@ -9523,6 +9590,15 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
+    "split": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
+      "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -9613,6 +9689,15 @@
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.1"
+      }
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1"
       }
     },
     "stream-exhaust": {
@@ -9935,8 +10020,7 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "through2": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "gulp-babel": "^6.1.3",
     "gulp-concat": "^2.6.1",
     "gulp-filter": "^5.0.0",
+    "gulp-frep": "^0.1.3",
     "gulp-imagemin": "^5.0.0",
     "gulp-jshint": "^2.0.0",
     "gulp-load-plugins": "^1.6.0",


### PR DESCRIPTION
On Windows, the CSS and JS files that gulp generates has `\r\n` at line endings instead of `\n`. This change replaces all `\r\n` instances with `\n` to facilitate development on Windows.