### PR TITLE
Notification Timezone bug fix

### DIFF
--- a/dt-notifications/notifications.php
+++ b/dt-notifications/notifications.php
@@ -337,7 +337,7 @@ class Disciple_Tools_Notifications
 
     public static function pretty_timestamp( $timestamp ) {
         /** Get current time */
-        $now = current_time('timestamp');
+        $now = current_time( 'timestamp' );
 
         /** Get "this" notification timestamp */
         $notification_date = strtotime( $timestamp );

--- a/dt-notifications/notifications.php
+++ b/dt-notifications/notifications.php
@@ -337,7 +337,7 @@ class Disciple_Tools_Notifications
 
     public static function pretty_timestamp( $timestamp ) {
         /** Get current time */
-        $now = time();
+        $now = current_time('timestamp');
 
         /** Get "this" notification timestamp */
         $notification_date = strtotime( $timestamp );


### PR DESCRIPTION
Use WP time settings instead of server settings.
fixes issues #1066