### PR TITLE
HTML Entities in Titles

### DIFF
--- a/dt-posts/dt-posts.php
+++ b/dt-posts/dt-posts.php
@@ -428,8 +428,8 @@ class DT_Posts extends Disciple_Tools_Posts {
 
 
         self::adjust_post_custom_fields( $post_settings, $post_id, $fields );
-        $fields["name"] = $wp_post->post_title;
-        $fields["title"] = $wp_post->post_title;
+        $fields["name"] = wp_specialchars_decode( $wp_post->post_title );
+        $fields["title"] = wp_specialchars_decode( $wp_post->post_title );
 
         $fields = apply_filters( 'dt_after_get_post_fields_filter', $fields, $post_type );
         wp_cache_set( "post_" . $current_user_id . '_' . $post_id, $fields );
@@ -479,6 +479,7 @@ class DT_Posts extends Disciple_Tools_Posts {
 
         $ids = [];
         foreach ( $records as $record ) {
+            $record->post_title = wp_specialchars_decode( $record->post_title );
             $ids[] = $record->ID;
         }
         $ids_sql = dt_array_to_sql( $ids );
@@ -542,7 +543,7 @@ class DT_Posts extends Disciple_Tools_Posts {
 
             self::adjust_post_custom_fields( $post_settings, $record["ID"], $record, $fields_to_return, $all_posts[$record["ID"]] ?? [], $all_post_user_meta[$record["ID"]] ?? [] );
             $record["permalink"] = $site_url . '/' . $post_type .'/' . $record["ID"];
-            $record["name"] = $record["post_title"];
+            $record["name"] = wp_specialchars_decode( $record["post_title"] );
             $record["post_date"] = [
                 "timestamp" => is_numeric( $record["post_date"] ) ? $record["post_date"] : dt_format_date( $record["post_date"], "U" ),
                 "formatted" => dt_format_date( $record["post_date"] )

--- a/dt-posts/posts.php
+++ b/dt-posts/posts.php
@@ -222,21 +222,21 @@ class Disciple_Tools_Posts
             if ($activity->field_type === "connection from"){
                 $from = get_post( $activity->object_id );
                 $to = get_post( $activity->meta_value );
-                $from_title = $from->post_title;
-                $to_title = $to->post_title ?? '#' . $activity->meta_value;
+                $from_title = wp_specialchars_decode( $from->post_title );
+                $to_title = wp_specialchars_decode( $to->post_title ) ?? '#' . $activity->meta_value;
             } elseif ( $activity->field_type === "connection to"){
                 $to = get_post( $activity->object_id );
                 $from = get_post( $activity->meta_value );
-                $to_title = $to->post_title;
-                $from_title = $from->post_title ?? '#' . $activity->meta_value;
+                $to_title = wp_specialchars_decode( $to->post_title );
+                $from_title = wp_specialchars_decode( $from->post_title ) ?? '#' . $activity->meta_value;
             } else {
                 return "CONNECTION DESTROYED";
             }
         } else {
             $p2p_from = get_post( $p2p_record->p2p_from, ARRAY_A );
             $p2p_to = get_post( $p2p_record->p2p_to, ARRAY_A );
-            $from_title = $p2p_from["post_title"];
-            $to_title = $p2p_to["post_title"];
+            $from_title = wp_specialchars_decode( $p2p_from["post_title"] );
+            $to_title = wp_specialchars_decode( $p2p_to["post_title"] );
         }
         $object_note_from = '';
         $object_note_to = '';
@@ -1066,6 +1066,10 @@ class Disciple_Tools_Posts
                 $posts[] = $post;
                 $total_rows++;
             }
+        }
+        //decode special characters in post titles
+        foreach ( $posts as $post ) {
+            $post->post_title = wp_specialchars_decode( $post->post_title );
         }
         return [
             "posts" => $posts,


### PR DESCRIPTION
uses wp_specialchars_decode() to fix the HTML encoded characters in contact and group Titles.

wp_specialchars_decode() will handle &, <, >, ", and ‘.

The other PRs for this were a start, but were flawed. So I just started over. I believe I hit all the places that post titles are shown. I checked the Dashboard plugin, lists pages, and individual pages, and various metrics pages.

I also checked it against XSS injections and it seems to hold up, but that is always worth double checking.