### PR TITLE
Comment Bug Fix

### DIFF
--- a/dt-assets/js/comments.js
+++ b/dt-assets/js/comments.js
@@ -246,18 +246,18 @@ jQuery(document).ready(function($) {
     let comment_html = comment.comment_content // eg: "Tom &amp; Jerry"
 
 
-/**
- * .DT - while previewing submitted comments, enhance the presentation of special characters with a helper function below
- */
+    /**
+     * .DT - while previewing submitted comments, enhance the presentation of special characters with a helper function below
+     */
 
-function unescapeHtml(safe) {
-  return safe.replace(/&amp;/g, '&')
-      //.replace(/&lt;/g, '<')
-      //.replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'")
-      .replace(/&#039;/g, "'");
-}
+    function unescapeHtml(safe) {
+      return safe.replace(/&amp;/g, '&')
+          //.replace(/&lt;/g, '<')
+          //.replace(/&gt;/g, '>')
+          .replace(/&quot;/g, '"')
+          .replace(/&#39;/g, "'")
+          .replace(/&#039;/g, "'");
+    }
 
     // textarea deos not render HTML, so using _.unescape is safe. Note that
     // _.unescape will silently ignore invalid HTML, for instance,
@@ -471,9 +471,6 @@ function unescapeHtml(safe) {
     commentData.forEach(comment => {
       comment.date = moment(comment.comment_date_gmt + "Z")
 
-      if(comment.comment_content.match(/function|script/)) {
-        comment.comment_content = _.escape(comment.comment_content)
-      }
       /* comment_content should be HTML. However, we want to make sure that
        * HTML like "<div>Hello" gets transformed to "<div>Hello</div>", that
        * is, that all tags are closed, so that the comment_content can be
@@ -483,7 +480,7 @@ function unescapeHtml(safe) {
        * thanks to wp_new_comment . */
 
         // .DT lets strip out the tags provided from the submited comment and treat it as pure text.
-       comment.comment_content = $("<div>").html(comment.comment_content).text()
+       comment.comment_content = $("<div>").text(comment.comment_content).text()
 
       if (!typesCount[comment.comment_type]){
         typesCount[comment.comment_type] = 0;

--- a/dt-assets/js/comments.js
+++ b/dt-assets/js/comments.js
@@ -21,7 +21,7 @@ jQuery(document).ready(function($) {
         commentButton.toggleClass('loading')
         commentInput.attr("disabled", true)
         commentButton.attr("disabled", true)
-        rest_api.post_comment(postType, postId, _.escape(comment_plain_text), commentType ).then(data => {
+        rest_api.post_comment(postType, postId, comment_plain_text, commentType ).then(data => {
           let updated_comment = data.comment || data
           commentInput.val("").trigger( "change" )
           commentButton.toggleClass('loading')

--- a/dt-posts/dt-posts.php
+++ b/dt-posts/dt-posts.php
@@ -757,7 +757,7 @@ class DT_Posts extends Disciple_Tools_Posts {
                 "comment_date" => $comment->comment_date,
                 "comment_date_gmt" => $comment->comment_date_gmt,
                 "gravatar" => preg_replace( "/^http:/i", "https:", $url ),
-                "comment_content" => wp_kses_post( $comment->comment_content ),
+                "comment_content" => wp_kses_post(html_entity_decode($comment->comment_content)),
                 "user_id" => $comment->user_id,
                 "comment_type" => $comment->comment_type,
                 "comment_post_ID" => $comment->comment_post_ID

--- a/dt-posts/dt-posts.php
+++ b/dt-posts/dt-posts.php
@@ -8,10 +8,10 @@ class DT_Posts extends Disciple_Tools_Posts {
         parent::__construct();
     }
 
-    /** 
-     * Specifies which HTML tags are permissible in comments.  
+    /**
+     * Specifies which HTML tags are permissible in comments.
      */
-    private static $allowableCommentTags = array(
+    private static $allowable_comment_tags = array(
         'a' => array(
           'href' => array(),
           'title' => array()
@@ -19,7 +19,7 @@ class DT_Posts extends Disciple_Tools_Posts {
         'br' => array(),
         'em' => array(),
         'strong' => array(),
-    );    
+    );
 
     /**
      * Get settings on the post type
@@ -680,7 +680,7 @@ class DT_Posts extends Disciple_Tools_Posts {
         foreach ( $comments as $comment ){
             $comment_data = [
                 'comment_post_ID'      => $post_id,
-                'comment_content'      => wp_kses($comment, self::$allowableCommentTags),
+                'comment_content'      => wp_kses($comment, self::$allowable_comment_tags),
                 'user_id'              => $user_id,
                 'comment_author'       => $args["comment_author"] ?? $user->display_name,
                 'comment_author_url'   => $args["comment_author_url"] ?? "",
@@ -770,7 +770,7 @@ class DT_Posts extends Disciple_Tools_Posts {
                 "comment_date" => $comment->comment_date,
                 "comment_date_gmt" => $comment->comment_date_gmt,
                 "gravatar" => preg_replace( "/^http:/i", "https:", $url ),
-                "comment_content" => wp_kses( $comment->comment_content, self::$allowableCommentTags),
+                "comment_content" => wp_kses( $comment->comment_content, self::$allowable_comment_tags),
                 "user_id" => $comment->user_id,
                 "comment_type" => $comment->comment_type,
                 "comment_post_ID" => $comment->comment_post_ID

--- a/dt-posts/dt-posts.php
+++ b/dt-posts/dt-posts.php
@@ -667,7 +667,7 @@ class DT_Posts extends Disciple_Tools_Posts {
         foreach ( $comments as $comment ){
             $comment_data = [
                 'comment_post_ID'      => $post_id,
-                'comment_content'      => $comment,
+                'comment_content'      => wp_kses_post($comment),
                 'user_id'              => $user_id,
                 'comment_author'       => $args["comment_author"] ?? $user->display_name,
                 'comment_author_url'   => $args["comment_author_url"] ?? "",


### PR DESCRIPTION
removes escaping from the Javascript so that the PHP gets the unescaped HTML and then applies wp_kses_post() to it to strip out malicious attributes and tags.