### PR TITLE
User Visibility by Role Preferences

### DIFF
--- a/dt-core/admin/class-roles.php
+++ b/dt-core/admin/class-roles.php
@@ -371,7 +371,7 @@ class Disciple_Tools_Roles
             $role->add_cap( 'assign_any_contacts' );
             $role->add_cap( 'update_any_contacts' );
             $role->add_cap( 'delete_any_contacts' );
-            $role->add_cap( 'dt_list_users');
+            $role->add_cap( 'dt_list_users' );
 
             /* Add WP-Admin caps for contacts */
             $role->add_cap( 'edit_contact' );

--- a/dt-core/admin/class-roles.php
+++ b/dt-core/admin/class-roles.php
@@ -103,6 +103,7 @@ class Disciple_Tools_Roles
                 'read'                      => true, //access to admin
 
                 'list_users'                => true,
+                'dt_list_users'             => true,
 
                 'view_project_metrics'      => true,
 
@@ -236,6 +237,7 @@ class Disciple_Tools_Roles
                 'create_users'              => true,
                 'delete_users'              => true,
                 'list_users'                => true,
+                'dt_list_users'             => true,
 
                 /* Add custom caps for contacts */
                 'access_contacts'           => true,
@@ -369,6 +371,7 @@ class Disciple_Tools_Roles
             $role->add_cap( 'assign_any_contacts' );
             $role->add_cap( 'update_any_contacts' );
             $role->add_cap( 'delete_any_contacts' );
+            $role->add_cap( 'dt_list_users');
 
             /* Add WP-Admin caps for contacts */
             $role->add_cap( 'edit_contact' );

--- a/dt-core/admin/menu/tabs/tab-general.php
+++ b/dt-core/admin/menu/tabs/tab-general.php
@@ -500,12 +500,13 @@ class Disciple_Tools_General_Tab extends Disciple_Tools_Abstract_Menu_Base
                 <?php
                 $role_object = get_role( $role_key );
                 ?>
+                <?php if ( !array_key_exists( 'view_any_contacts', $role_object->capabilities ) ) : ?>
                 <tr>
                     <td>
-                        <input type="checkbox" name="<?php echo esc_attr( $role_key ); ?>" <?php checked( array_key_exists( 'dt_list_users', $role_object->capabilities ) );
-                        if ( array_key_exists( 'view_any_contacts', $role_object->capabilities ) ) { echo esc_attr( "disabled" ); }  ?>/> <?php echo esc_attr( $name ); ?>
+                        <input type="checkbox" name="<?php echo esc_attr( $role_key ); ?>" <?php checked( array_key_exists( 'dt_list_users', $role_object->capabilities ) ); ?>/> <?php echo esc_attr( $name ); ?>
                     </td>
                 </tr>
+                <?php endif; ?>
             <?php endforeach; ?>
 
                 <?php wp_nonce_field( 'user_visibility' . get_current_user_id(), 'user_visibility_nonce' )?>

--- a/dt-core/admin/menu/tabs/tab-general.php
+++ b/dt-core/admin/menu/tabs/tab-general.php
@@ -479,10 +479,10 @@ class Disciple_Tools_General_Tab extends Disciple_Tools_Abstract_Menu_Base
             $dt_roles = dt_multi_role_get_editable_role_names();
             foreach ( $dt_roles as $role_key => $name ) :
                 $role_object = get_role( $role_key );
-                if ( isset( $_POST[$role_key] ) && !array_key_exists( 'list_users', $role_object->capabilities ) ) {
-                    $role_object->add_cap( 'list_users' );
-                } else if ( !isset( $_POST[$role_key] ) && array_key_exists( 'list_users', $role_object->capabilities ) ) {
-                    $role_object->remove_cap( 'list_users' );
+                if ( isset( $_POST[$role_key] ) && !array_key_exists( 'dt_list_users', $role_object->capabilities ) ) {
+                    $role_object->add_cap( 'dt_list_users' );
+                } else if ( !isset( $_POST[$role_key] ) && array_key_exists( 'dt_list_users', $role_object->capabilities ) ) {
+                    $role_object->remove_cap( 'dt_list_users' );
                 }
             endforeach;
         }
@@ -502,7 +502,7 @@ class Disciple_Tools_General_Tab extends Disciple_Tools_Abstract_Menu_Base
                 ?>
                 <tr>
                     <td>
-                        <input type="checkbox" name="<?php echo esc_attr( $role_key ); ?>" <?php checked( array_key_exists( 'list_users', $role_object->capabilities ) ); ?>/> <?php echo esc_attr( $name ); ?>
+                        <input type="checkbox" name="<?php echo esc_attr( $role_key ); ?>" <?php checked( array_key_exists( 'dt_list_users', $role_object->capabilities ) ); ?>/> <?php echo esc_attr( $name ); ?>
                     </td>
                 </tr>
             <?php endforeach; ?>

--- a/dt-core/admin/menu/tabs/tab-general.php
+++ b/dt-core/admin/menu/tabs/tab-general.php
@@ -87,6 +87,13 @@ class Disciple_Tools_General_Tab extends Disciple_Tools_Abstract_Menu_Base
             $this->box( 'bottom' );
             /* Site Notifications */
 
+            /* User Visability */
+            $this->box( 'top', 'Group Tile Preferences' );
+            $this->process_user_visibility();
+            $this->update_user_visibility();
+            $this->box( 'bottom' );
+            /* User Visability */
+
             $this->template( 'right_column' );
 
             $this->template( 'end' );
@@ -457,6 +464,60 @@ class Disciple_Tools_General_Tab extends Disciple_Tools_Abstract_Menu_Base
                         <input type="checkbox" name="four_fields" <?php echo empty( $group_preferences['four_fields'] ) ? '' : 'checked' ?> /> Four Fields
                     </td>
                 </tr>
+                <?php wp_nonce_field( 'group_preferences' . get_current_user_id(), 'group_preferences_nonce' )?>
+            </table>
+            <br>
+            <span style="float:right;"><button type="submit" class="button float-right"><?php esc_html_e( "Save", 'disciple_tools' ) ?></button> </span>
+        </form>
+        <?php
+    }
+
+    /** Group Preferences */
+    public function process_user_visibility(){
+
+        if ( isset( $_POST['user_visibility_nonce'] ) &&
+             wp_verify_nonce( sanitize_key( wp_unslash( $_POST['user_visibility_nonce'] ) ), 'user_visibility' . get_current_user_id() ) ) {
+
+            // $site_options = dt_get_option( "dt_site_options" );
+            // if ( isset( $_POST['church_metrics'] ) && ! empty( $_POST['church_metrics'] ) ) {
+            //     $site_options["group_preferences"]["church_metrics"] = true;
+            // } else {
+            //     $site_options["group_preferences"]["church_metrics"] = false;
+            // }
+            // if ( isset( $_POST['four_fields'] ) && ! empty( $_POST['four_fields'] ) ) {
+            //     $site_options["group_preferences"]["four_fields"] = true;
+            // } else {
+            //     $site_options["group_preferences"]["four_fields"] = false;
+            // }
+
+            // update_option( 'dt_site_options', $site_options, true );
+        }
+
+    }
+
+    public function update_user_visibility(){
+        $group_preferences = dt_get_option( 'group_preferences' );
+        $dt_roles = dt_multi_role_get_editable_role_names();
+        ?>
+        <p><?php esc_html_e( "What User Roles can view other users names" ) ?></p>
+        <form method="post" >
+            <table class="widefat">
+            <?php foreach ( $dt_roles as $role_key => $name ) : ?>
+                <?php
+                $role_object = get_role( $role_key );
+                if ( !array_key_exists( 'list_users', $role_object->capabilities ) ) {
+                        dt_write_log( "no" );
+                } else {
+                    dt_write_log( "yes" );
+                }
+                ?>
+                <tr>
+                    <td>
+                        <input type="checkbox" name="<?php echo esc_attr( $role_key ); ?>" <?php checked( array_key_exists( 'list_users', $role_object->capabilities ) ); ?>/> <?php echo esc_attr( $name ); ?>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+
                 <?php wp_nonce_field( 'group_preferences' . get_current_user_id(), 'group_preferences_nonce' )?>
             </table>
             <br>

--- a/dt-core/admin/menu/tabs/tab-general.php
+++ b/dt-core/admin/menu/tabs/tab-general.php
@@ -502,7 +502,8 @@ class Disciple_Tools_General_Tab extends Disciple_Tools_Abstract_Menu_Base
                 ?>
                 <tr>
                     <td>
-                        <input type="checkbox" name="<?php echo esc_attr( $role_key ); ?>" <?php checked( array_key_exists( 'dt_list_users', $role_object->capabilities ) ); ?>/> <?php echo esc_attr( $name ); ?>
+                        <input type="checkbox" name="<?php echo esc_attr( $role_key ); ?>" <?php checked( array_key_exists( 'dt_list_users', $role_object->capabilities ) );
+                        if ( array_key_exists( 'view_any_contacts', $role_object->capabilities ) ) { echo esc_attr( "disabled" ); }  ?>/> <?php echo esc_attr( $name ); ?>
                     </td>
                 </tr>
             <?php endforeach; ?>

--- a/dt-core/admin/menu/tabs/tab-general.php
+++ b/dt-core/admin/menu/tabs/tab-general.php
@@ -88,7 +88,7 @@ class Disciple_Tools_General_Tab extends Disciple_Tools_Abstract_Menu_Base
             /* Site Notifications */
 
             /* User Visability */
-            $this->box( 'top', 'Group Tile Preferences' );
+            $this->box( 'top', 'User Visibility Preferences' );
             $this->process_user_visibility();
             $this->update_user_visibility();
             $this->box( 'bottom' );
@@ -175,7 +175,6 @@ class Disciple_Tools_General_Tab extends Disciple_Tools_Abstract_Menu_Base
         if ( isset( $roles['administrator'] ) ) {
             unset( $roles['administrator'] );
         }
-//        dt_write_log( $roles );
 
         if ( isset( $_POST['metrics_nonce'] ) && wp_verify_nonce( sanitize_key( wp_unslash( $_POST['metrics_nonce'] ) ), 'metrics' . get_current_user_id() ) ) {
 
@@ -481,10 +480,8 @@ class Disciple_Tools_General_Tab extends Disciple_Tools_Abstract_Menu_Base
             foreach ( $dt_roles as $role_key => $name ) :
                 $role_object = get_role( $role_key );
                 if ( isset( $_POST[$role_key] ) && !array_key_exists( 'list_users', $role_object->capabilities ) ) {
-                    dt_write_log( 'add capability' );
                     $role_object->add_cap( 'list_users' );
                 } else if ( !isset( $_POST[$role_key] ) && array_key_exists( 'list_users', $role_object->capabilities ) ) {
-                    dt_write_log( 'delete capability' );
                     $role_object->remove_cap( 'list_users' );
                 }
             endforeach;
@@ -496,7 +493,7 @@ class Disciple_Tools_General_Tab extends Disciple_Tools_Abstract_Menu_Base
         $group_preferences = dt_get_option( 'group_preferences' );
         $dt_roles = dt_multi_role_get_editable_role_names();
         ?>
-        <p><?php esc_html_e( "What User Roles can view other users names" ) ?></p>
+        <p><?php esc_html_e( "User Roles that can view all other Disciple Tools users names" ) ?></p>
         <form method="post" >
             <table class="widefat">
             <?php foreach ( $dt_roles as $role_key => $name ) : ?>

--- a/dt-core/admin/menu/tabs/tab-general.php
+++ b/dt-core/admin/menu/tabs/tab-general.php
@@ -472,25 +472,22 @@ class Disciple_Tools_General_Tab extends Disciple_Tools_Abstract_Menu_Base
         <?php
     }
 
-    /** Group Preferences */
+    /** User Visibility Preferences */
     public function process_user_visibility(){
-
         if ( isset( $_POST['user_visibility_nonce'] ) &&
              wp_verify_nonce( sanitize_key( wp_unslash( $_POST['user_visibility_nonce'] ) ), 'user_visibility' . get_current_user_id() ) ) {
 
-            // $site_options = dt_get_option( "dt_site_options" );
-            // if ( isset( $_POST['church_metrics'] ) && ! empty( $_POST['church_metrics'] ) ) {
-            //     $site_options["group_preferences"]["church_metrics"] = true;
-            // } else {
-            //     $site_options["group_preferences"]["church_metrics"] = false;
-            // }
-            // if ( isset( $_POST['four_fields'] ) && ! empty( $_POST['four_fields'] ) ) {
-            //     $site_options["group_preferences"]["four_fields"] = true;
-            // } else {
-            //     $site_options["group_preferences"]["four_fields"] = false;
-            // }
-
-            // update_option( 'dt_site_options', $site_options, true );
+            $dt_roles = dt_multi_role_get_editable_role_names();
+            foreach ( $dt_roles as $role_key => $name ) :
+                $role_object = get_role( $role_key );
+                if ( isset( $_POST[$role_key] ) && !array_key_exists( 'list_users', $role_object->capabilities ) ) {
+                    dt_write_log( 'add capability' );
+                    $role_object->add_cap( 'list_users' );
+                } else if ( !isset( $_POST[$role_key] ) && array_key_exists( 'list_users', $role_object->capabilities ) ) {
+                    dt_write_log( 'delete capability' );
+                    $role_object->remove_cap( 'list_users' );
+                }
+            endforeach;
         }
 
     }
@@ -505,11 +502,6 @@ class Disciple_Tools_General_Tab extends Disciple_Tools_Abstract_Menu_Base
             <?php foreach ( $dt_roles as $role_key => $name ) : ?>
                 <?php
                 $role_object = get_role( $role_key );
-                if ( !array_key_exists( 'list_users', $role_object->capabilities ) ) {
-                        dt_write_log( "no" );
-                } else {
-                    dt_write_log( "yes" );
-                }
                 ?>
                 <tr>
                     <td>
@@ -518,7 +510,7 @@ class Disciple_Tools_General_Tab extends Disciple_Tools_Abstract_Menu_Base
                 </tr>
             <?php endforeach; ?>
 
-                <?php wp_nonce_field( 'group_preferences' . get_current_user_id(), 'group_preferences_nonce' )?>
+                <?php wp_nonce_field( 'user_visibility' . get_current_user_id(), 'user_visibility_nonce' )?>
             </table>
             <br>
             <span style="float:right;"><button type="submit" class="button float-right"><?php esc_html_e( "Save", 'disciple_tools' ) ?></button> </span>

--- a/dt-posts/dt-posts.php
+++ b/dt-posts/dt-posts.php
@@ -556,7 +556,28 @@ class DT_Posts extends Disciple_Tools_Posts {
         }
         if ( !$send_quick_results ){
             if ( !self::can_view_all( $post_type ) && !self::can_list_all( $post_type )) {
-                if ( self::can_view_users() ) {
+                if ( $post_type === "contacts" && self::can_view_users() ) {
+                    $shared_with_user = self::get_posts_shared_with_user( $post_type, $current_user->ID, $search_string );
+                    $query_args['meta_key'] = 'assigned_to';
+                    $query_args['meta_value'] = "user-" . $current_user->ID;
+                    $posts = $wpdb->get_results( $wpdb->prepare( "
+                        SELECT *, statusReport.meta_value as overall_status, pm.meta_value as corresponds_to_user
+                        FROM $wpdb->posts
+                        INNER JOIN $wpdb->postmeta as assigned_to ON ( $wpdb->posts.ID = assigned_to.post_id AND assigned_to.meta_key = 'assigned_to')
+                        LEFT JOIN $wpdb->postmeta statusReport ON ( statusReport.post_id = $wpdb->posts.ID AND statusReport.meta_key = 'overall_status')
+                        LEFT JOIN $wpdb->postmeta pm ON ( pm.post_id = $wpdb->posts.ID AND pm.meta_key = 'corresponds_to_user' )
+                        WHERE ( assigned_to.meta_value = %s OR ( pm.meta_key = 'corresponds_to_user' AND pm.meta_value IS NOT NULL ) )
+                        AND $wpdb->posts.post_title LIKE %s
+                        AND $wpdb->posts.post_type = %s AND ($wpdb->posts.post_status = 'publish' OR $wpdb->posts.post_status = 'private')
+                        ORDER BY CASE
+                            WHEN $wpdb->posts.post_title LIKE %s then 1
+                            ELSE 2
+                        END, CHAR_LENGTH($wpdb->posts.post_title), $wpdb->posts.post_title
+                        LIMIT 0, 30
+                    ", "user-". $current_user->ID, '%' . $search_string . '%', $post_type, '%' . $search_string . '%'
+                    ), OBJECT );
+                } else {
+                    //@todo better way to get the contact records for users my contacts are shared with
                     $shared_with_user = self::get_posts_shared_with_user( $post_type, $current_user->ID, $search_string );
                     $query_args['meta_key'] = 'assigned_to';
                     $query_args['meta_value'] = "user-" . $current_user->ID;
@@ -569,7 +590,6 @@ class DT_Posts extends Disciple_Tools_Posts {
                         WHERE assigned_to.meta_value = %s
                         AND $wpdb->posts.post_title LIKE %s
                         AND $wpdb->posts.post_type = %s AND ($wpdb->posts.post_status = 'publish' OR $wpdb->posts.post_status = 'private')
-                        OR ( pm.meta_key = 'corresponds_to_user' AND pm.meta_value IS NOT NULL )
                         ORDER BY CASE
                             WHEN $wpdb->posts.post_title LIKE %s then 1
                             ELSE 2
@@ -577,28 +597,7 @@ class DT_Posts extends Disciple_Tools_Posts {
                         LIMIT 0, 30
                     ", "user-". $current_user->ID, '%' . $search_string . '%', $post_type, '%' . $search_string . '%'
                     ), OBJECT );
-                } else {
-                //@todo better way to get the contact records for users my contacts are shared with
-                $shared_with_user = self::get_posts_shared_with_user( $post_type, $current_user->ID, $search_string );
-                $query_args['meta_key'] = 'assigned_to';
-                $query_args['meta_value'] = "user-" . $current_user->ID;
-                $posts = $wpdb->get_results( $wpdb->prepare( "
-                    SELECT *, statusReport.meta_value as overall_status, pm.meta_value as corresponds_to_user
-                    FROM $wpdb->posts
-                    INNER JOIN $wpdb->postmeta as assigned_to ON ( $wpdb->posts.ID = assigned_to.post_id AND assigned_to.meta_key = 'assigned_to')
-                    LEFT JOIN $wpdb->postmeta statusReport ON ( statusReport.post_id = $wpdb->posts.ID AND statusReport.meta_key = 'overall_status')
-                    LEFT JOIN $wpdb->postmeta pm ON ( pm.post_id = $wpdb->posts.ID AND pm.meta_key = 'corresponds_to_user' )
-                    WHERE assigned_to.meta_value = %s
-                    AND $wpdb->posts.post_title LIKE %s
-                    AND $wpdb->posts.post_type = %s AND ($wpdb->posts.post_status = 'publish' OR $wpdb->posts.post_status = 'private')
-                    ORDER BY CASE
-                        WHEN $wpdb->posts.post_title LIKE %s then 1
-                        ELSE 2
-                    END, CHAR_LENGTH($wpdb->posts.post_title), $wpdb->posts.post_title
-                    LIMIT 0, 30
-                ", "user-". $current_user->ID, '%' . $search_string . '%', $post_type, '%' . $search_string . '%'
-                ), OBJECT );
-            }
+                }
             } else {
                 $posts = $wpdb->get_results( $wpdb->prepare( "
                     SELECT ID, post_title, pm.meta_value as corresponds_to_user, statusReport.meta_value as overall_status

--- a/dt-posts/posts.php
+++ b/dt-posts/posts.php
@@ -62,7 +62,7 @@ class Disciple_Tools_Posts
      * @return bool
      */
     public static function can_view_users() {
-        return current_user_can( "list_users" );
+        return current_user_can( "dt_list_users" );
     }
 
     /**

--- a/dt-posts/posts.php
+++ b/dt-posts/posts.php
@@ -54,6 +54,14 @@ class Disciple_Tools_Posts
     }
 
     /**
+     *
+     * @return bool
+     */
+    public static function can_view_users() {
+        return current_user_can( "list_users" );
+    }
+
+    /**
      * @param string $post_type
      *
      * @return bool

--- a/dt-users/users.php
+++ b/dt-users/users.php
@@ -66,7 +66,7 @@ class Disciple_Tools_Users
         $user_id = get_current_user_id();
         $users = [];
         $update_needed = [];
-        if ( !user_can( get_current_user_id(), 'view_any_contacts' ) ){
+        if ( !user_can( get_current_user_id(), 'view_any_contacts' ) && !user_can( get_current_user_id(), 'list_users' ) ){
             // users that are shared posts that are shared with me
             $users_ids = $wpdb->get_results( $wpdb->prepare("
                 SELECT user_id

--- a/dt-users/users.php
+++ b/dt-users/users.php
@@ -66,7 +66,7 @@ class Disciple_Tools_Users
         $user_id = get_current_user_id();
         $users = [];
         $update_needed = [];
-        if ( !user_can( get_current_user_id(), 'view_any_contacts' ) && !user_can( get_current_user_id(), 'list_users' ) ){
+        if ( !user_can( get_current_user_id(), 'view_any_contacts' ) && !user_can( get_current_user_id(), 'dt_list_users' ) ){
             // users that are shared posts that are shared with me
             $users_ids = $wpdb->get_results( $wpdb->prepare("
                 SELECT user_id


### PR DESCRIPTION
Adds a Preference pane in Settings (DT) -> General Settings. This lists all the DT Roles and allows you to check the box if you want to allow that role to have access to the DT users on the front end. This will allow things like Assign, Sub-assign, and @ mentions to list all DT Users.