### PR TITLE
filtering out duplicates from the people group compact end point.

### DIFF
--- a/dt-people-groups/people-groups.php
+++ b/dt-people-groups/people-groups.php
@@ -345,6 +345,10 @@ class Disciple_Tools_People_Groups
 
         $total_found_posts = $query->found_posts + $meta_query->found_posts;
 
+        $list = array_intersect_key($list, array_unique( array_map( function ( $el ) {
+            return $el['ID'];
+        }, $list ) ) );
+
         return [
         "total" => $total_found_posts,
         "posts" => $list


### PR DESCRIPTION
This occurs when you have a translation setup for a people group, the search is looking for matches in both the title and the translation labels. If your search matches both (ie Title - American and Spanish Label - Americano and you search for American) it will return the people group twice. This compares the post ID to create a unique array that is returned.