### PR TITLE
Avoid double task creation

### DIFF
--- a/dt-posts/dt-posts.php
+++ b/dt-posts/dt-posts.php
@@ -407,9 +407,7 @@ class DT_Posts extends Disciple_Tools_Posts {
                  */
                 $already_handled = apply_filters( 'dt_post_updated_custom_handled_meta', [ "multi_select", "post_user_meta", "location", "location_meta", "communication_channel", "tags", "user_select" ], $post_type );
                 if ( $field_type && !in_array( $field_type, $already_handled ) ) {
-                    if ( isset( $post_settings["fields"][$field_key]['private'] ) && $post_settings["fields"][$field_key]['private'] ) {
-                        self::update_post_user_meta_fields( $post_settings["fields"], $post_id, $fields, [] );
-                    } else {
+                    if ( !( isset( $post_settings["fields"][$field_key]['private'] ) && $post_settings["fields"][$field_key]['private'] ) ){
                         update_post_meta( $post_id, $field_key, $field_value );
                     }
                 }

--- a/dt-posts/posts.php
+++ b/dt-posts/posts.php
@@ -1661,8 +1661,15 @@ class Disciple_Tools_Posts
     }
 
 
-
-
+    /**
+     * Create or update the dt_post_user_meta field
+     *
+     * @param array $field_settings
+     * @param int $post_id
+     * @param array $fields
+     * @param array $existing_record
+     * @return WP_Error
+     */
     public static function update_post_user_meta_fields( array $field_settings, int $post_id, array $fields, array $existing_record ){
         global $wpdb;
         foreach ( $fields as $field_key => $field ) {
@@ -1754,7 +1761,8 @@ class Disciple_Tools_Posts
                 }
             }
 
-            if ( isset( $field_settings[ $field_key ] ) && isset( $field_settings[$field_key]['private'] ) && $field_settings[$field_key]['private'] && ( $field_settings[ $field_key ]["type"] === "text" || $field_settings[ $field_key ]["type"] === "textarea" || $field_settings[ $field_key ]["type"] === "date" || $field_settings[ $field_key ]["type"] === "key_select" || $field_settings[ $field_key ]["type"] === "boolean" || $field_settings[ $field_key ]["type"] === "number" ) ) {
+            $private_field_types = [ "text", "textarea", "date", "key_select", "boolean", "number" ];
+            if ( isset( $field_settings[ $field_key ]["type"] ) && isset( $field_settings[$field_key]['private'] ) && $field_settings[$field_key]['private'] && in_array( $field_settings[ $field_key ]["type"], $private_field_types, true ) ) {
                 if ( $field_settings[ $field_key ]["type"] === "boolean" ){
                     if ( $fields[$field_key] === "1" || $fields[$field_key] === "yes" || $fields[$field_key] === "true" ){
                         $field_value = true;


### PR DESCRIPTION
update_post_user_meta_fields() only needs to be called once to process all the private fields.