### PR TITLE
Social Media List escape bug

### DIFF
--- a/dt-assets/js/contact-details.js
+++ b/dt-assets/js/contact-details.js
@@ -674,7 +674,7 @@ jQuery(document).ready(function($) {
     let channelOptions = ``
     _.forOwn( contactsDetailsWpApiSettings.channels, (val, key)=>{
       if ( ![ "phone", "email", "address"].includes( key ) ){
-        channelOptions += `<option value="${_.escape(key)}">${escape(val.label)}</option>`
+        channelOptions += `<option value="${_.escape(key)}">${_.escape(val.label)}</option>`
       }
     })
     idOfNextNewField++


### PR DESCRIPTION
fixes a bug in the contact edit modal -> Social Media selector. It was using javascripts native escape() function instead of _.escape() for the channel names. If the users locale was a non-latin script it showed a list of URL encoded non-sense instead of the actual string.