### PR TITLE
Expanded Group Metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ package-lock.json
 */development-only/*
 
 /composer.lock
+/.phpunit.result.cache

--- a/dt-groups/base-setup.php
+++ b/dt-groups/base-setup.php
@@ -275,9 +275,6 @@ class DT_Groups_Base extends DT_Module_Base {
                 'tile' => 'details',
                 'icon' => get_template_directory_uri() . '/dt-assets/images/date-end.svg',
             ];
-
-
-
             $fields["member_count"] = [
                 'name' => __( 'Member Count', 'disciple_tools' ),
                 'description' => _x( 'The number of members in this group. It will automatically be updated when new members are added or removed in the member list. Change this number manually to include people who may not be in the system but are also members of the group.', 'Optional Documentation', 'disciple_tools' ),
@@ -286,6 +283,33 @@ class DT_Groups_Base extends DT_Module_Base {
                 'tile' => 'relationships',
                 "show_in_table" => 25,
                 "icon" => get_template_directory_uri() . '/dt-assets/images/tally.svg',
+            ];
+            $fields["believer_count"] = [
+                'name' => __( 'Believer Count', 'disciple_tools' ),
+                'description' => _x( 'The number of believers in this group.', 'Optional Documentation', 'disciple_tools' ),
+                'type' => 'number',
+                'default' => '',
+                'tile' => 'relationships',
+                "show_in_table" => 25,
+                "icon" => get_template_directory_uri() . '/dt-assets/images/cross.svg',
+            ];
+            $fields["baptized_count"] = [
+                'name' => __( 'Baptized Count', 'disciple_tools' ),
+                'description' => _x( 'The number of believers who are baptized.', 'Optional Documentation', 'disciple_tools' ),
+                'type' => 'number',
+                'default' => '',
+                'tile' => 'relationships',
+                "show_in_table" => 25,
+                "icon" => get_template_directory_uri() . '/dt-assets/images/baptism.svg',
+            ];
+            $fields["baptized_in_group_count"] = [
+                'name' => __( 'Baptized in Group Count', 'disciple_tools' ),
+                'description' => _x( 'The number of believers who are baptized by the group', 'Optional Documentation', 'disciple_tools' ),
+                'type' => 'number',
+                'default' => '',
+                'tile' => 'relationships',
+                "show_in_table" => 25,
+                "icon" => get_template_directory_uri() . '/dt-assets/images/baptism.svg',
             ];
             $fields["members"] = [
                 "name" => __( 'Member List', 'disciple_tools' ),

--- a/dt-groups/groups.js
+++ b/dt-groups/groups.js
@@ -60,6 +60,8 @@ jQuery(document).ready(function($) {
   /* Member List*/
   let memberList = $('.member-list')
   let memberCountInput = $('#member_count')
+  let believerCountInput = $('#believer_count')
+  let baptizedCountInput = $('#baptized_count')
   let leaderCountInput = $('#leader_count')
   let populateMembersList = ()=>{
     memberList.empty()
@@ -106,6 +108,8 @@ jQuery(document).ready(function($) {
       $("#empty-members-list-message").hide()
     }
     memberCountInput.val( post.member_count )
+    believerCountInput.val(post.believer_count)
+    baptizedCountInput.val(post.baptized_count)
     leaderCountInput.val( post.leader_count )
     window.masonGrid.masonry('layout')
   }

--- a/dt-metrics/counter.php
+++ b/dt-metrics/counter.php
@@ -505,14 +505,48 @@ class Disciple_Tools_Queries
                       0            as parent_id,
                       a.post_title as name,
                       gs1.meta_value as group_status,
-                      type1.meta_value as group_type
+                      type1.meta_value as group_type,
+                      coach1.post_title as coach,
+                      location1.name as location_name,
+                      startdate1.meta_value as start_date,
+                      enddate1.meta_value as end_date,
+                      (SELECT COUNT( members1.p2p_id ) FROM $wpdb->p2p as members1 WHERE members1.p2p_to = a.ID AND members1.p2p_type = 'contacts_to_groups') as total_members,
+                      (SELECT COUNT( believers1.post_id ) FROM $wpdb->postmeta as believers1 WHERE believers1.post_id = a.ID AND believers1.meta_key = 'milestone_belief') as total_believers,
+                      (SELECT COUNT( baptized1.post_id ) FROM $wpdb->postmeta as baptized1 WHERE baptized1.post_id = a.ID AND baptized1.meta_key = 'milestone_baptized') as total_baptized,
+                      (SELECT COUNT( baptized2.p2p_id ) FROM $wpdb->p2p as baptized2 WHERE baptized2.p2p_from = a.ID AND baptized2.p2p_type = 'baptizer_to_baptized') as total_baptized_by_group,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as metricbaptized1 WHERE metricbaptized1.post_id = a.ID AND metricbaptized1.meta_key = 'health_metrics' AND metricbaptized1.meta_value = 'church_baptism')) as health_metrics_baptism,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as metricfellowship1 WHERE metricfellowship1.post_id = a.ID AND metricfellowship1.meta_key = 'health_metrics' AND metricfellowship1.meta_value = 'church_fellowship')) as health_metrics_fellowship,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as metricsharing1 WHERE metricsharing1.post_id = a.ID AND metricsharing1.meta_key = 'health_metrics' AND metricsharing1.meta_value = 'church_sharing')) as health_metrics_sharing,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as metricpraise1 WHERE metricpraise1.post_id = a.ID AND metricpraise1.meta_key = 'health_metrics' AND metricpraise1.meta_value = 'church_praise')) as health_metrics_praise,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as metricleaders1 WHERE metricleaders1.post_id = a.ID AND metricleaders1.meta_key = 'health_metrics' AND metricleaders1.meta_value = 'church_leaders')) as health_metrics_leaders,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as metriccommitment1 WHERE metriccommitment1.post_id = a.ID AND metriccommitment1.meta_key = 'health_metrics' AND metriccommitment1.meta_value = 'church_commitment')) as health_metrics_commitment,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as metricbible1 WHERE metricbible1.post_id = a.ID AND metricbible1.meta_key = 'health_metrics' AND metricbible1.meta_value = 'church_bible')) as health_metrics_bible,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as metriccommunion1 WHERE metriccommunion1.post_id = a.ID AND metriccommunion1.meta_key = 'health_metrics' AND metriccommunion1.meta_value = 'church_communion')) as health_metrics_communion,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as metricgiving1 WHERE metricgiving1.post_id = a.ID AND metricgiving1.meta_key = 'health_metrics' AND metricgiving1.meta_value = 'church_giving')) as health_metrics_giving,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as metricprayer1 WHERE metricprayer1.post_id = a.ID AND metricprayer1.meta_key = 'health_metrics' AND metricprayer1.meta_value = 'church_prayer')) as health_metrics_prayer
                     FROM $wpdb->posts as a
                      LEFT JOIN $wpdb->postmeta as gs1
                       ON gs1.post_id=a.ID
                       AND gs1.meta_key = 'group_status'
-                      LEFT JOIN $wpdb->postmeta as type1
+                     LEFT JOIN $wpdb->postmeta as type1
                       ON type1.post_id=a.ID
                       AND type1.meta_key = 'group_type'
+                     LEFT JOIN $wpdb->p2p as groupcoach1
+                      ON groupcoach1.p2p_from=a.ID
+                      AND groupcoach1.p2p_type = 'groups_to_coaches'
+                    LEFT JOIN $wpdb->posts as coach1
+                      ON coach1.ID=groupcoach1.p2p_to
+                    LEFT JOIN $wpdb->postmeta as grouplocation1
+                      ON grouplocation1.post_id=a.ID
+                      AND grouplocation1.meta_key = 'location_grid'
+                    LEFT JOIN $wpdb->dt_location_grid as location1
+                      ON location1.grid_id=grouplocation1.meta_value
+                    LEFT JOIN $wpdb->postmeta as startdate1
+                      ON startdate1.post_id=a.ID
+                      AND startdate1.meta_key = 'church_start_date'
+                    LEFT JOIN $wpdb->postmeta as enddate1
+                      ON enddate1.post_id=a.ID
+                      AND enddate1.meta_key = 'end_date'
                     WHERE a.post_status = 'publish'
                     AND a.post_type = 'groups'
                     AND a.ID NOT IN (
@@ -533,10 +567,45 @@ class Disciple_Tools_Queries
                       p.p2p_to    as parent_id,
                       (SELECT sub.post_title FROM $wpdb->posts as sub WHERE sub.ID = p.p2p_from ) as name,
                       (SELECT gsmeta.meta_value FROM $wpdb->postmeta as gsmeta WHERE gsmeta.post_id = p.p2p_from AND gsmeta.meta_key = 'group_status' LIMIT 1 ) as group_status,
-                      (SELECT gsmeta.meta_value FROM $wpdb->postmeta as gsmeta WHERE gsmeta.post_id = p.p2p_from AND gsmeta.meta_key = 'group_type' LIMIT 1 ) as group_type
+                      (SELECT gsmeta.meta_value FROM $wpdb->postmeta as gsmeta WHERE gsmeta.post_id = p.p2p_from AND gsmeta.meta_key = 'group_type' LIMIT 1 ) as group_type,
+                      gcoach1.post_title as coach,
+                      glocation1.name as location,
+                      gstartdate1.meta_value as start_date,
+                      genddate1.meta_value as end_date,
+                      (SELECT COUNT( gsmembers1.p2p_id ) FROM $wpdb->p2p as gsmembers1 WHERE gsmembers1.p2p_to = p.p2p_from AND gsmembers1.p2p_type = 'contacts_to_groups') as total_members,
+                      (SELECT COUNT( gbelievers1.post_id ) FROM $wpdb->postmeta as gbelievers1 WHERE gbelievers1.post_id = p.p2p_from AND gbelievers1.meta_key = 'milestone_belief') as total_believers,
+                      (SELECT COUNT( gbaptized1.post_id ) FROM $wpdb->postmeta as gbaptized1 WHERE gbaptized1.post_id = p.p2p_from AND gbaptized1.meta_key = 'milestone_baptized') as total_believers,
+                      (SELECT COUNT( gbaptized2.p2p_id ) FROM $wpdb->p2p as gbaptized2 WHERE gbaptized2.p2p_from = p.p2p_from AND gbaptized2.p2p_type = 'baptizer_to_baptized') as total_baptized_by_group,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as gmetricbaptized1 WHERE gmetricbaptized1.post_id = p.p2p_from AND gmetricbaptized1.meta_key = 'health_metrics' AND gmetricbaptized1.meta_value = 'church_baptism')) as health_metrics_baptism,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as gmetricfellowship1 WHERE gmetricfellowship1.post_id = p.p2p_from AND gmetricfellowship1.meta_key = 'health_metrics' AND gmetricfellowship1.meta_value = 'church_fellowship')) as health_metrics_fellowship,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as gmetricsharing1 WHERE gmetricsharing1.post_id = p.p2p_from AND gmetricsharing1.meta_key = 'health_metrics' AND gmetricsharing1.meta_value = 'church_sharing')) as health_metrics_sharing,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as gmetricpraise1 WHERE gmetricpraise1.post_id = p.p2p_from AND gmetricpraise1.meta_key = 'health_metrics' AND gmetricpraise1.meta_value = 'church_praise')) as health_metrics_praise,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as gmetricleaders1 WHERE gmetricleaders1.post_id = p.p2p_from AND gmetricleaders1.meta_key = 'health_metrics' AND gmetricleaders1.meta_value = 'church_leaders')) as health_metrics_leaders,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as gmetriccommitment1 WHERE gmetriccommitment1.post_id = p.p2p_from AND gmetriccommitment1.meta_key = 'health_metrics' AND gmetriccommitment1.meta_value = 'church_commitment')) as health_metrics_commitment,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as gmetricbible1 WHERE gmetricbible1.post_id = p.p2p_from AND gmetricbible1.meta_key = 'health_metrics' AND gmetricbible1.meta_value = 'church_bible')) as health_metrics_bible,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as gmetriccommunion1 WHERE gmetriccommunion1.post_id = p.p2p_from AND gmetriccommunion1.meta_key = 'health_metrics' AND gmetriccommunion1.meta_value = 'church_communion')) as health_metrics_communion,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as gmetricgiving1 WHERE gmetricgiving1.post_id = p.p2p_from AND gmetricgiving1.meta_key = 'health_metrics' AND gmetricgiving1.meta_value = 'church_giving')) as health_metrics_giving,
+                      (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as gmetricprayer1 WHERE gmetricprayer1.post_id = p.p2p_from AND gmetricprayer1.meta_key = 'health_metrics' AND gmetricprayer1.meta_value = 'church_prayer')) as health_metrics_prayer
                     FROM $wpdb->p2p as p
+                    LEFT JOIN $wpdb->p2p as ggroupcoach1
+                      ON ggroupcoach1.p2p_from=p.p2p_from
+                      AND ggroupcoach1.p2p_type = 'groups_to_coaches'
+                    LEFT JOIN $wpdb->posts as gcoach1
+                      ON gcoach1.ID=ggroupcoach1.p2p_to
+                    LEFT JOIN $wpdb->postmeta as ggrouplocation1
+                      ON ggrouplocation1.post_id=p.p2p_from
+                      AND ggrouplocation1.meta_key = 'location_grid'
+                    LEFT JOIN $wpdb->dt_location_grid as glocation1
+                      ON glocation1.grid_id=ggrouplocation1.meta_value
+                    LEFT JOIN $wpdb->postmeta as gstartdate1
+                      ON gstartdate1.post_id=p.p2p_from
+                      AND gstartdate1.meta_key = 'start_date'
+                    LEFT JOIN $wpdb->postmeta as genddate1
+                      ON genddate1.post_id=p.p2p_from
+                      AND genddate1.meta_key = 'end_date'
                     WHERE p.p2p_type = 'groups_to_groups'
-                ", ARRAY_A );
+                ", ARRAY_A);
+
                 break;
 
             case 'coaching_all':

--- a/dt-metrics/counter.php
+++ b/dt-metrics/counter.php
@@ -499,7 +499,7 @@ class Disciple_Tools_Queries
                 break;
 
             case 'multiplying_groups_only':
-                $query = $wpdb->get_results("
+                $query = "
                     SELECT
                       a.ID         as id,
                       0            as parent_id,
@@ -510,10 +510,10 @@ class Disciple_Tools_Queries
                       location1.name as location_name,
                       startdate1.meta_value as start_date,
                       enddate1.meta_value as end_date,
-                      (SELECT COUNT( members1.p2p_id ) FROM $wpdb->p2p as members1 WHERE members1.p2p_to = a.ID AND members1.p2p_type = 'contacts_to_groups') as total_members,
-                      (SELECT COUNT( believers1.post_id ) FROM $wpdb->postmeta as believers1 WHERE believers1.post_id = a.ID AND believers1.meta_key = 'milestone_belief') as total_believers,
-                      (SELECT COUNT( baptized1.post_id ) FROM $wpdb->postmeta as baptized1 WHERE baptized1.post_id = a.ID AND baptized1.meta_key = 'milestone_baptized') as total_baptized,
-                      (SELECT COUNT( baptized2.p2p_id ) FROM $wpdb->p2p as baptized2 WHERE baptized2.p2p_from = a.ID AND baptized2.p2p_type = 'baptizer_to_baptized') as total_baptized_by_group,
+                      IFNULL(members1.meta_value, 0) as total_members,
+                      IFNULL(believers1.meta_value, 0) as total_believers,
+                      IFNULL(baptized1.meta_value, 0) as total_baptized,
+                      IFNULL(baptized2.meta_value, 0) as total_baptized_by_group,
                       (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as metricbaptized1 WHERE metricbaptized1.post_id = a.ID AND metricbaptized1.meta_key = 'health_metrics' AND metricbaptized1.meta_value = 'church_baptism')) as health_metrics_baptism,
                       (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as metricfellowship1 WHERE metricfellowship1.post_id = a.ID AND metricfellowship1.meta_key = 'health_metrics' AND metricfellowship1.meta_value = 'church_fellowship')) as health_metrics_fellowship,
                       (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as metricsharing1 WHERE metricsharing1.post_id = a.ID AND metricsharing1.meta_key = 'health_metrics' AND metricsharing1.meta_value = 'church_sharing')) as health_metrics_sharing,
@@ -525,13 +525,25 @@ class Disciple_Tools_Queries
                       (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as metricgiving1 WHERE metricgiving1.post_id = a.ID AND metricgiving1.meta_key = 'health_metrics' AND metricgiving1.meta_value = 'church_giving')) as health_metrics_giving,
                       (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as metricprayer1 WHERE metricprayer1.post_id = a.ID AND metricprayer1.meta_key = 'health_metrics' AND metricprayer1.meta_value = 'church_prayer')) as health_metrics_prayer
                     FROM $wpdb->posts as a
-                     LEFT JOIN $wpdb->postmeta as gs1
+                    LEFT JOIN $wpdb->postmeta as members1
+                      ON members1.post_id=a.ID
+                      AND members1.meta_key = 'member_count'
+                    LEFT JOIN $wpdb->postmeta as believers1
+                      ON believers1.post_id=a.ID
+                      AND believers1.meta_key = 'believer_count'
+                    LEFT JOIN $wpdb->postmeta as baptized1
+                      ON baptized1.post_id=a.ID
+                      AND baptized1.meta_key = 'baptized_count'
+                    LEFT JOIN $wpdb->postmeta as baptized2
+                      ON baptized2.post_id=a.ID
+                      AND baptized2.meta_key = 'baptized_in_group_count'
+                    LEFT JOIN $wpdb->postmeta as gs1
                       ON gs1.post_id=a.ID
                       AND gs1.meta_key = 'group_status'
-                     LEFT JOIN $wpdb->postmeta as type1
+                    LEFT JOIN $wpdb->postmeta as type1
                       ON type1.post_id=a.ID
                       AND type1.meta_key = 'group_type'
-                     LEFT JOIN $wpdb->p2p as groupcoach1
+                    LEFT JOIN $wpdb->p2p as groupcoach1
                       ON groupcoach1.p2p_from=a.ID
                       AND groupcoach1.p2p_type = 'groups_to_coaches'
                     LEFT JOIN $wpdb->posts as coach1
@@ -572,10 +584,10 @@ class Disciple_Tools_Queries
                       glocation1.name as location,
                       gstartdate1.meta_value as start_date,
                       genddate1.meta_value as end_date,
-                      (SELECT COUNT( gsmembers1.p2p_id ) FROM $wpdb->p2p as gsmembers1 WHERE gsmembers1.p2p_to = p.p2p_from AND gsmembers1.p2p_type = 'contacts_to_groups') as total_members,
-                      (SELECT COUNT( gbelievers1.post_id ) FROM $wpdb->postmeta as gbelievers1 WHERE gbelievers1.post_id = p.p2p_from AND gbelievers1.meta_key = 'milestone_belief') as total_believers,
-                      (SELECT COUNT( gbaptized1.post_id ) FROM $wpdb->postmeta as gbaptized1 WHERE gbaptized1.post_id = p.p2p_from AND gbaptized1.meta_key = 'milestone_baptized') as total_believers,
-                      (SELECT COUNT( gbaptized2.p2p_id ) FROM $wpdb->p2p as gbaptized2 WHERE gbaptized2.p2p_from = p.p2p_from AND gbaptized2.p2p_type = 'baptizer_to_baptized') as total_baptized_by_group,
+                      IFNULL(gmembers1.meta_value, 0) as total_members,
+                      IFNULL(gbelievers1.meta_value, 0) as total_believers,
+                      IFNULL(gbaptized1.meta_value, 0) as total_believers,
+                      IFNULL(gbaptized2.meta_value, 0) as total_baptized_by_group,
                       (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as gmetricbaptized1 WHERE gmetricbaptized1.post_id = p.p2p_from AND gmetricbaptized1.meta_key = 'health_metrics' AND gmetricbaptized1.meta_value = 'church_baptism')) as health_metrics_baptism,
                       (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as gmetricfellowship1 WHERE gmetricfellowship1.post_id = p.p2p_from AND gmetricfellowship1.meta_key = 'health_metrics' AND gmetricfellowship1.meta_value = 'church_fellowship')) as health_metrics_fellowship,
                       (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as gmetricsharing1 WHERE gmetricsharing1.post_id = p.p2p_from AND gmetricsharing1.meta_key = 'health_metrics' AND gmetricsharing1.meta_value = 'church_sharing')) as health_metrics_sharing,
@@ -587,6 +599,18 @@ class Disciple_Tools_Queries
                       (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as gmetricgiving1 WHERE gmetricgiving1.post_id = p.p2p_from AND gmetricgiving1.meta_key = 'health_metrics' AND gmetricgiving1.meta_value = 'church_giving')) as health_metrics_giving,
                       (SELECT EXISTS (SELECT 1 FROM $wpdb->postmeta as gmetricprayer1 WHERE gmetricprayer1.post_id = p.p2p_from AND gmetricprayer1.meta_key = 'health_metrics' AND gmetricprayer1.meta_value = 'church_prayer')) as health_metrics_prayer
                     FROM $wpdb->p2p as p
+                    LEFT JOIN $wpdb->postmeta as gmembers1
+                      ON gmembers1.post_id=p.p2p_from
+                      AND gmembers1.meta_key = 'member_count'
+                    LEFT JOIN $wpdb->postmeta as gbelievers1
+                      ON gbelievers1.post_id=p.p2p_from
+                      AND gbelievers1.meta_key = 'believer_count'
+                    LEFT JOIN $wpdb->postmeta as gbaptized1
+                      ON gbaptized1.post_id=p.p2p_from
+                      AND gbaptized1.meta_key = 'baptized_count'
+                    LEFT JOIN $wpdb->postmeta as gbaptized2
+                      ON gbaptized2.post_id=p.p2p_from
+                      AND gbaptized2.meta_key = 'baptized_in_group_count'
                     LEFT JOIN $wpdb->p2p as ggroupcoach1
                       ON ggroupcoach1.p2p_from=p.p2p_from
                       AND ggroupcoach1.p2p_type = 'groups_to_coaches'
@@ -604,7 +628,8 @@ class Disciple_Tools_Queries
                       ON genddate1.post_id=p.p2p_from
                       AND genddate1.meta_key = 'end_date'
                     WHERE p.p2p_type = 'groups_to_groups'
-                ", ARRAY_A);
+                ";
+                $query = $wpdb->get_results($query, ARRAY_A);
 
                 break;
 
@@ -629,7 +654,7 @@ class Disciple_Tools_Queries
                       (SELECT sub.post_title FROM $wpdb->posts as sub WHERE sub.ID = p.p2p_from ) as name
                     FROM $wpdb->p2p as p
                     WHERE p.p2p_type = 'contacts_to_contacts'
-                ", ARRAY_A );
+                ", ARRAY_A);
                 break;
 
             case 'multiplying_coaching_only':

--- a/dt-posts/posts.php
+++ b/dt-posts/posts.php
@@ -2170,7 +2170,7 @@ class Disciple_Tools_Posts
                 } else if ( isset( $field_settings[$key] ) && $field_settings[$key]['type'] === 'array' ) {
                     $fields[$key] = maybe_unserialize( $value[0] );
                 } else if ( isset( $field_settings[$key] ) && $field_settings[$key]['type'] === 'number' ) {
-                    $fields[$key] = maybe_unserialize( $value[0] ) + 0;
+                    $fields[$key] = maybe_unserialize( (int) $value[0] ) + 0;
                 } else if ( isset( $field_settings[$key] ) && $field_settings[$key]['type'] === 'date' ) {
                     if ( isset( $value[0] ) && !empty( $value[0] ) ){
                         $fields[$key] = [


### PR DESCRIPTION
<img width="455" alt="Screen Shot 2021-09-21 at 2 13 39 PM" src="https://user-images.githubusercontent.com/5910297/134233691-a4a2178b-054a-42dd-b153-11958c032dbf.png">

This pull request adds the following fields to the group dashboard: 

- Believer Count
- Baptized Count
- Baptized in Group Count

Believer count and baptized counts are auto-updated with milestones are added/removed from contacts within a group. "Baptized in Group" is not auto-updated, because there is currently no relationship in place between baptisms and groups. This could be implemented in the future if such a relationship was in place. 

It also expands the dt-metrics multiplying_groups_only query to include the new metrics along with church health metrics. This expanded data will be used in a forth-coming pull request to `disciple-tools/disciple-tools-dashboard`. 