### PR TITLE
1292 - Error Log Retention Policy Management

### DIFF
--- a/dt-core/admin/menu/tabs/tab-error-logs.php
+++ b/dt-core/admin/menu/tabs/tab-error-logs.php
@@ -71,7 +71,7 @@ class Disciple_Tools_Tab_Logs extends Disciple_Tools_Abstract_Menu_Base {
         if ( isset( $_POST['email_error_logs_nonce'] ) && wp_verify_nonce( sanitize_key( wp_unslash( $_POST['email_error_logs_nonce'] ) ), 'email_error_logs_nonce' ) ) {
             update_option( 'dt_error_log_dispatch_emails', isset( $_POST['dispatch_error_log_emails'] ) ? 1 : 0 );
             update_option( 'dt_error_log_display_count', isset( $_POST['number_of_error_logs_to_display'] ) ? intval( $_POST['number_of_error_logs_to_display'] ) : 20 );
-            update_option( 'dt_error_log_enforce_retention_policy', isset( $_POST['enforce_retention_policy'] ) ? 1 : 0 );
+            update_option( 'dt_error_log_enforce_retention_policy', isset( $_POST['enforce_retention_policy'] ) ? 0 : 1 );
             update_option( 'dt_error_log_retention_period_count', isset( $_POST['retention_period_days'] ) ? intval( $_POST['retention_period_days'] ) : 30 );
         }
     }
@@ -86,7 +86,7 @@ class Disciple_Tools_Tab_Logs extends Disciple_Tools_Abstract_Menu_Base {
     }
 
     private function is_enforce_retention_policy_enabled(): bool {
-        return boolval( get_option( 'dt_error_log_enforce_retention_policy' ) );
+        return ! boolval( get_option( 'dt_error_log_enforce_retention_policy' ) );
     }
 
     private function fetch_retention_period_count(): int {

--- a/dt-core/admin/menu/tabs/tab-error-logs.php
+++ b/dt-core/admin/menu/tabs/tab-error-logs.php
@@ -58,7 +58,6 @@ class Disciple_Tools_Tab_Logs extends Disciple_Tools_Abstract_Menu_Base {
 
             $this->process_settings();
             $this->display_settings();
-
             $this->display_logs();
 
             $this->template( 'right_column' );
@@ -68,23 +67,36 @@ class Disciple_Tools_Tab_Logs extends Disciple_Tools_Abstract_Menu_Base {
         endif;
     }
 
+    private function process_settings() {
+        if ( isset( $_POST['email_error_logs_nonce'] ) && wp_verify_nonce( sanitize_key( wp_unslash( $_POST['email_error_logs_nonce'] ) ), 'email_error_logs_nonce' ) ) {
+            update_option( 'dt_error_log_dispatch_emails', isset( $_POST['dispatch_error_log_emails'] ) ? 1 : 0 );
+            update_option( 'dt_error_log_display_count', isset( $_POST['number_of_error_logs_to_display'] ) ? intval( $_POST['number_of_error_logs_to_display'] ) : 20 );
+            update_option( 'dt_error_log_enforce_retention_policy', isset( $_POST['enforce_retention_policy'] ) ? 1 : 0 );
+            update_option( 'dt_error_log_retention_period_count', isset( $_POST['retention_period_days'] ) ? intval( $_POST['retention_period_days'] ) : 30 );
+        }
+    }
+
+    private function is_dispatch_emails_enabled(): bool {
+        return boolval( get_option( 'dt_error_log_dispatch_emails' ) );
+    }
+
     private function fetch_display_count(): int {
         $display_count_option = get_option( 'dt_error_log_display_count' );
         return ( $display_count_option > 0 ) ? intval( $display_count_option ) : 20;
     }
 
-    private function process_settings() {
-        if ( isset( $_POST['email_error_logs_nonce'] ) && wp_verify_nonce( sanitize_key( wp_unslash( $_POST['email_error_logs_nonce'] ) ), 'email_error_logs_nonce' ) ) {
-            update_option( 'dt_error_log_dispatch_emails', isset( $_POST['dispatch_error_log_emails'] ) ? 1 : 0 );
-            update_option( 'dt_error_log_display_count', isset( $_POST['number_of_error_logs_to_display'] ) ? intval( $_POST['number_of_error_logs_to_display'] ) : 20 );
-        }
+    private function is_enforce_retention_policy_enabled(): bool {
+        return boolval( get_option( 'dt_error_log_enforce_retention_policy' ) );
+    }
+
+    private function fetch_retention_period_count(): int {
+        $retention_period_count = get_option( 'dt_error_log_retention_period_count' );
+        return ( $retention_period_count > 0 ) ? intval( $retention_period_count ) : 30;
     }
 
     private function display_settings() {
 
         $this->box( 'top', 'Logging Settings', [ "col_span" => 4 ] );
-
-        $checked = boolval( get_option( 'dt_error_log_dispatch_emails' ) ) ? 'checked' : '';
 
         ?>
         <form method="POST">
@@ -94,7 +106,7 @@ class Disciple_Tools_Tab_Logs extends Disciple_Tools_Abstract_Menu_Base {
                 <tr>
                     <td align="right">
                         <input type="checkbox" id="dispatch_error_log_emails"
-                               name="dispatch_error_log_emails" <?php echo esc_html( $checked ) ?> />
+                               name="dispatch_error_log_emails" <?php echo esc_html( $this->is_dispatch_emails_enabled() ? 'checked' : '' ) ?> />
                     </td>
                     <td>Dispatch Error Log Notification Emails</td>
                 </tr>
@@ -104,6 +116,20 @@ class Disciple_Tools_Tab_Logs extends Disciple_Tools_Abstract_Menu_Base {
                                name="number_of_error_logs_to_display" value="<?php echo esc_html( $this->fetch_display_count() ) ?>"/>
                     </td>
                     <td>Number Of Error Logs To Be Displayed</td>
+                </tr>
+                <tr>
+                    <td align="right">
+                        <input type="checkbox" id="enforce_retention_policy"
+                               name="enforce_retention_policy" <?php echo esc_html( $this->is_enforce_retention_policy_enabled() ? 'checked' : '' ) ?> />
+                    </td>
+                    <td>Enforce Error Log Retention Policy</td>
+                </tr>
+                <tr>
+                    <td align="right">
+                        <input type="number" id="retention_period_days"
+                               name="retention_period_days" value="<?php echo esc_html( $this->fetch_retention_period_count() ) ?>"/>
+                    </td>
+                    <td>Retention Period (Days)</td>
                 </tr>
             </table>
             <br>

--- a/dt-workflows/error-log-dispatch-email.php
+++ b/dt-workflows/error-log-dispatch-email.php
@@ -4,10 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 } // Exit if accessed directly
 
-if ( ! wp_next_scheduled( 'dispatch-error-log-email' ) ) {
-    wp_schedule_event( time(), 'daily', 'dispatch-error-log-email' );
+if ( ! wp_next_scheduled( 'error_log_dispatch_email' ) ) {
+    wp_schedule_event( time(), 'daily', 'error_log_dispatch_email' );
 }
-add_action( 'dispatch-error-log-email', 'find_new_error_logs' );
+add_action( 'error_log_dispatch_email', 'find_new_error_logs' );
 
 function find_new_error_logs() {
     global $wpdb, $wp;

--- a/dt-workflows/error-log-retention-enforcer.php
+++ b/dt-workflows/error-log-retention-enforcer.php
@@ -11,7 +11,7 @@ add_action( 'error_log_retention_enforcer', 'enforce_error_log_retention_policy'
 
 function enforce_error_log_retention_policy() {
     // Stop if enforce retention policy feature if disabled.
-    if ( ! boolval( get_option( 'dt_error_log_enforce_retention_policy' ) ) ) {
+    if ( boolval( get_option( 'dt_error_log_enforce_retention_policy' ) ) ) {
         return;
     }
 

--- a/dt-workflows/error-log-retention-enforcer.php
+++ b/dt-workflows/error-log-retention-enforcer.php
@@ -1,0 +1,40 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+} // Exit if accessed directly
+
+if ( ! wp_next_scheduled( 'error_log_retention_enforcer' ) ) {
+    wp_schedule_event( time(), 'daily', 'error_log_retention_enforcer' );
+}
+add_action( 'error_log_retention_enforcer', 'enforce_error_log_retention_policy' );
+
+function enforce_error_log_retention_policy() {
+    // Stop if enforce retention policy feature if disabled.
+    if ( ! boolval( get_option( 'dt_error_log_enforce_retention_policy' ) ) ) {
+        return;
+    }
+
+    global $wpdb;
+
+    $current_retention_period_count = fetch_retention_period_count();
+
+    // Identify count of logs greater than specified retention period.
+    $stale_logs_count = $wpdb->get_results( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->dt_activity_log WHERE (action = 'error_log') AND (hist_time < %s)",
+        esc_attr( strtotime( '-' . $current_retention_period_count . ' day' ) )
+    ) );
+
+    // Only delete if stale logs detected.
+    if ( $stale_logs_count > 0 ) {
+        $wpdb->get_results( $wpdb->prepare( "DELETE FROM $wpdb->dt_activity_log WHERE (action = 'error_log') AND (hist_time < %s)",
+            esc_attr( strtotime( '-' . $current_retention_period_count . ' day' ) )
+        ) );
+    }
+
+}
+
+function fetch_retention_period_count(): int {
+    $retention_period_count = get_option( 'dt_error_log_retention_period_count' );
+
+    return ( $retention_period_count > 0 ) ? intval( $retention_period_count ) : 30;
+}

--- a/dt-workflows/workflows.php
+++ b/dt-workflows/workflows.php
@@ -41,6 +41,7 @@ class Disciple_Tools_Workflows {
         new Disciple_Tools_Update_Needed();
         new Disciple_Tools_Update_Needed_Async();
         include( 'tasks.php' );
-        include( 'dispatch-error-log-email.php' );
+        include( 'error-log-dispatch-email.php' );
+        include( 'error-log-retention-enforcer.php' );
     }
 }


### PR DESCRIPTION
## Implementation Summary

- Additional logging settings have been added, so as to (1) Enable/Disable the enforcement of error log retention policy. (2) Specify retention period in days.
- A new cron job [`error_log_retention_enforcer`] has also been added to handle retention policy error log removals.
- Existing dispatch email cron job naming has been changed to [`error_log_dispatch_email`], for uniformity.

![new-error-log-retention-policy-settings](https://user-images.githubusercontent.com/19330800/115726391-9a009880-a37a-11eb-904a-287cdb507f01.png)
