### PR TITLE
Permissions & Registered Role: A single magic page is added for the u…

### DIFF
--- a/dt-users/template-no-permission.php
+++ b/dt-users/template-no-permission.php
@@ -1,0 +1,113 @@
+<?php
+if ( !defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly.
+
+class Disciple_Tools_No_Permission extends DT_Magic_Url_Base
+{
+    public $magic = false;
+    public $parts = false;
+    public $page_title = 'Home';
+    public $root = "porch_app";
+    public $type = 'home';
+
+    private static $_instance = null;
+    public static function instance() {
+        if ( is_null( self::$_instance ) ) {
+            self::$_instance = new self();
+        }
+        return self::$_instance;
+    } // End instance()
+
+    public function __construct() {
+        parent::__construct();
+
+        $url = dt_get_url_path();
+        if ( 'registered' === $url && ! dt_is_rest() ) {
+
+            // register url and access
+            add_action( "template_redirect", [ $this, 'theme_redirect' ] );
+            add_filter( 'dt_blank_access', [ $this, 'dt_blank_access' ], 100, 1 ); // allows non-logged in visit
+
+            // header content
+            add_filter( "dt_blank_title", [ $this, "page_tab_title" ] ); // adds basic title to browser tab
+            add_action( 'wp_print_scripts', [ $this, 'print_scripts' ], 1500 ); // authorizes scripts
+            add_action( 'wp_print_styles', [ $this, 'print_styles' ], 1500 ); // authorizes styles
+
+            // page content
+            add_action( 'dt_blank_head', [ $this, '_header' ] );
+            add_action( 'dt_blank_footer', [ $this, '_footer' ] );
+            add_action( 'dt_blank_body', [ $this, 'body' ] ); // body for no post key
+
+            add_filter( 'dt_magic_url_base_allowed_css', [ $this, 'dt_magic_url_base_allowed_css' ], 10, 1 );
+            add_filter( 'dt_magic_url_base_allowed_js', [ $this, 'dt_magic_url_base_allowed_js' ], 10, 1 );
+            add_action( 'wp_enqueue_scripts', [ $this, 'wp_enqueue_scripts' ], 99 );
+        }
+    }
+
+    public function dt_blank_access() {
+        if ( user_can( get_current_user_id(), 'access_contacts' ) ) {
+            dt_route_front_page();
+        }
+        else if ( ! is_user_logged_in() ) {
+            dt_please_log_in();
+        }
+        return true;
+    }
+
+    public function dt_magic_url_base_allowed_js( $allowed_js ) {
+        return [
+            'jquery',
+            'jquery-ui',
+            'site-js'
+        ];
+    }
+
+    public function dt_magic_url_base_allowed_css( $allowed_css ) {
+        return [
+            'jquery-ui-site-css',
+            'foundations-css',
+        ];
+    }
+
+    public function wp_enqueue_scripts() {
+    }
+
+    public function theme_redirect() {
+        $path = get_theme_file_path( 'template-blank.php' );
+        include( $path );
+        die();
+    }
+
+    public function body(){
+        ?>
+        <style>
+            body {
+                background:white;
+            }
+        </style>
+        <div class="grid-x">
+            <div class="cell" style="text-align:center; padding-top:2em;"><?php esc_html_e( 'You are registered but an administrator needs to assign you access permissions.', 'disciple_tools' ) ?></div>
+        </div>
+        <?php
+    }
+
+    public function footer_javascript(){
+        ?>
+        <script>
+            let jsObject = [<?php echo json_encode([
+                'root' => esc_url_raw( rest_url() ),
+                'nonce' => wp_create_nonce( 'wp_rest' ),
+                'parts' => $this->parts,
+                'translations' => [
+                    'add' => __( 'Add Magic', 'disciple_tools' ),
+                ],
+            ]) ?>][0]
+
+            jQuery(document).ready(function(){
+                clearInterval(window.fiveMinuteTimer)
+            })
+        </script>
+        <?php
+        return true;
+    }
+}
+Disciple_Tools_No_Permission::instance();

--- a/dt-users/template-user-management.php
+++ b/dt-users/template-user-management.php
@@ -3,7 +3,7 @@
  * Name: User Management
 */
 if ( !current_user_can( 'list_users' ) && !current_user_can( 'manage_dt' ) ) {
-    wp_safe_redirect( '/settings' );
+    wp_safe_redirect( '/registered' );
     exit();
 }
 $dt_url_path = dt_get_url_path();

--- a/dt-users/users.php
+++ b/dt-users/users.php
@@ -358,7 +358,7 @@ class Disciple_Tools_Users
 
         }
 
-        return wp_redirect( get_site_url() ."/settings" );
+        return wp_redirect( get_site_url() ."/registered" );
     }
 
 

--- a/functions.php
+++ b/functions.php
@@ -178,6 +178,9 @@ else {
             require_once( get_template_directory() . '/dt-core/configuration/restrict-rest-api.php' ); // sets authentication requirement for rest end points. Disables rest for pre-wp-4.7 sites.
             require_once( get_template_directory() . '/dt-core/configuration/restrict-site-access.php' ); // protect against DDOS attacks.
             require_once( get_template_directory() . '/dt-core/configuration/dt-configuration.php' ); //settings and configuration to alter default WP
+            require_once( get_template_directory() . '/dt-reports/magic-url-class.php' );
+            require_once( get_template_directory() . '/dt-reports/magic-url-base.php' );
+
 
             /**
              * User Groups & Multi Roles
@@ -317,6 +320,8 @@ else {
             require_once( get_template_directory() . '/dt-users/user-management.php' );
             require_once( get_template_directory() . '/dt-users/hover-coverage-map.php' );
             require_once( get_template_directory() . '/dt-users/mapbox-coverage-map.php' );
+            require_once( get_template_directory() . '/dt-users/template-no-permission.php' );
+
 
 
             /**
@@ -342,8 +347,6 @@ else {
              * Reports
              */
             require_once( get_template_directory() . '/dt-reports/reports.php' );
-            require_once( get_template_directory() . '/dt-reports/magic-url-class.php' );
-            require_once( get_template_directory() . '/dt-reports/magic-url-base.php' );
 
             /**
              * Workflows
@@ -460,7 +463,7 @@ else {
              * This is used for specific custom roles that are not intended to see the basic framework of DT.
              * Use this to create a dedicated landing page for partners, donors, or subscribers.
              */
-            wp_safe_redirect( apply_filters( 'dt_non_standard_front_page', home_url( '/settings' ) ) );
+            wp_safe_redirect( apply_filters( 'dt_non_standard_front_page', home_url( '/registered' ) ) );
         }
     }
     function set_up_wpdb_tables(){

--- a/template-metrics-wide.php
+++ b/template-metrics-wide.php
@@ -6,7 +6,7 @@
 dt_please_log_in();
 
 if ( ! current_user_can( 'access_contacts' ) ) {
-    wp_safe_redirect( '/settings' );
+    wp_safe_redirect( '/registered' );
     exit();
 }
 ?>

--- a/template-metrics.php
+++ b/template-metrics.php
@@ -5,7 +5,7 @@ Template Name: Metrics
 dt_please_log_in();
 
 if ( !current_user_can( 'access_contacts' ) && !current_user_can( "view_project_metrics" ) ) {
-    wp_safe_redirect( '/settings' );
+    wp_safe_redirect( '/registered' );
     exit();
 }
 ?>

--- a/template-notifications.php
+++ b/template-notifications.php
@@ -5,7 +5,7 @@ Template Name: Notifications
 dt_please_log_in();
 
 if ( ! current_user_can( 'access_contacts' ) ) {
-    wp_safe_redirect( '/settings' );
+    wp_safe_redirect( '/registered' );
     exit();
 }
 

--- a/template-settings.php
+++ b/template-settings.php
@@ -3,6 +3,10 @@
 Template Name: Settings
 */
 dt_please_log_in();
+if ( ! current_user_can( 'access_contacts' ) ) {
+    wp_safe_redirect( '/registered' );
+    exit();
+}
 /* Process $_POST content */
 // We're not checking the nonce here because update_user_contact_info will
 // phpcs:ignore


### PR DESCRIPTION
Permissions & Registered Role: A single magic page is added for the url /registered and is a holding page for registered users who have not been given access_contacts or the registered role. Once a person is given a role with more permissions they will be redirected from this page like normal.  Both override filters remain in place, so that plugins can catch and move registered people. This replaces the previous redirect to /settings which reveals more of DT than is needed.