### PR TITLE
People Groups typeahead on the new records 

### DIFF
--- a/dt-assets/js/new-record.js
+++ b/dt-assets/js/new-record.js
@@ -132,12 +132,16 @@ jQuery(function($) {
           accent: true,
           searchOnFocus: true,
           maxItem: 20,
-          template: function (query, item) {
-            return `<span dir="auto">${_.escape(item.name)} (#${_.escape( item.ID )})</span>`
+          template: window.TYPEAHEADS.contactListRowTemplate,
+          source: TYPEAHEADS.typeaheadPostsSource(post_type, field_key),
+          display: ["name", "label"],
+          templateValue: function() {
+            if (this.items[this.items.length - 1].label) {
+              return "{{label}}"
+            } else {
+              return "{{name}}"
+            }
           },
-          source: TYPEAHEADS.typeaheadPostsSource(post_type),
-          display: "name",
-          templateValue: "{{name}}",
           dynamic: true,
           multiselect: {
             matchOn: ["ID"],


### PR DESCRIPTION
brings the People Groups typeahead on the new records page up to date to the details page version.