### PR TITLE
Menus: Use filters instead of actions to load menu items

### DIFF
--- a/dt-assets/functions/menu.php
+++ b/dt-assets/functions/menu.php
@@ -11,10 +11,16 @@
 function disciple_tools_top_nav_desktop() {
 
     /**
-     * Loads top row menu
+     * Loads nav bar menu items
      * @note Main post types (Contacts, Groups, Metrics) fire between 20-30. If you want to add an item before the
      * main post types, load before 20, if you want to load after the list, load after 30.
      */
+    $tabs = apply_filters( "desktop_navbar_menu_options", [] );
+    foreach ( $tabs as $tab ) : ?>
+        <li><a href="<?php echo esc_url( $tab["link"] ) ?>"> <?php echo esc_html( $tab["label"] ) ?> </a></li>
+    <?php endforeach;
+
+    //append a non standard menu item at the end
     do_action( 'dt_top_nav_desktop' );
 }
 
@@ -29,14 +35,20 @@ function disciple_tools_off_canvas_nav() {
             </div>
             <hr/>
         </li>
-
         <?php
 
         /**
-         * Loads main menu items
+         * Loads offcanvas menu items for mobile
          * @note Main post types (Contacts, Groups, Metrics) fire between 20-30. If you want to add an item before the
          * main post types, load before 20, if you want to load after the list, load after 30.
          */
+        $tabs = apply_filters( "off_canvas_menu_options", [] );
+
+        foreach ( $tabs as $tab ) : ?>
+            <li><a href="<?php echo esc_url( $tab["link"] ) ?>"> <?php echo esc_html( $tab["label"] ) ?> </a></li>
+        <?php endforeach;
+
+        //append a non standard menu item at the end
         do_action( 'dt_off_canvas_nav' );
 
         ?>

--- a/dt-metrics/metrics.php
+++ b/dt-metrics/metrics.php
@@ -99,16 +99,20 @@ class Disciple_Tools_Metrics
         /**
          * Add Navigation Menu
          */
-        add_action( 'dt_top_nav_desktop', function(){
-            ?>
-            <li><a href="<?php echo esc_url( site_url( '/metrics/' ) ); ?>"><?php esc_html_e( "Metrics" ); ?></a></li>
-            <?php
-        }, 21 );
-        add_action( 'dt_off_canvas_nav', function(){
-            ?>
-            <li><a href="<?php echo esc_url( site_url( '/metrics/' ) ); ?>"><?php esc_html_e( "Metrics" ); ?></a></li>
-            <?php
-        }, 21 );
+        add_action( 'desktop_navbar_menu_options', function( $tabs ){
+            $tabs[] = [
+                "link" => site_url( '/metrics/' ),
+                "label" => __( "Metrics", "disciple_tools" )
+            ];
+            return $tabs;
+        }, 25 );
+        add_action( 'off_canvas_menu_options', function( $tabs ){
+            $tabs[] = [
+                "link" => site_url( '/metrics/' ),
+                "label" => __( "Metrics", "disciple_tools" )
+            ];
+            return $tabs;
+        }, 25 );
     }
 
 }

--- a/dt-posts/custom-post-type.php
+++ b/dt-posts/custom-post-type.php
@@ -19,9 +19,8 @@ class Disciple_Tools_Post_Type_Template {
         add_action( 'init', [ $this, 'register_post_type' ] );
         add_action( 'init', [ $this, 'rewrite_init' ] );
         add_filter( 'post_type_link', [ $this, 'permalink' ], 1, 3 );
-        add_action( 'dt_top_nav_desktop', [ $this, 'add_menu_link' ], 20 );
-        add_action( 'dt_off_canvas_nav', [ $this, 'add_menu_link' ], 20 );
-        add_filter( 'off_canvas_menu_options', [ $this, 'add_hamburger_menu' ] );
+        add_action( 'desktop_navbar_menu_options', [ $this, 'add_navigation_links' ], 20 );
+        add_filter( 'off_canvas_menu_options', [ $this, 'add_navigation_links' ], 20 );
         add_filter( 'dt_templates_for_urls', [ $this, 'add_template_for_url' ] );
         add_action( 'dt_nav_add_post_menu', [ $this, 'dt_nav_add_post_menu' ] );
         add_filter( 'dt_get_post_type_settings', [ $this, 'dt_get_post_type_settings' ], 10, 2 );
@@ -110,13 +109,7 @@ class Disciple_Tools_Post_Type_Template {
         }
     }
 
-    public function add_menu_link(){
-        if ( current_user_can( 'access_' . $this->post_type ) ) : ?>
-            <li><a href="<?php echo esc_url( site_url( '/' . $this->post_type . '/' ) ); ?>"><?php echo esc_html( $this->plural ); ?></a></li>
-        <?php endif;
-    }
-
-    public function add_hamburger_menu( $tabs ) {
+    public function add_navigation_links( $tabs ) {
         if ( current_user_can( 'access_' . $this->post_type ) ) {
             $tabs[] = [
                 "link" => site_url( "/$this->post_type/" ),


### PR DESCRIPTION
I would like us to use a filter instead of an action to load the menu item for the nav bar and the offcanvas menu items.
The main reasons:
- we can reorganize them if needed or if there are too many links to display
- a org can create a plugin hooking into the filter with a high priority number to reorder them (ie groups first)
- we can change the navbar strategy down the road without needed to change the html in all plugin that add a nav item.