### PR TITLE
use current theme stylesheet to get correct update option

### DIFF
--- a/dt-assets/parts/nav-topbar.php
+++ b/dt-assets/parts/nav-topbar.php
@@ -134,7 +134,8 @@ $dt_nav_tabs = dt_default_menu_array();
                 <!-- core update -->
                 <?php
                 if ( current_user_can( "update_core" ) ){
-                    $update = maybe_unserialize( get_site_option( "puc_external_updates_theme-disciple-tools-theme", "" ) );
+                    $theme = wp_get_theme();
+                    $update = maybe_unserialize( get_site_option( "puc_external_updates_theme-" . $theme->get_stylesheet(), "" ) );
                     if ( !empty( $update ) && isset( $update->update->version ) && version_compare( $update->update->version, wp_get_theme()->version, '>' ) ) : ?>
                         <li class="image-menu-nav">
                             <a href="<?php echo esc_url( network_admin_url( 'update-core.php' ) ); ?>">


### PR DESCRIPTION
If theme directory is not named exactly `disciple-tools-theme`, the theme detection in the header does not seem to be working. This can happen from old installs that are named `disciple-tools-theme-master`, so adding this fix to grab the directory name from the current theme.