### PR TITLE
Format numbers and dates

### DIFF
--- a/dt-assets/js/comments.js
+++ b/dt-assets/js/comments.js
@@ -10,6 +10,8 @@ jQuery(document).ready(function($) {
 
   let comments = []
   let activity = [] // not guaranteed to be in any particular order
+  let langcode = document.querySelector('html').getAttribute('lang') ? document.querySelector('html').getAttribute('lang').replace('_', '-') : "en";// get the language attribute from the HTML or default to english if it doesn't exists.
+
   function post_comment(postId) {
     let commentInput = jQuery("#comment-input")
     let commentButton = jQuery("#add-comment-button")
@@ -49,7 +51,7 @@ jQuery(document).ready(function($) {
     let createdDate = moment.utc(currentContact.post_date_gmt, "YYYY-MM-DD HH:mm:ss", true)
     const createdContactActivityItem = {
       hist_time: createdDate.unix(),
-      object_note: settings.txt_created.replace("{}", formatDate(createdDate.local())),
+      object_note: settings.txt_created.replace("{}", formatDate(createdDate.local(), langcode)),
       name: settings.contact_author_name,
       user_id: currentContact.post_author,
     }
@@ -84,8 +86,10 @@ jQuery(document).ready(function($) {
     let tab = $(`[data-id="activity"].tab-button-label`)
     let text = tab.text()
     text = text.substring(0, text.indexOf('(')) || text
-    text += ` (${activityData.length})`
+    text += ` (${formatNumber(activityData.length, langcode)})`
     tab.text(text)
+
+    console.log(activityData);
   }
   $(".show-tabs").on("click", function () {
     let id = $(this).attr("id")
@@ -203,13 +207,15 @@ function unescapeHtml(safe) {
     })
   })
 
-  function formatDate(date) {
-
-    const langcode = document.querySelector('html').getAttribute('lang').replace('_', '-');
+  function formatDate(date, langcode) {
     const options = { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' }
     const last_modified = new Intl.DateTimeFormat(`${langcode}-u-ca-gregory`, options).format(new Date (date));
 
     return last_modified;
+  }
+
+  function formatNumber(num, lang) {
+    return num.toLocaleString(lang);
   }
 
   function display_activity_comment() {
@@ -267,7 +273,7 @@ function unescapeHtml(safe) {
         commentsWrapper.append(commentTemplate({
           name: array[0].name,
           gravatar: array[0].gravatar,
-          date:formatDate(array[0].date),
+          date:formatDate(array[0].date, langcode),
           activity: array
         }))
         array = [obj]
@@ -277,7 +283,7 @@ function unescapeHtml(safe) {
       commentsWrapper.append(commentTemplate({
         gravatar: array[0].gravatar,
         name: array[0].name,
-        date:formatDate(array[0].date),
+        date:formatDate(array[0].date, langcode),
         activity: array
       }))
     }
@@ -402,7 +408,7 @@ function unescapeHtml(safe) {
       let tab = $(`[data-id="${key}"].tab-button-label`)
       let text = tab.text()
       text = text.substring(0, text.indexOf('(')) || text
-      text += ` (${val})`
+      text += ` (${formatNumber(val, langcode)})`
       tab.text(text)
     })
     comments = commentData

--- a/dt-assets/js/comments.js
+++ b/dt-assets/js/comments.js
@@ -89,7 +89,6 @@ jQuery(document).ready(function($) {
     text += ` (${formatNumber(activityData.length, langcode)})`
     tab.text(text)
 
-    console.log(activityData);
   }
   $(".show-tabs").on("click", function () {
     let id = $(this).attr("id")

--- a/dt-assets/js/comments.js
+++ b/dt-assets/js/comments.js
@@ -173,7 +173,7 @@ function unescapeHtml(safe) {
       .replace(/&#39;/g, "'")
       .replace(/&#039;/g, "'");
 }
- 
+
     // textarea deos not render HTML, so using _.unescape is safe. Note that
     // _.unescape will silently ignore invalid HTML, for instance,
     // _.unescape("Tom & Jerry") will return "Tom & Jerry"
@@ -204,7 +204,12 @@ function unescapeHtml(safe) {
   })
 
   function formatDate(date) {
-    return date.format("MMM D, YYYY h:mm a")
+
+    const langcode = document.querySelector('html').getAttribute('lang').replace('_', '-');
+    const options = { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' }
+    const last_modified = new Intl.DateTimeFormat(`${langcode}-u-ca-gregory`, options).format(new Date (date));
+
+    return last_modified;
   }
 
   function display_activity_comment() {
@@ -384,7 +389,7 @@ function unescapeHtml(safe) {
        * that. This is not sufficient for malicious input, but hopefully we
        * can trust the contents of the database to have been sanitized
        * thanks to wp_new_comment . */
-    
+
         // .DT lets strip out the tags provided from the submited comment and treat it as pure text.
        comment.comment_content = $("<div>").html(comment.comment_content).text()
 

--- a/dt-assets/js/list.js
+++ b/dt-assets/js/list.js
@@ -113,7 +113,7 @@
         <a href="#" class="accordion-title">
           ${_.escape(tab.label)}
           <span class="tab-count-span" data-tab="${_.escape(tab.key)}">
-              ${tab.count || tab.count >= 0 ? `(${_.escape(tab.count)})`: ``} 
+              ${tab.count || tab.count >= 0 ? `(${_.escape(tab.count)})`: ``}
           </span>
         </a>
         <div class="accordion-content" data-tab-content>
@@ -126,7 +126,7 @@
                   <span id="total_filter_label">${_.escape(filter.name)}</span>
                   <span class="list-view__count js-list-view-count" data-value="${_.escape(filter.ID)}">${_.escape(filter.count )}</span>
                 </label>
-                `  
+                `
               }
             }).join('')}
           </div>
@@ -341,7 +341,9 @@
       return '<a href="' + _.escape(group.permalink) + '">' + group.post_title + "</a>";
     }).join(", ");
 
-    const last_modified = new Date(contact.last_modified*1000).toString().slice(0, 15);
+const langcode = document.querySelector('html').getAttribute('lang').replace('_', '-');
+const options = { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' }
+const last_modified = new Intl.DateTimeFormat(`${langcode}-u-ca-gregory`, options).format(new Date(contact.last_modified*1000))
 
     const context = _.assign({last_modified: 0}, contact, wpApiListSettings, {
       index,

--- a/dt-assets/parts/loop-activity-comment.php
+++ b/dt-assets/parts/loop-activity-comment.php
@@ -108,7 +108,7 @@
                                            class="tabs-section"
                                         <?php echo esc_html( ( isset( $section["selected_by_default"] ) && $section["selected_by_default"] === true ) ? 'checked' : '' ) ?>
                                     >
-                                    <span class="tab-button-label"
+                                    <span class="tab-button-label" dir="auto"
                                           data-id="<?php echo esc_html( $section["key"] ) ?>"> <?php echo esc_html( $section["label"] ) ?></span>
                                 </label>
 

--- a/dt-core/admin/config-site-defaults.php
+++ b/dt-core/admin/config-site-defaults.php
@@ -690,14 +690,18 @@ function dt_custom_dir_attr( $lang ){
     }
 
     $current_user = wp_get_current_user();
-    $user_language = $current_user->locale;
+    $user_language = get_user_locale( $current_user->ID );
+    /* translators: If your language is written right to left make this tranlation as 'rtl', if it is written ltr make the translated text 'ltr' or leave it blank */
     $dir = _x( 'ltr', 'either rtl or ltr', 'disciple_tools' );
+
     if ( $dir === 'ltr' || $dir === 'text direction' || !$dir || empty( $dir ) ){
         $dir = "ltr";
     } else {
         $dir = "rtl";
     }
     $dir_attr = 'dir="' . $dir . '"';
+
+    dt_write_log( $dir );
     return 'lang="' . $user_language .'" ' .$dir_attr;
 }
 

--- a/dt-core/admin/config-site-defaults.php
+++ b/dt-core/admin/config-site-defaults.php
@@ -701,7 +701,6 @@ function dt_custom_dir_attr( $lang ){
     }
     $dir_attr = 'dir="' . $dir . '"';
 
-    dt_write_log( $dir );
     return 'lang="' . $user_language .'" ' .$dir_attr;
 }
 


### PR DESCRIPTION
fixed the language attribute in Multilingual situations.

Fixes the time stamps and date strings to use localized string, but still uses Gregorian calendar.

Fixes the number formatting in the comments tab.