### PR TITLE
Escapeing bug

### DIFF
--- a/dt-assets/js/contact-details.js
+++ b/dt-assets/js/contact-details.js
@@ -965,7 +965,7 @@ jQuery(document).ready(function($) {
   let urlRegex = /[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/gi
   let protocolRegex = /^(?:https?:\/\/)?(?:www.)?/gi
   let resetDetailsFields = (contact=>{
-    $('.title').html(_.escape(contact.title))
+    $('.title').html(contact.title)
     let contact_methods = ["contact_email", "contact_phone", "contact_address"]
     contact_methods.forEach(contact_method=>{
       let fieldDesignator = contact_method.replace('contact_', '')

--- a/dt-assets/js/contact-details.js
+++ b/dt-assets/js/contact-details.js
@@ -977,7 +977,7 @@ jQuery(document).ready(function($) {
   let urlRegex = /[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/gi
   let protocolRegex = /^(?:https?:\/\/)?(?:www.)?/gi
   let resetDetailsFields = (contact=>{
-    $('.title').html(contact.title)
+    $('.title').html(_.replace(_.escape(contact.title), "&amp;", "&"));
     let contact_methods = ["contact_email", "contact_phone", "contact_address"]
     contact_methods.forEach(contact_method=>{
       let fieldDesignator = contact_method.replace('contact_', '')
@@ -1420,7 +1420,7 @@ jQuery(document).ready(function($) {
     html += `<div style='background-color: #f2f2f2; padding:2%; overflow: hidden;'>
       <h5 style='font-weight: bold; color: #3f729b;'>
       <a href="${window.wpApiShare.site_url}/contacts/${_.escape(dupe.ID)}" target=_blank>
-      ${ _.escape(dupe.contact.title) }
+      ${  _.replace(_.escape(contact.title), "&amp;", "&") }
       <span style="font-weight: normal; font-size:16px"> #${dupe.ID} (${_.get(dupe.contact, "overall_status.label") ||""}) </span>
       </a>
     </h5>`
@@ -1489,7 +1489,7 @@ jQuery(document).ready(function($) {
       let original_contact_html = `<div style='background-color: #f2f2f2; padding:2%; overflow: hidden;'>
         <h5 style='font-weight: bold; color: #3f729b;'>
         <a href="${window.wpApiShare.site_url}/contacts/${_.escape(contact.ID)}" target=_blank>
-        ${ _.escape(contact.title) }
+        ${  _.replace(_.escape(contact.title), "&amp;", "&") }
         <span style="font-weight: normal; font-size:16px"> #${contact.ID} (${_.get(contact, "overall_status.label") ||""}) </span>
         </a>
         </h5>`

--- a/dt-assets/js/group-details.js
+++ b/dt-assets/js/group-details.js
@@ -673,7 +673,7 @@ jQuery(document).ready(function($) {
   })
 
   let resetDetailsFields = (group=>{
-    $('.title').html(group.title)
+    $('.title').html(_.replace(_.escape(group.title), "&amp;", "&"));
     let contact_methods = ["contact_address"]
     contact_methods.forEach(contact_method=>{
       let fieldDesignator = contact_method.replace('contact_', '')

--- a/dt-assets/js/group-details.js
+++ b/dt-assets/js/group-details.js
@@ -673,7 +673,7 @@ jQuery(document).ready(function($) {
   })
 
   let resetDetailsFields = (group=>{
-    $('.title').html(_.escape(group.title))
+    $('.title').html(group.title)
     let contact_methods = ["contact_address"]
     contact_methods.forEach(contact_method=>{
       let fieldDesignator = contact_method.replace('contact_', '')

--- a/dt-assets/js/list.js
+++ b/dt-assets/js/list.js
@@ -245,7 +245,7 @@
       <!--<td><img src="<%- template_directory_uri %>/dt-assets/images/star.svg" width=13 height=12></td>-->
       <!--<td></td>-->
       <td>
-        <a href="<%- permalink %>" class="list-name-link"><%- post_title %></a>
+        <a href="<%- permalink %>" class="list-name-link"><%= post_title %></a>
         <br>
         <%- phone_numbers.join(", ") %>
         <span class="show-for-small-only">
@@ -285,13 +285,13 @@
       <!--<td><img src="<%- template_directory_uri %>/dt-assets/images/green_flag.svg" width=10 height=12></td>-->
       <!--<td></td>-->
       <td class="show-for-small-only">
-        <a href="<%- permalink %>" class="list-name-link"><%- post_title %></a>
+        <a href="<%- permalink %>" class="list-name-link"><%= post_title %></a>
         <br>
         <%- status %> <%- type %> <%- member_count %>
         <%- locations.join(", ") %>
         <%= leader_links %>
       </td>
-      <td class="hide-for-small-only"><a href="<%- permalink %>"><%- post_title %></a></td>
+      <td class="hide-for-small-only"><a href="<%- permalink %>"><%= post_title %></a></td>
       <td class="hide-for-small-only">
         <span class="group-status group-status--<%- group_status %>"><%- status %>
         <% if (update_needed){ %>


### PR DESCRIPTION
fixes #929.

The problem is occurring when someone with a role that does not have `unfiltered_html` capabilities (everything except Administrator) created a contact or group with an & in the title. This almost fixes the issue.

Right now this works for everyone, but if an Administrator (not a dt_admin) or Super_admin in Multisite creates a contact or group with an XSS attack it doesn't get filtered because they have unfiltered_html capabilities and Wordpress doesn't fun it through kses functions. This is Wordpress's default settings and any user with Admin or Super_admin role can put malicious XSS code into a post, but honestly someone with those roles could do this through any number of means with out needing a XSS vulnerability.