### PR TITLE
Adds logic to recombine comm channels with spaces.

### DIFF
--- a/dt-posts/posts.php
+++ b/dt-posts/posts.php
@@ -446,6 +446,7 @@ class Disciple_Tools_Posts
                 } else if ( strpos( $activity->meta_key, "contact_" ) === 0 ) {
                     $channel = explode( '_', $activity->meta_key );
                     $channel_key_count = count( $channel ) - 1;
+                    //handle when a communication channel key has an underscore in it.
                     if ( isset( $channel[1] ) ) {
                         $channel_key = "";
                         for ( $i = 1; $i < $channel_key_count; $i++ ) {

--- a/dt-posts/posts.php
+++ b/dt-posts/posts.php
@@ -445,8 +445,19 @@ class Disciple_Tools_Posts
                     }
                 } else if ( strpos( $activity->meta_key, "contact_" ) === 0 ) {
                     $channel = explode( '_', $activity->meta_key );
-                    if ( isset( $channel[1] ) && isset( $post_type_settings["channels"][ $channel[1] ] ) ){
-                        $channel = $post_type_settings["channels"][ $channel[1] ];
+                    $channel_key_count = count( $channel ) - 1;
+                    if ( isset( $channel[1] ) ) {
+                        $channel_key = "";
+                        for ( $i = 1; $i < $channel_key_count; $i++ ) {
+                            if ($channel_key) {
+                                $channel_key = $channel_key . '_' . $channel[$i];
+                            } else {
+                                $channel_key = $channel[$i];
+                            }
+                        }
+                    }
+                    if ( isset( $channel_key ) && isset( $post_type_settings["channels"][ $channel_key ] ) ){
+                        $channel = $post_type_settings["channels"][ $channel_key ];
                         if ( $activity->old_value === "" ){
                             $message = sprintf( _x( 'Added %1$s: %2$s', 'Added Facebook: facebook.com/123', 'disciple_tools' ), $channel["label"] ?? $activity->meta_key, $activity->meta_value );
                         } else if ( $activity->meta_value != "value_deleted" ){


### PR DESCRIPTION
This fixes a bug that if a custom communication channel has a space it would not add an update in the activity section of the comments. 

Basically the space was converted to a underscore and previously we were exploding the string based on underscores. So we were expecting something like `contact_customChannel_d123` and then searched the $post_type_settings["channels"] for the key `customChannel`, this broke when we have something like `contact_custom_channel_d123` because we were be searching the $post_type_settings["channel"] for a key of "custom" instead of "custom_channel".
