### PR TITLE
Add `post_date` to `search_viewable_post` results

### DIFF
--- a/dt-posts/posts.php
+++ b/dt-posts/posts.php
@@ -925,7 +925,7 @@ class Disciple_Tools_Posts
         // phpcs:disable
         // WordPress.WP.PreparedSQL.NotPrepared
         $prepared_sql = $wpdb->prepare("
-            SELECT SQL_CALC_FOUND_ROWS $wpdb->posts.ID, $wpdb->posts.post_title, $wpdb->posts.post_type FROM $wpdb->posts
+            SELECT SQL_CALC_FOUND_ROWS $wpdb->posts.ID, $wpdb->posts.post_title, $wpdb->posts.post_type, $wpdb->posts.post_date FROM $wpdb->posts
             " . $inner_joins . " " . $share_joins . " " . $access_joins . " " . $sort_join . "
             WHERE 1=1
             " . $post_type_check . " " . $connections_sql_to . " ". $connections_sql_from . " " . $location_sql . " " . $meta_query . " " . $includes_query . " " . $access_query . "


### PR DESCRIPTION
A contact's creation date is not currently available when using DT_Posts::list_posts, so this adds it in.