### PR TITLE
fix: add display: none; to hide #hide-hidden-fields button initially

### DIFF
--- a/template-new-post.php
+++ b/template-new-post.php
@@ -116,7 +116,7 @@ if ( isset( $post_settings["fields"]["type"] ) && sizeof( $post_settings["fields
                             <a class="button clear" id="show-hidden-fields" style="margin:0;padding:3px 0; width:100%">
                                 <?php esc_html_e( 'Show all fields', 'disciple_tools' ); ?>
                             </a>
-                            <a class="button clear" id="hide-hidden-fields" style="margin:0;padding:3px 0; width:100%">
+                            <a class="button clear" id="hide-hidden-fields" style="margin:0;padding:3px 0; width:100%; display: none;">
                                 <?php esc_html_e( 'Hide fields', 'disciple_tools' ); ?>
                             </a>
                         </div>


### PR DESCRIPTION
fixes the 'hide fields' button showing initially on the add group page.