### PR TITLE
Added tel: links to contact phone numbers in the collapsed details pane

### DIFF
--- a/dt-assets/js/details.js
+++ b/dt-assets/js/details.js
@@ -811,7 +811,11 @@ jQuery(document).ready(function($) {
         }
 
         $(`#collapsed-detail-${field_key}`).toggle(values_html !== ``)
-        $(`#collapsed-detail-${field_key} .collapsed-items`).html(`<span title="${values_html}">${values_html}</span>`)
+        if (field_key == "contact_phone") {
+          $(`#collapsed-detail-${field_key} .collapsed-items`).html(`<a href="tel:${values_html}" title="${values_html}">${values_html}</span>`)
+        } else {
+          $(`#collapsed-detail-${field_key} .collapsed-items`).html(`<span title="${values_html}">${values_html}</span>`)
+        }
       }
 
     })


### PR DESCRIPTION
This was a feature we had before V1. This adds the tel: link to the contact phone number field in the collapsed details pane