### PR TITLE
Fix "Waiting on Accept" Metric

### DIFF
--- a/dt-metrics/metrics.php
+++ b/dt-metrics/metrics.php
@@ -859,7 +859,7 @@ abstract class Disciple_Tools_Metrics_Hooks_Base
                     JOIN $wpdb->postmeta as b
                     ON a.ID=b.post_id
                        AND b.meta_key = 'accepted'
-                       AND b.meta_value = ''
+                       AND (b.meta_value = '' OR b.meta_value = 'no')
                 JOIN $wpdb->postmeta as d
                 ON a.ID=d.post_id
                    AND d.meta_key = 'overall_status'


### PR DESCRIPTION
On the Project Overview metrics dashboard, the Waiting on Accept is not showing the same number as when you filter the contacts list by the same status. It seems to be because the value in the database could be either blank or "no" and the metrics query was only checking for blank.