### PR TITLE
Enlarge Value Column in the DT_Reports table to handle larger numbers

### DIFF
--- a/dt-core/configuration/class-migration-engine.php
+++ b/dt-core/configuration/class-migration-engine.php
@@ -12,7 +12,7 @@ if ( !defined( 'ABSPATH' ) ) {
 class Disciple_Tools_Migration_Engine
 {
 
-    public static $migration_number = 39;
+    public static $migration_number = 40;
 
     protected static $migrations = null;
 

--- a/dt-core/migrations/0040-update-reports-value-column.php
+++ b/dt-core/migrations/0040-update-reports-value-column.php
@@ -1,0 +1,25 @@
+<?php
+if ( !defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly
+
+/**
+ * Class Disciple_Tools_Migration_0040
+ *
+ * Updates the value column of reports to bigint 22 from int 11.
+ */
+class Disciple_Tools_Migration_0040 extends Disciple_Tools_Migration {
+    public function up() {
+        global $wpdb;
+        $wpdb->query( "ALTER TABLE `wp_70_dt_reports` CHANGE `value` `value` BIGINT(22)  NOT NULL  DEFAULT '0';" );
+        $wpdb->query( "ALTER TABLE `wp_70_dt_reports` ADD INDEX (`value`);" );
+    }
+
+    public function down() {
+    }
+
+    public function test() {
+    }
+
+    public function get_expected_tables(): array {
+        return [];
+    }
+}

--- a/dt-core/migrations/0040-update-reports-value-column.php
+++ b/dt-core/migrations/0040-update-reports-value-column.php
@@ -9,8 +9,8 @@ if ( !defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly
 class Disciple_Tools_Migration_0040 extends Disciple_Tools_Migration {
     public function up() {
         global $wpdb;
-        $wpdb->query( "ALTER TABLE `wp_70_dt_reports` CHANGE `value` `value` BIGINT(22)  NOT NULL  DEFAULT '0';" );
-        $wpdb->query( "ALTER TABLE `wp_70_dt_reports` ADD INDEX (`value`);" );
+        $wpdb->query( "ALTER TABLE $wpdb->dt_reports CHANGE `value` `value` BIGINT(22)  NOT NULL  DEFAULT '0';" );
+        $wpdb->query( "ALTER TABLE $wpdb->dt_reports ADD INDEX (`value`);" );
     }
 
     public function down() {


### PR DESCRIPTION
This pull request adds a migration to expand the size of the value column in dt_reports from INT(11) to BIGINT(22). This will allow larger numbers to be used. The immediate application is felt in a recurring time scheduling feature.