### PR TITLE
Settings permission shift

### DIFF
--- a/dt-contacts/base-setup.php
+++ b/dt-contacts/base-setup.php
@@ -125,6 +125,7 @@ class DT_Contacts_Base {
 
         //strategist
         $expected_roles["strategist"]["permissions"]['view_project_metrics'] = true;
+        $expected_roles["strategist"]["permissions"]['access_settings'] = true;
 
         $expected_roles["administrator"]["permissions"] = array_merge( $expected_roles["dt_admin"]["permissions"], $multiplier_permissions );
         $expected_roles["administrator"]["permissions"] = array_merge( $expected_roles["dt_admin"]["permissions"], $user_management_permissions );

--- a/dt-core/configuration/class-roles.php
+++ b/dt-core/configuration/class-roles.php
@@ -69,6 +69,7 @@ class Disciple_Tools_Roles
             'list_peoplegroups' => true,
             'access_groups' => true,
             'create_groups' => true,
+            'access_settings' => true,
         ];
     }
 

--- a/dt-users/template-no-permission.php
+++ b/dt-users/template-no-permission.php
@@ -85,7 +85,10 @@ class Disciple_Tools_No_Permission extends DT_Magic_Url_Base
             }
         </style>
         <div class="grid-x">
-            <div class="cell" style="text-align:center; padding-top:2em;"><?php esc_html_e( 'You are registered but an administrator needs to assign you access permissions.', 'disciple_tools' ) ?></div>
+            <div class="cell" style="text-align:center; padding-top:2em;">
+                <?php esc_html_e( 'You are registered but an administrator needs to assign you access permissions.', 'disciple_tools' ) ?><br><br>
+                <a href="<?php echo esc_url( wp_logout_url() ); ?>"><?php esc_html_e( 'Log Off', 'disciple_tools' )?></a>
+            </div>
         </div>
         <?php
     }

--- a/dt-users/users.php
+++ b/dt-users/users.php
@@ -366,7 +366,7 @@ class Disciple_Tools_Users
 
         }
 
-        return wp_redirect( get_site_url() ."/registered" );
+        return wp_redirect( get_site_url() ."/settings" );
     }
 
 

--- a/template-settings.php
+++ b/template-settings.php
@@ -3,7 +3,7 @@
 Template Name: Settings
 */
 dt_please_log_in();
-if ( ! current_user_can( 'access_contacts' ) ) {
+if ( ! current_user_can( 'access_settings' ) ) {
     wp_safe_redirect( '/registered' );
     exit();
 }


### PR DESCRIPTION
One critical bug fix to a redirect in the settings page.
Added 'access_settings' as a new capability for accessing the settings page instead of access_contacts. This allows you to give only the strategist role, without making them a multiplier.