### PR TITLE
1374 - Test Geocoding Keys in Admin Area

### DIFF
--- a/dt-mapping/geocode-api/google-api.php
+++ b/dt-mapping/geocode-api/google-api.php
@@ -197,8 +197,15 @@ if ( ! class_exists( 'Disciple_Tools_Google_Geocode_API' ) ) {
                 $status_class = 'connected';
                 $message      = 'Successfully connected to Google Maps API.';
             } else {
-                $status_class = 'not-connected';
-                $message      = ! empty( $google_key_active_state['message'] ) ? $google_key_active_state['message'] : 'API NOT CONFIGURED.';
+
+                // As a no-google-key is an ok state; no need to flag as an error
+                if ( ! empty( $key ) ) {
+                    $status_class = 'not-connected';
+                    $message      = ! empty( $google_key_active_state['message'] ) ? $google_key_active_state['message'] : 'API NOT CONFIGURED.';
+                } else {
+                    $status_class = 'connected';
+                    $message      = '';
+                }
             }
             ?>
             <form method="post">

--- a/dt-mapping/geocode-api/mapbox-api.php
+++ b/dt-mapping/geocode-api/mapbox-api.php
@@ -389,16 +389,22 @@ if ( ! class_exists( 'DT_Mapbox_API' ) ) {
             add_action( "admin_enqueue_scripts", [ 'DT_Mapbox_API', 'load_mapbox_header_scripts' ] );
         }
 
-        public static function is_active_mapbox_key() : bool {
+        public static function is_active_mapbox_key() : array {
             $key = self::get_key();
             $url = self::$mapbox_endpoint . 'Denver.json?access_token=' . $key;
             $response = wp_remote_get( esc_url_raw( $url ) );
             $data_result = json_decode( wp_remote_retrieve_body( $response ), true );
 
             if ( isset( $data_result['features'] ) && ! empty( $data_result['features'] ) ) {
-                return true;
+                return [
+                    'success' => true,
+                    'message' => ''
+                ];
             } else {
-                return false;
+                return [
+                    'success' => false,
+                    'message' => ( isset( $data_result['message'] ) && ! empty( $data_result['message'] ) ) ? $data_result['message'] : ''
+                ];
             }
         }
 
@@ -421,15 +427,17 @@ if ( ! class_exists( 'DT_Mapbox_API' ) ) {
             }
             $key = self::get_key();
 
-            if ( self::is_active_mapbox_key() ) {
+            $mapbox_key_active_state = self::is_active_mapbox_key();
+            if ( $mapbox_key_active_state['success'] ) {
                 $status_class = 'connected';
-                $message = 'Successfully connected to selected source.';
+                $message      = 'Successfully connected to selected source.';
             } else {
                 $status_class = 'not-connected';
-                if ( empty( $key )){
+                if ( empty( $key ) ) {
                     $message = 'Please add a Mapbox API Token';
                 } else {
                     $message = 'Could not connect to the Mapbox API or could not verify the token';
+                    $message .= ! empty( $mapbox_key_active_state['message'] ) ? ' - ' . $mapbox_key_active_state['message'] : '';
                 }
             }
             ?>


### PR DESCRIPTION
## Implementation Summary

- Mapbox:
  - Refactored `is_active_mapbox_key()` logic to also include/display additional error messages.
- Google:
  - Implemented is_active_google_key() logic to display additional error messages and check across the following api types:
    - Address based search.
    - Latitude and longitude coordinates based search.
    - Address based search with components. 


![Screenshot 2021-05-28 at 14 14 15](https://user-images.githubusercontent.com/19330800/119997733-f2553680-bfc7-11eb-92c8-9937ec16e884.png)

![Screenshot 2021-05-28 at 14 42 42](https://user-images.githubusercontent.com/19330800/119997736-f3866380-bfc7-11eb-8e37-eed8d3dd3660.png)

![Screenshot 2021-05-28 at 14 46 09](https://user-images.githubusercontent.com/19330800/119997738-f41efa00-bfc7-11eb-99d9-d0f01d49f4ad.png)
