### PR TITLE
Dynamic Health Circle

### DIFF
--- a/dt-assets/images/groups/word-2.svg
+++ b/dt-assets/images/groups/word-2.svg
@@ -5,9 +5,9 @@
     </clipPath>
   </defs>
   <g id="word-2" clip-path="url(#clip-path)">
-    <path id="Path_720" data-name="Path 720" d="M45,45H3a2,2,0,0,1-2-2V11A2,2,0,0,1,3,9H45a2,2,0,0,1,2,2V43A2,2,0,0,1,45,45Z" transform="translate(-1 -3)" fill="#444"/>
-    <path id="Path_721" data-name="Path 721" d="M40,40H8a1,1,0,0,1-1-1V15a1,1,0,0,1,1-1H40a1,1,0,0,1,1,1V39A1,1,0,0,1,40,40Z" transform="translate(-1 -3)" fill="#848484"/>
-    <path id="Path_722" data-name="Path 722" d="M42.585,3.189a1,1,0,0,0-.9-.138L24,8.946V39a1.01,1.01,0,0,0,.316-.051l18-6A1,1,0,0,0,43,32V4A1,1,0,0,0,42.585,3.189Z" transform="translate(-1 -3)" fill="#c6c6c6"/>
-    <path id="Path_723" data-name="Path 723" d="M24,8.946,6.316,3.051A1,1,0,0,0,5,4V32a1,1,0,0,0,.684.949l18,6A1.01,1.01,0,0,0,24,39Z" transform="translate(-1 -3)" fill="#e6e6e6"/>
+    <path id="Path_720" data-name="Path 720" d="M45,45H3a2,2,0,0,1-2-2V11A2,2,0,0,1,3,9H45a2,2,0,0,1,2,2V43A2,2,0,0,1,45,45Z" transform="translate(-1 -3)" fill="#4d1900"/>
+    <path id="Path_721" data-name="Path 721" d="M40,40H8a1,1,0,0,1-1-1V15a1,1,0,0,1,1-1H40a1,1,0,0,1,1,1V39A1,1,0,0,1,40,40Z" transform="translate(-1 -3)" fill="#a09982"/>
+    <path id="Path_722" data-name="Path 722" d="M42.585,3.189a1,1,0,0,0-.9-.138L24,8.946V39a1.01,1.01,0,0,0,.316-.051l18-6A1,1,0,0,0,43,32V4A1,1,0,0,0,42.585,3.189Z" transform="translate(-1 -3)" fill="#e0dac7"/>
+    <path id="Path_723" data-name="Path 723" d="M24,8.946,6.316,3.051A1,1,0,0,0,5,4V32a1,1,0,0,0,.684.949l18,6A1.01,1.01,0,0,0,24,39Z" transform="translate(-1 -3)" fill="#f4eed9"/>
   </g>
 </svg>

--- a/dt-groups/base-setup.php
+++ b/dt-groups/base-setup.php
@@ -488,10 +488,9 @@ class DT_Groups_Base extends DT_Module_Base {
             $fields = DT_Posts::get_post_field_settings( $post_type );
             //<!-- Health Metrics-->
             if ( ! empty( $group_preferences['church_metrics'] ) ) :
-                $health_church_commitment = 'committed';
                 ?>
                 <style>
-                .custom-group-health-item {
+                .health-item {
                     display: none;
                     margin: auto;
                     position: absolute;
@@ -504,7 +503,7 @@ class DT_Groups_Base extends DT_Module_Base {
                     font-style: italic;
                 }
 
-                .custom-group-health-item img {
+                .health-item img {
                     height: 50px;
                     width: 50px;
                     filter: grayscale(1) opacity(0.3);
@@ -514,7 +513,16 @@ class DT_Groups_Base extends DT_Module_Base {
                     filter:  none !important;
                 }
 
-                .custom-group-health-circle {
+                .practiced-button {
+                    background-color: #3f729b !important;
+                    opacity: unset !important;
+                }
+
+                .practiced-button img {
+                    filter:  none !important;;
+                }
+
+                .health-circle {
                     display: block;
                     margin:auto;
                     height:300px;
@@ -523,7 +531,7 @@ class DT_Groups_Base extends DT_Module_Base {
                     border: 3px darkgray dashed;
                 }
 
-                .custom-group-health-grid {
+                .health-grid {
                     display: inline-block;
                     position: relative;
                     height:75%;
@@ -538,7 +546,7 @@ class DT_Groups_Base extends DT_Module_Base {
                 }
 
                 .group-progress-button {
-                    background-color: darkgray;
+                    opacity: 0.5;
                 }
 
                 .group-progress-button img {
@@ -547,14 +555,14 @@ class DT_Groups_Base extends DT_Module_Base {
                 </style>
                 <div class="grid-x">
                     <div style="margin-right:auto; margin-left:auto;min-height:302px">
-                        <div class="custom-group-health-circle <?php echo esc_attr( $health_church_commitment ); ?>" id="custom-group-health-items-container">
-                            <div class="custom-group-health-grid">
+                        <div class="health-circle" id="health-items-container">
+                            <div class="health-grid">
                                 <?php
                                 $fields = DT_Posts::get_post_field_settings( $post_type );
                                 foreach ( $fields['health_metrics']['default'] as $key => $option ) :
                                     if ( $key !== 'church_commitment' ) :
                                     ?>
-                                    <div class="custom-group-health-item" id="icon_<?php echo esc_attr( strtolower( $key ) ) ?>" title="<?php echo esc_attr( $option['description'] ); ?>">
+                                    <div class="health-item" id="icon_<?php echo esc_attr( strtolower( $key ) ) ?>" title="<?php echo esc_attr( $option['description'] ); ?>">
                                         <img src="<?php echo esc_attr( $option['image'] ); ?>">
                                     </div>
                                     <?php endif; 
@@ -567,37 +575,7 @@ class DT_Groups_Base extends DT_Module_Base {
                     
                     
             </script>
-            <script>
-                // Toggle practiced/non-practiced items
-                jQuery(document).ready(function($) {
-                      let group_id       = window.detailsSettings.post_id;
-                      let post_type      = window.detailsSettings.post_type;
-                      let post           = window.detailsSettings.post_fields;
-                      let field_settings = window.detailsSettings.post_settings.fields;
-
-                      $('.summary-icons').on('click', function () {
-                        let fieldId = $(this).attr('id');
-                        if (fieldId == 'church_commitment') {
-                          $( '#custom-group-health-items-container' ).toggleClass( 'committed' );
-                          $( this ).toggleClass('half-opacity');
-                        } else {
-                          $( '#' + fieldId ).toggleClass('half-opacity');
-                          $( '#icon_' + fieldId ).toggleClass('half-opacity');
-                        }
-
-                        $.ajax( {
-                          type: 'POST',
-                          contentType: 'application/json; charset=utf-8',
-                          dataType: "json",
-                          url: window.wpApiShare.root + 'custom_group_health_plugin/v1/update_practice/' + group_id + '/' + fieldId,
-                          beforeSend: function(xhr) {
-                              xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce );
-                              },
-                          } )
-                      });
-                    });
-                </script>
-                <div style="display:flex;flex-wrap:wrap;margin-top:10px" class=" js-progress-bordered-box half-opacity">
+                <div style="display:flex;flex-wrap:wrap;margin-top:10px" class=" js-progress-bordered-box">
                     <?php foreach ( $fields["health_metrics"]["default"] as $key => $option ) : ?>
                         <div class="group-progress-button-wrapper">
                             <button  class="group-progress-button" id="<?php echo esc_html( $key ) ?>">

--- a/dt-groups/base-setup.php
+++ b/dt-groups/base-setup.php
@@ -481,8 +481,8 @@ class DT_Groups_Base extends DT_Module_Base {
         return $fields;
     }
 
-    public function dt_details_additional_section( $section, $post_type ){
-        // Display 'Health Metrics' tile
+    public function dt_details_additional_section( $section, $post_type ) {
+        // Display 'Health Metrics' Tile
         if ( $post_type === "groups" && $section === "health-metrics" ) {
             $group_preferences = dt_get_option( 'group_preferences' );
             $fields = DT_Posts::get_post_field_settings( $post_type );
@@ -490,91 +490,109 @@ class DT_Groups_Base extends DT_Module_Base {
             if ( ! empty( $group_preferences['church_metrics'] ) ) :
                 ?>
                 <style>
-                .health-item {
-                    display: none;
-                    margin: auto;
-                    position: absolute;
-                    height: 50px;
-                    width: 50px;
-                    border-radius: 100%;
-                    font-size: 16px;
-                    color: black;
-                    text-align: center;
-                    font-style: italic;
-                }
+                    .health-item {
+                        display: none;
+                        margin: auto;
+                        position: absolute;
+                        height: 50px;
+                        width: 50px;
+                        border-radius: 100%;
+                        font-size: 16px;
+                        color: black;
+                        text-align: center;
+                        font-style: italic;
+                    }
 
-                .health-item img {
-                    height: 50px;
-                    width: 50px;
-                    filter: grayscale(1) opacity(0.3);
-                }
+                    .health-item img {
+                        height: 50px;
+                        width: 50px;
+                        filter: grayscale(1) opacity(0.3);
+                    }
 
-                .practiced-item {
-                    filter:  none !important;
-                }
+                    .practiced-item {
+                        filter: none !important;
+                    }
 
-                .practiced-button {
-                    background-color: #3f729b !important;
-                    opacity: unset !important;
-                }
+                    .practiced-button {
+                        background-color: #3f729b !important;
+                        opacity: unset !important;
+                    }
 
-                .practiced-button img {
-                    filter:  none !important;;
-                }
+                    .practiced-button img {
+                        filter: none !important;;
+                    }
 
-                .health-circle {
-                    display: block;
-                    margin:auto;
-                    height:280px;
-                    width:280px;
-                    border-radius:100%;
-                    border: 3px darkgray dashed;
-                }
+                    .health-circle {
+                        display: block;
+                        margin: auto;
+                        height: 280px;
+                        width: 280px;
+                        border-radius: 100%;
+                        border: 3px darkgray dashed;
+                    }
 
-                .health-grid {
-                    display: inline-block;
-                    position: relative;
-                    height:75%;
-                    width:75%;
-                    margin-top: 12.5%;
-                    margin-left: auto;
-                    margin-right: auto;
-                }
+                    .health-grid {
+                        display: inline-block;
+                        position: relative;
+                        height: 100%;
+                        width: 100%;
+                        margin-left: auto;
+                        margin-right: auto;
+                    }
 
-                .committed {
-                    border: 3px #4caf50 solid !important;
-                }
+                    .committed {
+                        border: 3px #4caf50 solid !important;
+                    }
 
-                .group-progress-button {
-                    opacity: 0.5;
-                }
+                    .group-progress-button {
+                        opacity: 0.5;
+                    }
 
-                .group-progress-button img {
-                    filter: grayscale(1) contrast(1.35);
-                }
+                    .group-progress-button img {
+                        filter: grayscale(1) contrast(1.35);
+                    }
+
+                    .empty-health {
+                        width: 35px;
+                        height: 35px;
+                        margin-left: auto;
+                        margin-right: auto;
+                        margin-top: 40%;
+                    }
+
+                    .empty-health-text {
+                        text-align: center;
+                        font-style: italic;
+                        margin-left: -15%;
+                        margin-top: -15%;
+                    }
                 </style>
                 <div class="grid-x">
                     <div style="margin-right:auto; margin-left:auto;min-height:302px">
                         <div class="health-circle" id="health-items-container">
                             <div class="health-grid">
-                                <?php
-                                $fields = DT_Posts::get_post_field_settings( $post_type );
-                                foreach ( $fields['health_metrics']['default'] as $key => $option ) :
-                                    if ( $key !== 'church_commitment' ) :
-                                        ?>
-                                    <div class="health-item" id="icon_<?php echo esc_attr( strtolower( $key ) ) ?>" title="<?php echo esc_attr( $option['description'] ); ?>">
-                                        <img src="<?php echo esc_attr( $option['image'] ); ?>">
+                                <?php $fields = DT_Posts::get_post_field_settings( $post_type );
+                                if ( empty( $fields['health_metrics']['default'] ) ): ?>
+                                    <div class="custom-group-health-item empty-health" id="health-metrics" style="filter: opacity(0.35);">
+                                        <img src="<?php echo esc_attr( get_template_directory_uri() . '/dt-assets/images/dots.svg' ); ?>">
+                                        <div class="empty-health-text">
+                                            <?php echo esc_html( 'Empty', 'disciple_tools' ); ?>
+                                        </div>
                                     </div>
-                                    <?php endif;
-                                endforeach; ?>
+                                <?php else : ?>
+                                    <?php foreach ( $fields['health_metrics']['default'] as $key => $option ) : ?>
+                                        <?php if ( $key !== 'church_commitment' ) : ?>
+                                            <div class="health-item" id="icon_<?php echo esc_attr( strtolower( $key ) ) ?>" title="<?php echo esc_attr( $option['description'] ); ?>">
+                                                <img src="<?php echo esc_attr( $option['image'] ); ?>">
+                                            </div>
+                                        <?php endif; ?>
+                                    <?php endforeach; ?>
+                                <?php endif; ?>
                             </div>
                         </div>
                     </div>
                 </div>
-                <script>
-                    
-                    
-            </script>
+                <?php if ( ! empty( $fields['health_metrics']['default'] ) ) : ?>
                 <div style="display:flex;flex-wrap:wrap;margin-top:10px" class=" js-progress-bordered-box">
                     <?php foreach ( $fields["health_metrics"]["default"] as $key => $option ) : ?>
                         <div class="group-progress-button-wrapper">
@@ -585,9 +603,9 @@ class DT_Groups_Base extends DT_Module_Base {
                         </div>
                     <?php endforeach; ?>
                 </div>
-            <?php endif; ?>
-
-        <?php }
+                <?php endif; ?>
+        <?php endif;
+        }
             // Display 'Four Fields' tile
         if ( $post_type === "groups" && $section === "four-fields" ) {
             $group_preferences = dt_get_option( 'group_preferences' );

--- a/dt-groups/base-setup.php
+++ b/dt-groups/base-setup.php
@@ -525,8 +525,8 @@ class DT_Groups_Base extends DT_Module_Base {
                 .health-circle {
                     display: block;
                     margin:auto;
-                    height:300px;
-                    width:300px;
+                    height:280px;
+                    width:280px;
                     border-radius:100%;
                     border: 3px darkgray dashed;
                 }
@@ -561,11 +561,11 @@ class DT_Groups_Base extends DT_Module_Base {
                                 $fields = DT_Posts::get_post_field_settings( $post_type );
                                 foreach ( $fields['health_metrics']['default'] as $key => $option ) :
                                     if ( $key !== 'church_commitment' ) :
-                                    ?>
+                                        ?>
                                     <div class="health-item" id="icon_<?php echo esc_attr( strtolower( $key ) ) ?>" title="<?php echo esc_attr( $option['description'] ); ?>">
                                         <img src="<?php echo esc_attr( $option['image'] ); ?>">
                                     </div>
-                                    <?php endif; 
+                                    <?php endif;
                                 endforeach; ?>
                             </div>
                         </div>

--- a/dt-groups/base-setup.php
+++ b/dt-groups/base-setup.php
@@ -197,52 +197,52 @@ class DT_Groups_Base extends DT_Module_Base {
                     "church_baptism" => [
                         "label" => __( "Baptism", 'disciple_tools' ),
                         "description" => _x( "The group is baptising.", 'Optional Documentation', 'disciple_tools' ),
-                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/baptism.svg?v=2'
+                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/baptism-2.svg'
                     ],
                     "church_bible" => [
                         "label" => __( "Bible Study", 'disciple_tools' ),
                         "description" => _x( "The group is studying the bible.", 'Optional Documentation', 'disciple_tools' ),
-                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/word.svg?v=2'
+                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/word-2.svg'
                     ],
                     "church_communion" => [
                         "label" => __( "Communion", 'disciple_tools' ),
                         "description" => _x( "The group is practicing communion.", 'Optional Documentation', 'disciple_tools' ),
-                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/communion.svg?v=2'
+                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/communion-2.svg'
                     ],
                     "church_fellowship" => [
                         "label" => __( "Fellowship", 'disciple_tools' ),
                         "description" => _x( "The group is fellowshiping.", 'Optional Documentation', 'disciple_tools' ),
-                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/heart.svg?v=2'
+                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/heart-2.svg'
                     ],
                     "church_giving" => [
                         "label" => __( "Giving", 'disciple_tools' ),
                         "description" => _x( "The group is giving.", 'Optional Documentation', 'disciple_tools' ),
-                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/giving.svg?v=2'
+                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/giving-2.svg'
                     ],
                     "church_prayer" => [
                         "label" => __( "Prayer", 'disciple_tools' ),
                         "description" => _x( "The group is praying.", 'Optional Documentation', 'disciple_tools' ),
-                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/prayer.svg?v=2'
+                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/prayer-2.svg'
                     ],
                     "church_praise" => [
                         "label" => __( "Praise", 'disciple_tools' ),
                         "description" => _x( "The group is praising.", 'Optional Documentation', 'disciple_tools' ),
-                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/praise.svg?v=2'
+                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/praise-2.svg'
                     ],
                     "church_sharing" => [
                         "label" => __( "Sharing the Gospel", 'disciple_tools' ),
                         "description" => _x( "The group is sharing the gospel.", 'Optional Documentation', 'disciple_tools' ),
-                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/evangelism.svg?v=2'
+                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/evangelism-2.svg'
                     ],
                     "church_leaders" => [
                         "label" => __( "Leaders", 'disciple_tools' ),
                         "description" => _x( "The group has leaders.", 'Optional Documentation', 'disciple_tools' ),
-                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/leadership.svg?v=2'
+                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/leadership-2.svg'
                     ],
                     "church_commitment" => [
                         "label" => __( "Church Commitment", 'disciple_tools' ),
                         "description" => _x( "The group has committed to be church.", 'Optional Documentation', 'disciple_tools' ),
-                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/covenant.svg?v=2'
+                        "image" => get_template_directory_uri() . '/dt-assets/images/groups/covenant.svg'
                     ],
                 ],
                 "customizable" => "add_only",
@@ -487,13 +487,116 @@ class DT_Groups_Base extends DT_Module_Base {
             $group_preferences = dt_get_option( 'group_preferences' );
             $fields = DT_Posts::get_post_field_settings( $post_type );
             //<!-- Health Metrics-->
-            if ( ! empty( $group_preferences['church_metrics'] ) ) : ?>
+            if ( ! empty( $group_preferences['church_metrics'] ) ) :
+                $health_church_commitment = 'committed';
+                ?>
+                <style>
+                .custom-group-health-item {
+                    display: none;
+                    margin: auto;
+                    position: absolute;
+                    height: 50px;
+                    width: 50px;
+                    border-radius: 100%;
+                    font-size: 16px;
+                    color: black;
+                    text-align: center;
+                    font-style: italic;
+                }
 
+                .custom-group-health-item img {
+                    height: 50px;
+                    width: 50px;
+                    filter: grayscale(1) opacity(0.3);
+                }
+
+                .practiced-item {
+                    filter:  none !important;
+                }
+
+                .custom-group-health-circle {
+                    display: block;
+                    margin:auto;
+                    height:300px;
+                    width:300px;
+                    border-radius:100%;
+                    border: 3px darkgray dashed;
+                }
+
+                .custom-group-health-grid {
+                    display: inline-block;
+                    position: relative;
+                    height:75%;
+                    width:75%;
+                    margin-top: 12.5%;
+                    margin-left: auto;
+                    margin-right: auto;
+                }
+
+                .committed {
+                    border: 3px #4caf50 solid !important;
+                }
+
+                .group-progress-button {
+                    background-color: darkgray;
+                }
+
+                .group-progress-button img {
+                    filter: grayscale(1) contrast(1.35);
+                }
+                </style>
                 <div class="grid-x">
                     <div style="margin-right:auto; margin-left:auto;min-height:302px">
-                        <object id="church-svg-wrapper" type="image/svg+xml" data="<?php echo esc_attr( get_template_directory_uri() . '/dt-assets/images/groups/church-wheel.svg?v=2' ); ?>"></object>
+                        <div class="custom-group-health-circle <?php echo esc_attr( $health_church_commitment ); ?>" id="custom-group-health-items-container">
+                            <div class="custom-group-health-grid">
+                                <?php
+                                $fields = DT_Posts::get_post_field_settings( $post_type );
+                                foreach ( $fields['health_metrics']['default'] as $key => $option ) :
+                                    if ( $key !== 'church_commitment' ) :
+                                    ?>
+                                    <div class="custom-group-health-item" id="icon_<?php echo esc_attr( strtolower( $key ) ) ?>" title="<?php echo esc_attr( $option['description'] ); ?>">
+                                        <img src="<?php echo esc_attr( $option['image'] ); ?>">
+                                    </div>
+                                    <?php endif; 
+                                endforeach; ?>
+                            </div>
+                        </div>
                     </div>
                 </div>
+                <script>
+                    
+                    
+            </script>
+            <script>
+                // Toggle practiced/non-practiced items
+                jQuery(document).ready(function($) {
+                      let group_id       = window.detailsSettings.post_id;
+                      let post_type      = window.detailsSettings.post_type;
+                      let post           = window.detailsSettings.post_fields;
+                      let field_settings = window.detailsSettings.post_settings.fields;
+
+                      $('.summary-icons').on('click', function () {
+                        let fieldId = $(this).attr('id');
+                        if (fieldId == 'church_commitment') {
+                          $( '#custom-group-health-items-container' ).toggleClass( 'committed' );
+                          $( this ).toggleClass('half-opacity');
+                        } else {
+                          $( '#' + fieldId ).toggleClass('half-opacity');
+                          $( '#icon_' + fieldId ).toggleClass('half-opacity');
+                        }
+
+                        $.ajax( {
+                          type: 'POST',
+                          contentType: 'application/json; charset=utf-8',
+                          dataType: "json",
+                          url: window.wpApiShare.root + 'custom_group_health_plugin/v1/update_practice/' + group_id + '/' + fieldId,
+                          beforeSend: function(xhr) {
+                              xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce );
+                              },
+                          } )
+                      });
+                    });
+                </script>
                 <div style="display:flex;flex-wrap:wrap;margin-top:10px" class=" js-progress-bordered-box half-opacity">
                     <?php foreach ( $fields["health_metrics"]["default"] as $key => $option ) : ?>
                         <div class="group-progress-button-wrapper">

--- a/dt-groups/groups.js
+++ b/dt-groups/groups.js
@@ -9,34 +9,19 @@ jQuery(document).ready(function($) {
   /* Church Metrics */
   let health_keys = Object.keys(field_settings.health_metrics.default)
   function fillOutChurchHealthMetrics() {
-    if ( $("#health-metrics").length ) {
-      let svgItem = document.getElementById("church-svg-wrapper").contentDocument
-
-      let churchWheel = $(svgItem).find('svg')
-      health_keys.forEach(m=>{
-        if (post[`health_metrics`] && post.health_metrics.includes(m) ){
-          churchWheel.find(`#${m.replace("church_", "")}`).css("opacity", "1")
-          $(`#${m}`).css("opacity", "1")
-        } else {
-          churchWheel.find(`#${m.replace("church_", "")}`).css("opacity", ".1")
-          $(`#${m}`).css("opacity", ".4")
+    let items = $("div[id^='icon']");
+    let practiced_items = window.detailsSettings.post_fields.health_metrics;
+    items.each( function( k, v ) {
+        if ( practiced_items.indexOf( v.id.replace( 'icon_', '' ), practiced_items ) !== -1 ) {
+            $(this).children('img').attr('class','practiced-item');
         }
-      })
-      if ( !(post.health_metrics ||[]).includes("church_commitment") ){
-        churchWheel.find('#group').css("opacity", "1")
-        $(`#church_commitment`).css("opacity", ".4")
-      } else {
-        churchWheel.find('#group').css("opacity", ".1")
-        $(`#church_commitment`).css("opacity", "1")
-      }
-
-      $(".js-progress-bordered-box").removeClass("half-opacity")
-    }
+    });
   }
   $('#church-svg-wrapper').on('load', function() {
     fillOutChurchHealthMetrics()
   })
-  fillOutChurchHealthMetrics()
+  fillOutChurchHealthMetrics();
+  distributeItems();
 
   $('.group-progress-button').on('click', function () {
     let fieldId = $(this).attr('id')
@@ -54,6 +39,53 @@ jQuery(document).ready(function($) {
         console.log(err)
     })
   })
+
+  // Dynamically distribute items in Church Health Circle
+  function distributeItems() {
+    let radius = 75;
+    let items = $('.custom-group-health-item'),
+        container = $('#custom-group-health-items-container'),
+        item_count = items.length,
+        fade_delay = 45,
+        width = container.width(),
+        height = container.height(),
+        angle = 0,
+        step = (2*Math.PI) / items.length,
+        y_offset = -35;
+
+        if ( item_count >= 5 && item_count < 7 ) {
+            radius = 90;
+        }
+
+        if ( item_count >= 7 & item_count < 11 ) {
+            radius = 100;
+        }
+
+        if ( item_count >= 11 ) {
+            radius = 110;
+        }
+
+        if ( item_count == 3 ) {
+            angle = 22.5;
+        }
+
+    items.each(function() {
+        let X = Math.round(width/2 + radius * Math.cos(angle) - $(this).width()/2);
+        let y = Math.round(height/2 + radius * Math.sin(angle) - $(this).height()/2) + y_offset;
+        
+        if ( item_count == 1 ) {
+            X = 112.5;
+            y = 68;
+        }
+        $(this).css({
+            left: X + 'px',
+            top: y + 'px',
+        });
+        $(this).delay(fade_delay).fadeIn(1000,'linear');
+        angle += step;
+        fade_delay += 45;
+    });
+  }
   /* end Church fields*/
 
 

--- a/dt-groups/groups.js
+++ b/dt-groups/groups.js
@@ -71,7 +71,7 @@ jQuery(document).ready(function($) {
         item_count = items.length,
         fade_delay = 45,
         width = container.width(),
-        height = container.height(),
+        height = container.height() + 66,
         angle = 0,
         step = (2*Math.PI) / items.length,
         y_offset = -35;

--- a/dt-groups/groups.js
+++ b/dt-groups/groups.js
@@ -6,26 +6,27 @@ jQuery(document).ready(function($) {
   let post           = window.detailsSettings.post_fields;
   let field_settings = window.detailsSettings.post_settings.fields;
 
-  /* Church Metrics */
+  /* Health Metrics */
   let health_keys = Object.keys(field_settings.health_metrics.default);
 
   function fillOutChurchHealthMetrics() {
     let practiced_items = window.detailsSettings.post_fields.health_metrics;
-    
-    // Make church commitment circle green
+
+    /* Make church commitment circle green */
     if ( practiced_items.indexOf( 'church_commitment' ) !== -1 ) {
       $('#health-items-container').addClass( 'committed' );
     }
 
-    // Color church circle items that are being practiced
+    /* Color church circle items that are being practiced */
     let items = $( 'div[id^="icon_"]' );
+
     items.each( function( k, v ) {
         if ( practiced_items.indexOf( v.id.replace( 'icon_', '' ), practiced_items ) !== -1 ) {
-            $( this ).children('img').attr( 'class','practiced-item' );
+            $( this ).children( 'img' ).attr( 'class','practiced-item' );
         }
     });
 
-    // Color group progress buttons
+    /* Color group progress buttons */
     let icons = $( '.group-progress-button' );
     icons.each( function( k, v ) {
       if ( practiced_items.indexOf( v.id, practiced_items ) !== -1 ) {
@@ -37,34 +38,36 @@ jQuery(document).ready(function($) {
   fillOutChurchHealthMetrics();
   distributeItems();
 
-  $('.group-progress-button').on('click', function () {
-    let fieldId = $(this).attr('id');
-    let already_set = window.lodash.get(post, `health_metrics`, []).includes(fieldId)
-    let update = {values:[{value:fieldId}]}
+  $( '.group-progress-button' ).on( 'click', function () {
+    let fieldId = $( this ).attr( 'id' );
+    let already_set = window.lodash.get(post, 'health_metrics', []).includes( fieldId );
+    let update = { values: [ { value : fieldId } ] };
     if ( already_set ){
       update.values[0].delete = true;
     }
-    API.update_post( post_type, post_id, {"health_metrics": update })
-      .then(groupData=>{
+    API.update_post( post_type, post_id, { 'health_metrics': update })
+      .then( groupData => {
         post = groupData;
-        // Update icons or commitment circle
-        if ( $(this).attr('id') === 'church_commitment' ) {
-          $('#health-items-container').toggleClass('committed');
-          $(this).toggleClass( 'practiced-button' );
+        /* Update icons or commitment circle */
+        if ( $( this ).attr( 'id' ) === 'church_commitment' ) {
+          $( '#health-items-container' ).toggleClass( 'committed' );
+          $( this ).toggleClass( 'practiced-button' );
           return true; 
         }
-        $( '#icon_' + $(this).attr('id') ).children('img').toggleClass( 'practiced-item' ); // Toggle church health circle item color
-        $(this).toggleClass( 'practiced-button' );
-      }).catch(err=>{
-        console.log(err)
-    })
-  })
+        /* Toggle church health circle item color */
+        $( '#icon_' + $( this ).attr( 'id' ) ).children( 'img' ).toggleClass( 'practiced-item' );
+        $( this ).toggleClass( 'practiced-button' );
+      }).catch( err=>{
+        console.log( err );
+    });
+  });
 
-  // Dynamically distribute items in Church Health Circle
+  /* Dynamically distribute items in Church Health Circle
+     according to amount of health metric elements */
   function distributeItems() {
     let radius = 75;
-    let items = $('.health-item'),
-        container = $('#health-items-container'),
+    let items = $( '.health-item' ),
+        container = $( '#health-items-container' ),
         item_count = items.length,
         fade_delay = 45,
         width = container.width(),
@@ -107,7 +110,7 @@ jQuery(document).ready(function($) {
         fade_delay += 45;
     });
   }
-  /* end Church fields*/
+  /* End Health Metrics*/
 
 
   /* Member List*/


### PR DESCRIPTION
Upgraded Look & Feel and Display Logic for Core Group Health Tile
![localhost_10033_groups_19_ (1)](https://user-images.githubusercontent.com/36511666/134993209-0555822b-a4eb-4685-a1a9-3d210bd58860.png)

![localhost_10033_groups_19_](https://user-images.githubusercontent.com/36511666/134992732-39a3da9f-1e37-47cc-80d4-906501377f66.png)


**Features:**
- Group Health Circle is now displayed dynamically.
- If health metrics are added, they'll display properly up to 12 elements.
- If health metrics are removed, they'll display properly up to 1 element.
- If no health metrics are loaded, an 'empty' icon and label will appear and no buttons will be displayed
- Tile is responsive