### PR TITLE
'My' coaching and group heading

### DIFF
--- a/dt-metrics/personal/coaching-tree.php
+++ b/dt-metrics/personal/coaching-tree.php
@@ -55,7 +55,7 @@ class DT_Metrics_Personal_Coaching_Tree extends DT_Metrics_Chart_Base
     public function data() {
         return [
             'translations' => [
-                'title_coaching_tree' => __( 'Coaching Generation Tree', 'disciple_tools' ),
+                'title_coaching_tree' => __( 'My Coaching Generation Tree', 'disciple_tools' ),
             ],
         ];
     }

--- a/dt-metrics/personal/group-tree.php
+++ b/dt-metrics/personal/group-tree.php
@@ -79,7 +79,7 @@ class DT_Metrics_Personal_Groups_Tree extends DT_Metrics_Chart_Base
     public function data() {
         return [
             'translations' => [
-                'title_group_tree' => __( 'Group Generation Tree', 'disciple_tools' ),
+                'title_group_tree' => __( 'My Group Generation Tree', 'disciple_tools' ),
                 'highlight_active' => __( 'Highlight Active', 'disciple_tools' ),
                 'highlight_churches' => __( 'Highlight Churches', 'disciple_tools' ),
                 'members' => __( 'Members', 'disciple_tools' ),
@@ -178,5 +178,3 @@ class DT_Metrics_Personal_Groups_Tree extends DT_Metrics_Chart_Base
 
 }
 new DT_Metrics_Personal_Groups_Tree();
-
-


### PR DESCRIPTION
This adds the word 'My' to the start of the page heading to help distinguish this is a personal tree and not the project tree.

Previously:
<img width="637" alt="Screen Shot 2021-04-23 at 00 21 03" src="https://user-images.githubusercontent.com/43966676/116644744-d1061980-a939-11eb-9513-1bd43b4b5794.png">

Now:
<img width="536" alt="Screen Shot 2021-04-29 at 22 14 56" src="https://user-images.githubusercontent.com/43966676/116644768-dfeccc00-a939-11eb-902c-2007721d3ec6.png">
