### PR TITLE
PHPCS: require spaces after opening control structure parenthesis and before the closing one

### DIFF
--- a/archive-template.php
+++ b/archive-template.php
@@ -262,7 +262,7 @@ dt_please_log_in();
                         ?>
                         <ul class="ul-no-bullets" style="">
                         <?php foreach ( $post_settings["fields"] as $field_key => $field_values ):
-                            if ( !empty( $field_values["hidden"] )){
+                            if ( !empty( $field_values["hidden"] ) ){
                                 continue;
                             }
                             ?>
@@ -326,7 +326,7 @@ dt_please_log_in();
                                         </div>
                                         <select id="overall_status" class="select-field">
                                             <option></option>
-                                            <?php foreach ($field_options["overall_status"]["default"] as $key => $option){
+                                            <?php foreach ( $field_options["overall_status"]["default"] as $key => $option ){
                                                 $value = $option["label"] ?? "";?>
                                                     <option value="<?php echo esc_html( $key ) ?>"><?php echo esc_html( $value ); ?></option>
                                             <?php } ?>
@@ -566,8 +566,8 @@ dt_please_log_in();
                     uasort( $field_options, function ( $a, $b ){
                         return strnatcmp( $a['name'] ?? 'z', $b['name'] ?? 'z' );
                     });
-                    foreach ( $field_options as $field_key => $field){
-                        if ( $field_key && in_array( $field["type"] ?? "", $allowed_types ) && !in_array( $field_key, $fields ) && !( isset( $field["hidden"] ) && $field["hidden"] )){
+                    foreach ( $field_options as $field_key => $field ){
+                        if ( $field_key && in_array( $field["type"] ?? "", $allowed_types ) && !in_array( $field_key, $fields ) && !( isset( $field["hidden"] ) && $field["hidden"] ) ){
                             $fields[] = $field_key;
                         }
                     }

--- a/dt-assets/functions/enqueue-scripts.php
+++ b/dt-assets/functions/enqueue-scripts.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types=1);
+declare( strict_types=1 );
 
 /**
  * Load scripts, in a way that implements cache-busting
@@ -85,7 +85,7 @@ function dt_site_scripts() {
     dt_theme_enqueue_style( 'site-css', 'dt-assets/build/css/style.min.css', array() );
 
     // Comment reply script for threaded comments
-    if ( is_singular() && comments_open() && ( get_option( 'thread_comments' ) == 1 )) {
+    if ( is_singular() && comments_open() && ( get_option( 'thread_comments' ) == 1 ) ) {
         wp_enqueue_script( 'comment-reply' );
     }
 
@@ -148,7 +148,7 @@ function dt_site_scripts() {
     $post_types = DT_Posts::get_post_types();
     if ( is_singular( $post_types ) ) {
         $post = DT_Posts::get_post( get_post_type(), get_the_ID() );
-        if ( !is_wp_error( $post )){
+        if ( !is_wp_error( $post ) ){
             $post_settings = DT_Posts::get_post_settings( $post_type );
             dt_theme_enqueue_script( 'jquery-mentions', 'dt-core/dependencies/jquery-mentions-input/jquery.mentionsInput.min.js', array( 'jquery' ), true );
             dt_theme_enqueue_script( 'jquery-mentions-elastic', 'dt-core/dependencies/jquery-mentions-input/lib/jquery.elastic.min.js', array( 'jquery' ), true );
@@ -315,7 +315,7 @@ function dt_site_scripts() {
         }
     }
 
-    if ($is_new_post){
+    if ( $is_new_post ){
         $post_settings = DT_Posts::get_post_settings( $post_type );
         $dependencies = [ 'jquery', 'lodash', 'shared-functions', 'typeahead-jquery' ];
         if ( DT_Mapbox_API::get_key() ){

--- a/dt-assets/parts/loop-activity-comment.php
+++ b/dt-assets/parts/loop-activity-comment.php
@@ -90,7 +90,7 @@
                     $sections = apply_filters( 'dt_comments_additional_sections', $sections, $post_type );
                     $section_keys = [];
                     foreach ( $sections as $section ) :
-                        if ( isset( $section["key"] ) && isset( $section["label"] ) && !in_array( $section["key"], $section_keys )) :
+                        if ( isset( $section["key"] ) && isset( $section["label"] ) && !in_array( $section["key"], $section_keys ) ) :
                             $section_keys[] = $section["key"];
                             ?>
                             <li class="tabs-title hide">

--- a/dt-contacts/access-module.php
+++ b/dt-contacts/access-module.php
@@ -421,12 +421,12 @@ class DT_Contacts_Access extends DT_Module_Base {
                 <?php
                 $active_color = "#366184";
                 $current_key = $contact["overall_status"]["key"] ?? "";
-                if ( isset( $contact_fields["overall_status"]["default"][ $current_key ]["color"] )){
+                if ( isset( $contact_fields["overall_status"]["default"][ $current_key ]["color"] ) ){
                     $active_color = $contact_fields["overall_status"]["default"][ $current_key ]["color"];
                 }
                 ?>
                 <select id="overall_status" class="select-field color-select" style="margin-bottom:0; background-color: <?php echo esc_html( $active_color ) ?>">
-                    <?php foreach ($contact_fields["overall_status"]["default"] as $key => $option){
+                    <?php foreach ( $contact_fields["overall_status"]["default"] as $key => $option ){
                         $value = $option["label"] ?? "";
                         if ( $contact["overall_status"]["key"] === $key ) {
                             ?>
@@ -442,13 +442,13 @@ class DT_Contacts_Access extends DT_Module_Base {
                         $hide_edit_button = false;
                         $status_key = isset( $contact["overall_status"]["key"] ) ? $contact["overall_status"]["key"] : "";
                         if ( $status_key === "paused" &&
-                            isset( $contact["reason_paused"]["label"] )){
+                            isset( $contact["reason_paused"]["label"] ) ){
                             echo '(' . esc_html( $contact["reason_paused"]["label"] ) . ')';
                         } else if ( $status_key === "closed" &&
-                            isset( $contact["reason_closed"]["label"] )){
+                            isset( $contact["reason_closed"]["label"] ) ){
                             echo '(' . esc_html( $contact["reason_closed"]["label"] ) . ')';
                         } else if ( $status_key === "unassignable" &&
-                            isset( $contact["reason_unassignable"]["label"] )){
+                            isset( $contact["reason_unassignable"]["label"] ) ){
                             echo '(' . esc_html( $contact["reason_unassignable"]["label"] ) . ')';
                         } else {
                             if ( !in_array( $status_key, [ "paused", "closed", "unassignable" ] ) ){
@@ -555,7 +555,7 @@ class DT_Contacts_Access extends DT_Module_Base {
 
         if ( isset( $post["post_type"] ) && $post["post_type"] === "contacts" && $field_key === "assigned_to"
             && isset( $contact_fields[$field_key] ) && !empty( $contact_fields[$field_key]["custom_display"] )
-            && empty( $contact_fields[$field_key]["hidden"] )){
+            && empty( $contact_fields[$field_key]["hidden"] ) ){
             $button_class =( current_user_can( 'dt_all_access_contacts' ) || current_user_can( 'list_users' ) ) ? "advanced_user_select" : "search_assigned_to"
             ?>
             <div class="section-subheader">
@@ -695,10 +695,10 @@ class DT_Contacts_Access extends DT_Module_Base {
                     self::handle_quick_action_button_event( $post_id, [ $field_key => $value ] );
                 }
             }
-            if ( isset( $fields["overall_status"], $fields["reason_paused"] ) && $fields["overall_status"] === "paused"){
+            if ( isset( $fields["overall_status"], $fields["reason_paused"] ) && $fields["overall_status"] === "paused" ){
                 $fields["requires_update"] = false;
             }
-            if ( isset( $fields["overall_status"], $fields["reason_closed"] ) && $fields["overall_status"] === "closed"){
+            if ( isset( $fields["overall_status"], $fields["reason_closed"] ) && $fields["overall_status"] === "closed" ){
                 $fields["requires_update"] = false;
             }
         }
@@ -759,9 +759,9 @@ class DT_Contacts_Access extends DT_Module_Base {
         }
         if ( !isset( $fields["overall_status"] ) ){
             $current_roles = wp_get_current_user()->roles;
-            if (in_array( "dispatcher", $current_roles, true ) || in_array( "marketer", $current_roles, true )) {
+            if ( in_array( "dispatcher", $current_roles, true ) || in_array( "marketer", $current_roles, true ) ) {
                 $fields["overall_status"] = "new";
-            } else if (in_array( "multiplier", $current_roles, true ) ) {
+            } else if ( in_array( "multiplier", $current_roles, true ) ) {
                 $fields["overall_status"] = "active";
             } else {
                 $fields["overall_status"] = "new";
@@ -1059,7 +1059,7 @@ class DT_Contacts_Access extends DT_Module_Base {
 
     //list page filters function
     private static function add_default_custom_list_filters( $filters ){
-        if ( empty( $filters )){
+        if ( empty( $filters ) ){
             $filters = [];
         }
         $default_filters = [
@@ -1329,7 +1329,7 @@ class DT_Contacts_Access extends DT_Module_Base {
     private static function check_requires_update( $contact_id ){
         if ( get_current_user_id() ){
             $requires_update = get_post_meta( $contact_id, "requires_update", true );
-            if ( $requires_update == "yes" || $requires_update == true || $requires_update == "1"){
+            if ( $requires_update == "yes" || $requires_update == true || $requires_update == "1" ){
                 //don't remove update needed if the user is a dispatcher (and not assigned to the contacts.)
                 if ( current_user_can( 'dt_all_access_contacts' ) ){
                     if ( dt_get_user_id_from_assigned_to( get_post_meta( $contact_id, "assigned_to", true ) ) === get_current_user_id() ){
@@ -1377,7 +1377,7 @@ class DT_Contacts_Access extends DT_Module_Base {
             } else {
                 $assign_to_id = 0;
                 $last_activity = DT_Posts::get_most_recent_activity_for_field( $contact_id, "assigned_to" );
-                if ( isset( $last_activity->user_id )){
+                if ( isset( $last_activity->user_id ) ){
                     $assign_to_id = $last_activity->user_id;
                 } else {
                     $base_user = dt_get_base_user( true );
@@ -1447,7 +1447,7 @@ class DT_Contacts_Access extends DT_Module_Base {
                     'meta_value' => true
                 ] );
                 foreach ( $following_all as $user ){
-                    if ( !in_array( $user->ID, $users_to_notify )){
+                    if ( !in_array( $user->ID, $users_to_notify ) ){
                         $users_to_notify[] = $user->ID;
                     }
                 }
@@ -1473,7 +1473,7 @@ class DT_Contacts_Access extends DT_Module_Base {
         $workload_status_options = dt_get_site_custom_lists()["user_workload_status"] ?? [];
         foreach ( $user_data as $user ) {
             $roles = maybe_unserialize( $user["roles"] );
-            if ( isset( $roles["multiplier"] ) || isset( $roles["dt_admin"] ) || isset( $roles["dispatcher"] ) || isset( $roles["marketer"] )) {
+            if ( isset( $roles["multiplier"] ) || isset( $roles["dt_admin"] ) || isset( $roles["dispatcher"] ) || isset( $roles["marketer"] ) ) {
                 $u = [
                     "name" => $user["display_name"],
                     "ID" => $user["ID"],

--- a/dt-contacts/base-setup.php
+++ b/dt-contacts/base-setup.php
@@ -46,7 +46,7 @@ class DT_Contacts_Base {
 
 
     public function after_setup_theme(){
-        if ( class_exists( 'Disciple_Tools_Post_Type_Template' )) {
+        if ( class_exists( 'Disciple_Tools_Post_Type_Template' ) ) {
             new Disciple_Tools_Post_Type_Template( "contacts", __( 'Contact', 'disciple_tools' ), __( 'Contacts', 'disciple_tools' ) );
         }
     }
@@ -549,7 +549,7 @@ class DT_Contacts_Base {
 
     //list page filters function
     private static function add_default_custom_list_filters( $filters ){
-        if ( empty( $filters )){
+        if ( empty( $filters ) ){
             $filters = [];
         }
         $default_filters = [
@@ -645,10 +645,10 @@ class DT_Contacts_Base {
 
     }
     public function dt_record_icon( $icon, $post_type, $dt_post ){
-        if ($post_type == 'contacts') {
+        if ( $post_type == 'contacts' ) {
             $gender = isset( $dt_post["gender"] ) ? $dt_post["gender"]["key"] : "male";
             $icon = 'fi-torso';
-            if ($gender == 'female') {
+            if ( $gender == 'female' ) {
                 $icon = $icon.'-'.$gender;
             }
         }

--- a/dt-contacts/contacts-transfer.php
+++ b/dt-contacts/contacts-transfer.php
@@ -264,7 +264,7 @@ class Disciple_Tools_Contacts_Transfer
 
 
         $comment = sprintf( __( 'This contact was transferred to %s for further follow-up.', 'disciple_tools' ), esc_attr( get_the_title( $site_post_id ) ) );
-        if ( isset( $result_body->created_id )){
+        if ( isset( $result_body->created_id ) ){
             $comment .= ' [link](https://' . $site['url'] . '/contacts/' . esc_attr( $result_body->created_id ) . ')';
         }
         // add note that the record was transferred

--- a/dt-contacts/duplicates-merging.php
+++ b/dt-contacts/duplicates-merging.php
@@ -219,7 +219,7 @@ class DT_Duplicate_Checker_And_Merging {
                             if ( $value["value"] === $dup_value["value"] ){
                                 $match_on[] = [ "field" => $field_key, "value" => $dup_value["value"] ];
                                 $points += 4;
-                            } else if ( stripos( $value["value"], $dup_value["value"] ) !== false || stripos( $dup_value["value"], $value["value"] ) !== false){
+                            } else if ( stripos( $value["value"], $dup_value["value"] ) !== false || stripos( $dup_value["value"], $value["value"] ) !== false ){
                                 $match_on[] = [ "field" => $field_key, "value" => $dup_value["value"] ];
                                 $points++;
                             }
@@ -348,21 +348,21 @@ class DT_Duplicate_Checker_And_Merging {
 
         $ignore_keys = array();
 
-        foreach ($phones as $phone) {
+        foreach ( $phones as $phone ) {
             $index = array_search( $phone, $current['contact_phone'] );
-            if ($index !== false) { $ignore_keys[] = $index;
+            if ( $index !== false ) { $ignore_keys[] = $index;
                 continue; }
             array_push( $update['contact_phone']['values'], [ 'value' => $phone ] );
         }
-        foreach ($emails as $email) {
+        foreach ( $emails as $email ) {
             $index = array_search( $email, $current['contact_email'] );
-            if ($index !== false) { $ignore_keys[] = $index;
+            if ( $index !== false ) { $ignore_keys[] = $index;
                 continue; }
             array_push( $update['contact_email']['values'], [ 'value' => $email ] );
         }
-        foreach ($addresses as $address) {
+        foreach ( $addresses as $address ) {
             $index = array_search( $address, $current['contact_address'] );
-            if ($index !== false) { $ignore_keys[] = $index;
+            if ( $index !== false ) { $ignore_keys[] = $index;
                 continue; }
             array_push( $update['contact_address']['values'], [ 'value' => $address ] );
         }
@@ -381,16 +381,16 @@ class DT_Duplicate_Checker_And_Merging {
                 if ( $contact_fields[ $key ]["type"] === "key_select" && ( ! isset( $contact[ $key ] ) || $contact[ $key ]['key'] === "none" || $contact[ $key ]['key'] === "not-set" || $contact[ $key ]['key'] === "" ) ) {
                     $update[ $key ] = $fields["key"];
                 }
-                if ( $contact_fields[ $key ]["type"] === "text" && ( ! isset( $contact[ $key ] ) || empty( $contact[ $key ] ) )) {
+                if ( $contact_fields[ $key ]["type"] === "text" && ( ! isset( $contact[ $key ] ) || empty( $contact[ $key ] ) ) ) {
                     $update[ $key ] = $fields;
                 }
-                if ( $contact_fields[ $key ]["type"] === "textarea" && ( ! isset( $contact[ $key ] ) || empty( $contact[ $key ] ) )) {
+                if ( $contact_fields[ $key ]["type"] === "textarea" && ( ! isset( $contact[ $key ] ) || empty( $contact[ $key ] ) ) ) {
                     $update[ $key ] = $fields;
                 }
-                if ( $contact_fields[ $key ]["type"] === "number" && ( ! isset( $contact[ $key ] ) || empty( $contact[ $key ] ) )) {
+                if ( $contact_fields[ $key ]["type"] === "number" && ( ! isset( $contact[ $key ] ) || empty( $contact[ $key ] ) ) ) {
                     $update[ $key ] = $fields;
                 }
-                if ( $contact_fields[ $key ]["type"] === "date" && ( ! isset( $contact[ $key ] ) || empty( $contact[ $key ] ) )) {
+                if ( $contact_fields[ $key ]["type"] === "date" && ( ! isset( $contact[ $key ] ) || empty( $contact[ $key ] ) ) ) {
                     $update[ $key ] = $fields["timestamp"] ?? "";
                 }
                 if ( $contact_fields[ $key ]["type"] === "array" && ( ! isset( $contact[ $key ] ) || empty( $contact[ $key ] ) ) ) {
@@ -398,7 +398,7 @@ class DT_Duplicate_Checker_And_Merging {
                         $update[ $key ] = $fields;
                     }
                 }
-                if ( $contact_fields[ $key ]["type"] === "boolean" && ( ! isset( $contact[ $key ] ) || empty( $contact[ $key ] ) )) {
+                if ( $contact_fields[ $key ]["type"] === "boolean" && ( ! isset( $contact[ $key ] ) || empty( $contact[ $key ] ) ) ) {
                     $update[ $key ] = $fields;
                 }
                 if ( $contact_fields[ $key ]["type"] === "tags" ) {
@@ -459,11 +459,11 @@ class DT_Duplicate_Checker_And_Merging {
         }
 
         $delete_fields = array();
-        if ($update['contact_phone']['values']) { $delete_fields[] = 'contact_phone'; }
-        if ($update['contact_email']['values']) { $delete_fields[] = 'contact_email'; }
-        if ($update['contact_address']['values']) { $delete_fields[] = 'contact_address'; }
+        if ( $update['contact_phone']['values'] ) { $delete_fields[] = 'contact_phone'; }
+        if ( $update['contact_email']['values'] ) { $delete_fields[] = 'contact_email'; }
+        if ( $update['contact_address']['values'] ) { $delete_fields[] = 'contact_address'; }
 
-        if ( !empty( $delete_fields )) {
+        if ( !empty( $delete_fields ) ) {
             self::remove_fields( $master_id, $delete_fields, $ignore_keys );
         }
 

--- a/dt-core/admin/menu/tabs/tab-custom-fields.php
+++ b/dt-core/admin/menu/tabs/tab-custom-fields.php
@@ -204,7 +204,7 @@ class Disciple_Tools_Tab_Custom_Fields extends Disciple_Tools_Abstract_Menu_Base
         $select_options = [];
         $selected_post_type = sanitize_text_field( wp_unslash( $selected_post_type ) );
         $fields = $this->get_post_fields( $selected_post_type );
-        uasort($fields, function( $a, $b) {
+        uasort($fields, function( $a, $b ) {
             return $a['name'] <=> $b['name'];
         });
         if ( $fields ){
@@ -704,7 +704,7 @@ class Disciple_Tools_Tab_Custom_Fields extends Disciple_Tools_Abstract_Menu_Base
             return;
         }
 
-        if ( isset( $post_fields[$post_submission["field_key"]] )){
+        if ( isset( $post_fields[$post_submission["field_key"]] ) ){
             if ( !isset( $field_customizations[$post_type][$field_key] ) ){
                 $field_customizations[$post_type][$field_key] = [];
             }
@@ -757,10 +757,10 @@ class Disciple_Tools_Tab_Custom_Fields extends Disciple_Tools_Abstract_Menu_Base
                 $custom_field["tile"] = $post_submission["tile_select"];
             }
             // key_select and multi_options
-            if ( isset( $post_fields[$field_key]["default"] ) && ( $field["type"] === 'multi_select' || $field["type"] === "key_select" )){
+            if ( isset( $post_fields[$field_key]["default"] ) && ( $field["type"] === 'multi_select' || $field["type"] === "key_select" ) ){
                 $field_options = $field["default"];
                 foreach ( $post_submission as $key => $val ){
-                    if ( strpos( $key, "field_option_" ) === 0) {
+                    if ( strpos( $key, "field_option_" ) === 0 ) {
                         if ( strpos( $key, 'translation' ) !== false ) {
                             $option_key           = substr( $key, 13, strpos( $key, 'translation' ) - 14 );
                             $translation_langcode = substr( $key, strpos( $key, 'translation' ) + strlen( 'translation-' ) );
@@ -793,7 +793,7 @@ class Disciple_Tools_Tab_Custom_Fields extends Disciple_Tools_Abstract_Menu_Base
                         }
                     }
 
-                    if ( strpos( $key, "option_description_" ) === 0) {
+                    if ( strpos( $key, "option_description_" ) === 0 ) {
                         if ( strpos( $key, 'translation' ) !== false ) {
                             $option_key = substr( $key, strlen( "option_description_" ), strpos( $key, 'translation' ) - ( strlen( "option_description_" ) + 1 ) );
                             $translation_langcode = substr( $key, strpos( $key, 'translation' ) + strlen( 'translation-' ) );
@@ -842,7 +842,7 @@ class Disciple_Tools_Tab_Custom_Fields extends Disciple_Tools_Abstract_Menu_Base
                     $field_options[ $post_submission["restore_option"] ]["deleted"] = false;
                 }
                 //move option  up or down
-                if ( isset( $post_submission["move_up"] ) || isset( $post_submission["move_down"] )){
+                if ( isset( $post_submission["move_up"] ) || isset( $post_submission["move_down"] ) ){
                     $option_key = $post_submission["move_up"] ?? $post_submission["move_down"];
                     $direction = isset( $post_submission["move_up"] ) ? -1 : 1;
                     $active_field_options = [];
@@ -861,8 +861,8 @@ class Disciple_Tools_Tab_Custom_Fields extends Disciple_Tools_Abstract_Menu_Base
                  */
                 if ( !empty( $post_submission["add_option"] ) ){
                     $option_key = dt_create_field_key( $post_submission["add_option"] );
-                    if ( !isset( $field_options[$option_key] )){
-                        if ( !empty( $option_key ) && !empty( $post_submission["add_option"] )){
+                    if ( !isset( $field_options[$option_key] ) ){
+                        if ( !empty( $option_key ) && !empty( $post_submission["add_option"] ) ){
                             $field_options[ $option_key ] = [ "label" => $post_submission["add_option"] ];
                             $custom_field["default"][$option_key] = [ "label" => $post_submission["add_option"] ];
                         }
@@ -1073,7 +1073,7 @@ class Disciple_Tools_Tab_Custom_Fields extends Disciple_Tools_Abstract_Menu_Base
                 $field_private = false;
             }
             $post_fields = $this->get_post_fields( $post_type );
-            if ( isset( $post_fields[ $field_key ] )){
+            if ( isset( $post_fields[ $field_key ] ) ){
                 self::admin_notice( __( "Field already exists", 'disciple_tools' ), "error" );
                 return false;
             }

--- a/dt-core/admin/menu/tabs/tab-custom-tags.php
+++ b/dt-core/admin/menu/tabs/tab-custom-tags.php
@@ -171,11 +171,11 @@ class Disciple_Tools_Tab_Custom_Tags extends Disciple_Tools_Abstract_Menu_Base
 
         $tag_fields = [];
         $post_types = DT_Posts::get_post_types();
-        foreach ($post_types as $post_type) {
+        foreach ( $post_types as $post_type ) {
             $post_fields = DT_Posts::get_post_field_settings( $post_type );
 
-            foreach ($post_fields as $key => $post_field) {
-                if ($post_field['type'] === 'tags') {
+            foreach ( $post_fields as $key => $post_field ) {
+                if ( $post_field['type'] === 'tags' ) {
                     $tag_fields[] = $key;
                 }
             }
@@ -238,7 +238,7 @@ class Disciple_Tools_Tab_Custom_Tags extends Disciple_Tools_Abstract_Menu_Base
             $tags = self::get_all_tags();
             $tags_amount = count( $tags );
 
-            for ( $i = 0; $i <= $tags_amount - 1; $i++): ?>
+            for ( $i = 0; $i <= $tags_amount - 1; $i++ ): ?>
                 <tr>
                     <td style="vertical-align: middle">
                         <input type="checkbox" name="checkbox_delete_tag[<?php echo esc_html( $tags[$i]['old'] ?? $tags[$i]['meta_value'] ); ?>]" value="<?php echo esc_html( ( $tags[$i]['type'] ?? $tags[$i]['meta_key'] ) . ':' . ( $tags[$i]['old'] ?? $tags[$i]['meta_value'] ) ); ?>">

--- a/dt-core/admin/menu/tabs/tab-custom-tiles.php
+++ b/dt-core/admin/menu/tabs/tab-custom-tiles.php
@@ -367,7 +367,7 @@ class Disciple_Tools_Tab_Custom_Tiles extends Disciple_Tools_Abstract_Menu_Base
                 //update tiles fields belong to.
                 $custom_fields = dt_get_option( "dt_field_customizations" );
                 foreach ( $order as $tile_order ){
-                    foreach ( $tile_order["fields"] as $field_key){
+                    foreach ( $tile_order["fields"] as $field_key ){
                         if ( !isset( $custom_fields[$post_type][$field_key] ) ){
                             $custom_fields[$post_type][$field_key] = [];
                         }
@@ -419,7 +419,7 @@ class Disciple_Tools_Tab_Custom_Tiles extends Disciple_Tools_Abstract_Menu_Base
 
         $tile_options = DT_Posts::get_post_tiles( $post_type, false );
 
-        if ( !isset( $tile_options[$tile_key] )){
+        if ( !isset( $tile_options[$tile_key] ) ){
             self::admin_notice( __( "Tile not found", 'disciple_tools' ), "error" );
             return;
         }
@@ -518,7 +518,7 @@ class Disciple_Tools_Tab_Custom_Tiles extends Disciple_Tools_Abstract_Menu_Base
         $post_type = $post_submission["post_type"];
         $tile_options = dt_get_option( "dt_custom_tiles" );
         $tile_key = $post_submission["tile_key"];
-        if ( !isset( $tile_options[$post_type][$tile_key] )){
+        if ( !isset( $tile_options[$post_type][$tile_key] ) ){
             $tile_options[$post_type][$tile_key] = [];
         }
         $post_fields = $this->get_post_fields( $post_type );
@@ -527,7 +527,7 @@ class Disciple_Tools_Tab_Custom_Tiles extends Disciple_Tools_Abstract_Menu_Base
         }
         $custom_tile = $tile_options[$post_type][$tile_key];
 
-        if ( isset( $post_submission["tile_label"] ) && $post_submission["tile_label"] != ( $custom_tile["label"] ?? $tile_key )){
+        if ( isset( $post_submission["tile_label"] ) && $post_submission["tile_label"] != ( $custom_tile["label"] ?? $tile_key ) ){
             $custom_tile["label"] = $post_submission["tile_label"];
         }
         if ( isset( $post_submission["hide_tile"] ) ){
@@ -552,7 +552,7 @@ class Disciple_Tools_Tab_Custom_Tiles extends Disciple_Tools_Abstract_Menu_Base
 
 
         //move option  up or down
-        if ( isset( $post_submission["move_up"] ) || isset( $post_submission["move_down"] )){
+        if ( isset( $post_submission["move_up"] ) || isset( $post_submission["move_down"] ) ){
             $option_key = $post_submission["move_up"] ?? $post_submission["move_down"];
             $direction = isset( $post_submission["move_up"] ) ? -1 : 1;
             $keys = $custom_tile["order"] ?? [];
@@ -575,7 +575,7 @@ class Disciple_Tools_Tab_Custom_Tiles extends Disciple_Tools_Abstract_Menu_Base
             $custom_tile["order"] = $order;
         }
 
-        if ( !empty( $custom_tile )){
+        if ( !empty( $custom_tile ) ){
             $tile_options[$post_type][$tile_key] = $custom_tile;
         }
 

--- a/dt-core/admin/menu/tabs/tab-utilities-overview.php
+++ b/dt-core/admin/menu/tabs/tab-utilities-overview.php
@@ -132,14 +132,14 @@ class Disciple_Tools_Utilities_Overview_Tab extends Disciple_Tools_Abstract_Menu
             $active_plugins[] = $plugin;
         }
         foreach ( $plugins as $i => $v ){
-            if ( !isset( $v["Name"], $v["Version"] )){
+            if ( !isset( $v["Name"], $v["Version"] ) ){
                 continue;
             }
             ?>
             <tr>
             <td><?php echo esc_html( $v["Name"] ); ?> version: <?php echo esc_html( $v["Version"] ); ?></td>
             <td>
-            <?php if ( in_array( $i, $active_plugins )): ?>
+            <?php if ( in_array( $i, $active_plugins ) ): ?>
                 Plugin Active
             <?php endif; ?>
 

--- a/dt-core/admin/multi-role/multi-role.php
+++ b/dt-core/admin/multi-role/multi-role.php
@@ -63,7 +63,7 @@ class Disciple_Tools_Multi_Roles {
         require_once( 'inc/functions-roles.php' );
         require_once( 'inc/functions-users.php' );
 
-        if (is_admin()) {
+        if ( is_admin() ) {
 
             // General admin functions.
             require_once( 'functions-admin.php' );

--- a/dt-core/admin/site-link-post-type.php
+++ b/dt-core/admin/site-link-post-type.php
@@ -1287,9 +1287,9 @@ if ( ! class_exists( 'Site_Link_System' ) ) {
                     if ( is_wp_error( $result ) ) {
                         // Second request failed too. Return appropriate error
                         $error_message = $result->get_error_message() ?? '';
-                        if (strpos( $error_message, 'not resolve' ) > -1 || strpos( $error_message, 'timed out' ) > -1) {
+                        if ( strpos( $error_message, 'not resolve' ) > -1 || strpos( $error_message, 'timed out' ) > -1 ) {
                             return new WP_Error( "site_check_error", $not_found, [ 'status' => 400 ] );
-                        } else if ( strpos( $error_message, 'SSL' ) > -1 || strpos( $error_message, 'HTTPS' ) > -1 || strpos( $error_message, 'certificate verification failed' ) > -1) {
+                        } else if ( strpos( $error_message, 'SSL' ) > -1 || strpos( $error_message, 'HTTPS' ) > -1 || strpos( $error_message, 'certificate verification failed' ) > -1 ) {
                             return new WP_Error( "site_check_error", $no_ssl, [ 'status' => 400 ] );
                         }
                         return $result;
@@ -1382,12 +1382,12 @@ if ( ! class_exists( 'Site_Link_System' ) ) {
          */
         public static function get_real_ip_address() {
             $ip = '';
-            if ( ! empty( $_SERVER['HTTP_CLIENT_IP'] ))   //check ip from share internet
+            if ( ! empty( $_SERVER['HTTP_CLIENT_IP'] ) )   //check ip from share internet
             {
                 // @codingStandardsIgnoreLine
                 $ip = $_SERVER['HTTP_CLIENT_IP'];
             }
-            elseif ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ))   //to check ip is pass from proxy
+            elseif ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) )   //to check ip is pass from proxy
             {
                 // @codingStandardsIgnoreLine
                 $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];

--- a/dt-core/configuration/class-migration-engine.php
+++ b/dt-core/configuration/class-migration-engine.php
@@ -34,7 +34,7 @@ class Disciple_Tools_Migration_Engine
         $expected_migration_number = 0;
         $rv = [];
         foreach ( $filenames as $filename ) {
-            if ( $filename[0] !== "." && $filename !== "abstract.php"){
+            if ( $filename[0] !== "." && $filename !== "abstract.php" ){
                 if ( preg_match( '/^([0-9][0-9][0-9][0-9])(-.*)?\.php$/i', $filename, $matches ) ) {
                     $got_migration_number = intval( $matches[1] );
                     if ( $expected_migration_number !== $got_migration_number ) {
@@ -98,7 +98,7 @@ class Disciple_Tools_Migration_Engine
             error_log( gmdate( " Y-m-d H:i:s T" ) . " Starting migrating to number $activating_migration_number" );
             try {
                 $migration->up();
-            } catch (Throwable $e) {
+            } catch ( Throwable $e ) {
                 update_option( 'dt_migrate_last_error', [
                     'message' => $e->getMessage(),
                     'code' => $e->getCode(),
@@ -151,8 +151,8 @@ class Disciple_Tools_Migration_Lock_Exception extends Exception
          * error logs, but this is a bit more user-friendly.
          */
         $last_migration_error = get_option( 'dt_migrate_last_error' );
-        if ($message === null) {
-            if ($last_migration_error === false) {
+        if ( $message === null ) {
+            if ( $last_migration_error === false ) {
                 $message = "Cannot migrate, as migration lock is held";
             } else {
                 $message =

--- a/dt-core/configuration/class-roles.php
+++ b/dt-core/configuration/class-roles.php
@@ -93,7 +93,7 @@ class Disciple_Tools_Roles
      */
     public function set_roles_if_needed() {
         $current_number = get_option( 'dt_roles_number' );
-        if ($current_number === false || intval( $current_number ) < self::$target_roles_version_number) {
+        if ( $current_number === false || intval( $current_number ) < self::$target_roles_version_number ) {
             $this->set_roles();
         }
     }

--- a/dt-core/configuration/config-site-defaults.php
+++ b/dt-core/configuration/config-site-defaults.php
@@ -155,7 +155,7 @@ function dt_get_option( string $name ) {
 
         case 'dt_email_base_subject':
             $subject_base = get_option( "dt_email_base_subject", "Disciple Tools" );
-            if ( empty( $subject_base )){
+            if ( empty( $subject_base ) ){
                 update_option( "dt_email_base_subject", "Disciple Tools" );
             }
             return $subject_base;
@@ -171,7 +171,7 @@ function dt_get_option( string $name ) {
 
         case 'dt_working_languages':
             $languages = get_option( 'dt_working_languages', [] );
-            if ( empty( $languages )){
+            if ( empty( $languages ) ){
                 $languages = [
                     "en" => [ "label" => "English" ],
                     "fr" => [ "label" => "French" ],

--- a/dt-core/configuration/dt-configuration.php
+++ b/dt-core/configuration/dt-configuration.php
@@ -65,7 +65,7 @@ function dt_filter_handler( $approved, $commentdata ){
 }
 
 function dt_custom_dir_attr( $lang ){
-    if (is_admin()) {
+    if ( is_admin() ) {
         return $lang;
     }
 

--- a/dt-core/configuration/restrict-site-access.php
+++ b/dt-core/configuration/restrict-site-access.php
@@ -246,7 +246,7 @@ add_action( 'login_init', 'dt_redirect_logged_in' );
 //redirect already logged in users from the login page.
 function dt_redirect_logged_in() {
     global $action;
-    if ( 'logout' === $action || !is_user_logged_in()) {
+    if ( 'logout' === $action || !is_user_logged_in() ) {
         return;
     }
     if ( !empty( $_GET["redirect_to"] ) ) {
@@ -260,7 +260,7 @@ function dt_redirect_logged_in() {
 /**
  * Force password reset to remain on current site for multi-site installations.
  */
-add_filter("lostpassword_url", function ( $url, $redirect) {
+add_filter("lostpassword_url", function ( $url, $redirect ) {
 
     $args = array( 'action' => 'lostpassword' );
 
@@ -272,13 +272,13 @@ add_filter("lostpassword_url", function ( $url, $redirect) {
 }, 10, 2);
 
 // fixes other password reset related urls
-add_filter( 'network_site_url', function( $url, $path, $scheme) {
+add_filter( 'network_site_url', function( $url, $path, $scheme ) {
 
-    if (stripos( $url, "action=lostpassword" ) !== false) {
+    if ( stripos( $url, "action=lostpassword" ) !== false ) {
         return site_url( 'wp-login.php?action=lostpassword', $scheme );
     }
 
-    if (stripos( $url, "action=resetpass" ) !== false) {
+    if ( stripos( $url, "action=resetpass" ) !== false ) {
         return site_url( 'wp-login.php?action=resetpass', $scheme );
     }
 
@@ -286,7 +286,7 @@ add_filter( 'network_site_url', function( $url, $path, $scheme) {
 }, 10, 3 );
 
 // fixes URLs in email that goes out.
-function dt_multisite_retrieve_password_message( $message, $key, $user_login, $user_data) {
+function dt_multisite_retrieve_password_message( $message, $key, $user_login, $user_data ) {
     $message = __( 'Someone has requested a password reset for the following account:', 'disciple_tools' ) . "\r\n\r\n";
     /* translators: %s: Site name. */
     $message .= sprintf( __( 'DT Site Name: %s', 'disciple_tools' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) . "\r\n\r\n";
@@ -300,7 +300,7 @@ function dt_multisite_retrieve_password_message( $message, $key, $user_login, $u
 add_filter( "retrieve_password_message", 'dt_multisite_retrieve_password_message', 99, 4 );
 
 // fixes email title
-add_filter("retrieve_password_title", function( $title) {
+add_filter("retrieve_password_title", function( $title ) {
     return "[" . wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) . "] Password Reset";
 });
 //add_filter( 'wp_handle_upload_prefilter', 'dt_disable_file_upload' ); //this breaks uploading plugins and themes
@@ -327,7 +327,7 @@ function restrict_super_admin( $caps, $cap, $user_id, $args ){
             }
         }
         //if it is not a D.T permission, continue as normal.
-        if ( !in_array( $cap, $dt_permissions, true )){
+        if ( !in_array( $cap, $dt_permissions, true ) ){
             return $caps;
         }
         //limit the super admin to the actions the administrator or dt_admin can take on a site.

--- a/dt-core/global-functions.php
+++ b/dt-core/global-functions.php
@@ -124,12 +124,12 @@ if ( ! defined( 'DT_FUNCTIONS_READY' ) ){
     }
 
     if ( ! function_exists( 'dt_array_to_sql' ) ) {
-        function dt_array_to_sql( $values) {
-            if (empty( $values )) {
+        function dt_array_to_sql( $values ) {
+            if ( empty( $values ) ) {
                 return 'NULL';
             }
-            foreach ($values as &$val) {
-                if ('\N' === $val) {
+            foreach ( $values as &$val ) {
+                if ( '\N' === $val ) {
                     $val = 'NULL';
                 } else {
                     $val = "'" . esc_sql( trim( $val ) ) . "'";
@@ -147,19 +147,19 @@ if ( ! defined( 'DT_FUNCTIONS_READY' ) ){
      * @return bool|int|string
      */
     if ( ! function_exists( 'dt_format_date' ) ) {
-        function dt_format_date( $date, $format = 'short') {
+        function dt_format_date( $date, $format = 'short' ) {
             $date_format = get_option( 'date_format' );
             $time_format = get_option( 'time_format' );
-            if ($format === 'short') {
+            if ( $format === 'short' ) {
                 // $format = $date_format;
                 // formatting it with internationally understood date, as there was a
                 // struggle getting dates to show in user's selected language and not
                 // in the site language.
                 $format = 'Y-m-d';
-            } else if ($format === 'long') {
+            } else if ( $format === 'long' ) {
                 $format = $date_format . ' ' . $time_format;
             }
-            if (is_numeric( $date )) {
+            if ( is_numeric( $date ) ) {
                 $formatted = date_i18n( $format, $date );
             } else {
                 $formatted = mysql2date( $format, $date );
@@ -182,14 +182,14 @@ if ( ! defined( 'DT_FUNCTIONS_READY' ) ){
         }
     }
     if ( ! function_exists( 'dt_get_year_from_timestamp' ) ) {
-        function dt_get_year_from_timestamp( int $time) {
+        function dt_get_year_from_timestamp( int $time ) {
             return gmdate( "Y", $time );
         }
     }
 
     if ( ! function_exists( 'dt_sanitize_array_html' ) ) {
-        function dt_sanitize_array_html( $array) {
-            array_walk_recursive($array, function ( &$v) {
+        function dt_sanitize_array_html( $array ) {
+            array_walk_recursive($array, function ( &$v ) {
                 $v = filter_var( trim( $v ), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES );
             });
             return $array;
@@ -222,7 +222,7 @@ if ( ! defined( 'DT_FUNCTIONS_READY' ) ){
     }
 
     if ( ! function_exists( 'dt_get_available_languages' ) ) {
-        function dt_get_available_languages( $code_as_key = false) {
+        function dt_get_available_languages( $code_as_key = false ) {
             $available_language_codes = get_available_languages( get_template_directory() .'/dt-assets/translation' );
             array_unshift( $available_language_codes, 'en_US' );
             $available_translations = [];
@@ -427,7 +427,7 @@ if ( ! defined( 'DT_FUNCTIONS_READY' ) ){
             ];
 
             foreach ( $available_language_codes as $code ){
-                if ( isset( $translations[$code] )){
+                if ( isset( $translations[$code] ) ){
                     $translations[$code]['site_default'] = $site_default_locale === $translations[$code]["language"];
                     if ( !$code_as_key ){
                         $available_translations[] = $translations[$code];
@@ -500,19 +500,19 @@ if ( ! defined( 'DT_FUNCTIONS_READY' ) ){
 
         $metadata = get_post_meta( $contact_id, $key = 'assigned_to', true );
 
-        if ( !empty( $metadata )) {
+        if ( !empty( $metadata ) ) {
             $meta_array = explode( '-', $metadata ); // Separate the type and id
             $type = $meta_array[0];
             $id = $meta_array[1];
 
-            if ($type == 'user') {
+            if ( $type == 'user' ) {
                 $value = get_user_by( 'id', $id );
                 $rv = $value->display_name;
             } else {
                 $value = get_term( $id );
                 $rv = $value->name;
             }
-            if ($return) {
+            if ( $return ) {
                 return $rv;
             } else {
                 echo esc_html( $rv );
@@ -632,7 +632,7 @@ if ( ! defined( 'DT_FUNCTIONS_READY' ) ){
                     <?php if ( !isset( $fields[$field_key]["default"]["none"] ) && empty( $fields[$field_key]["select_cannot_be_empty"] ) ) : ?>
                         <option value="" <?php echo esc_html( !isset( $post[$field_key] ) ?: "selected" ) ?>></option>
                     <?php endif; ?>
-                    <?php foreach ($fields[$field_key]["default"] as $option_key => $option_value):
+                    <?php foreach ( $fields[$field_key]["default"] as $option_key => $option_value ):
                         if ( !$show_hidden && isset( $option_value["hidden"] ) && $option_value["hidden"] === true ){
                             continue;
                         }

--- a/dt-core/migrations/0000-initial.php
+++ b/dt-core/migrations/0000-initial.php
@@ -17,7 +17,7 @@ class Disciple_Tools_Migration_0000 extends Disciple_Tools_Migration {
     public function up() {
         global $wpdb;
         $expected_tables = $this->get_expected_tables();
-        foreach ( $expected_tables as $name => $table) {
+        foreach ( $expected_tables as $name => $table ) {
             $rv = $wpdb->query( $table ); // WPCS: unprepared SQL OK
             if ( $rv == false ) {
                 throw new Exception( "Got error when creating table $name: $wpdb->last_error" );
@@ -31,7 +31,7 @@ class Disciple_Tools_Migration_0000 extends Disciple_Tools_Migration {
     public function down() {
         global $wpdb;
         $expected_tables = $this->get_expected_tables();
-        foreach ( $expected_tables as $name => $table) {
+        foreach ( $expected_tables as $name => $table ) {
             $rv = $wpdb->query( "DROP TABLE `{$name}`" ); // WPCS: unprepared SQL OK
             if ( $rv == false ) {
                 throw new Exception( "Got error when dropping table $name: $wpdb->last_error" );

--- a/dt-core/migrations/0007-confirm-setup.php
+++ b/dt-core/migrations/0007-confirm-setup.php
@@ -6,7 +6,7 @@ class Disciple_Tools_Migration_0007 extends Disciple_Tools_Migration {
         global $wpdb;
 
         $table_name = $wpdb->prefix . 'p2p';
-        if ($wpdb->get_var( "SHOW TABLES LIKE '$wpdb->p2p'" ) != $table_name ) {
+        if ( $wpdb->get_var( "SHOW TABLES LIKE '$wpdb->p2p'" ) != $table_name ) {
             P2P_Storage::install();
         }
 

--- a/dt-core/migrations/0013-field-changes.php
+++ b/dt-core/migrations/0013-field-changes.php
@@ -10,10 +10,10 @@ class Disciple_Tools_Migration_0013 extends Disciple_Tools_Migration {
         $custom_field_options = dt_get_option( "dt_field_customizations" );
 
         foreach ( $custom_lists as $list_key => $list_field ){
-            if ( in_array( $list_key, [ "seeker_path", "custom_status", "custom_reason_closed", "custom_reason_pause", "custom_reason_unassignable" ] )){
+            if ( in_array( $list_key, [ "seeker_path", "custom_status", "custom_reason_closed", "custom_reason_pause", "custom_reason_unassignable" ] ) ){
                 $list_key = str_replace( "custom_status", "overall_status", $list_key );
                 $key = str_replace( "custom_", "", $list_key );
-                if ( !isset( $custom_field_options["contacts"][$key] )){
+                if ( !isset( $custom_field_options["contacts"][$key] ) ){
                     $custom_field_options["contacts"][$key] = [
                         "default" => []
                     ];
@@ -24,9 +24,9 @@ class Disciple_Tools_Migration_0013 extends Disciple_Tools_Migration {
                     }
                 }
             }
-            if ( in_array( $list_key, [ "custom_church" ] )){
+            if ( in_array( $list_key, [ "custom_church" ] ) ){
                 $key = str_replace( "custom_", "", $list_key );
-                if ( !isset( $custom_field_options["groups"][$key] )){
+                if ( !isset( $custom_field_options["groups"][$key] ) ){
                     $custom_field_options["groups"][$key] = [
                         "default" => []
                     ];

--- a/dt-core/migrations/0037-rebuild-reports-table.php
+++ b/dt-core/migrations/0037-rebuild-reports-table.php
@@ -34,7 +34,7 @@ class Disciple_Tools_Migration_0037 extends Disciple_Tools_Migration {
 
         // create new reports table
         $expected_tables = $this->get_expected_tables();
-        foreach ( $expected_tables as $name => $table) {
+        foreach ( $expected_tables as $name => $table ) {
             $rv = $wpdb->query( $table ); // WPCS: unprepared SQL OK
             if ( $rv == false ) {
                 throw new Exception( "Got error when creating table $name: $wpdb->last_error" );

--- a/dt-core/setup-functions.php
+++ b/dt-core/setup-functions.php
@@ -23,7 +23,7 @@ function dt_setup_roles_and_permissions(){
 
     $role_keys = dt_multi_role_get_role_slugs();
     foreach ( $expected_roles as $role_key => $role_values ){
-        if ( !in_array( $role_key, $role_keys, true )){
+        if ( !in_array( $role_key, $role_keys, true ) ){
             add_role( $role_key, $role_values["label"] ?? "", $role_values["permissions"] ?? [] );
         }
     }
@@ -54,7 +54,7 @@ function dt_setup_roles_and_permissions(){
             //remove permissions if they are set by the $expected_roles
             foreach ( $role->capabilities as $cap_key => $cap_grant ){
                 if ( $cap_grant === true && !isset( $expected_roles[$role_key]["permissions"][$cap_key] ) ){
-                    if ( in_array( $role_key, [ "administrator" ], true ) && !in_array( $cap_key, $dt_permissions, true )){
+                    if ( in_array( $role_key, [ "administrator" ], true ) && !in_array( $cap_key, $dt_permissions, true ) ){
                         continue; //don't remove a non D.T cap from the administrator
                     }
                     $role->remove_cap( $cap_key );

--- a/dt-groups/base-setup.php
+++ b/dt-groups/base-setup.php
@@ -47,7 +47,7 @@ class DT_Groups_Base extends DT_Module_Base {
     }
 
     public function after_setup_theme(){
-        if ( class_exists( 'Disciple_Tools_Post_Type_Template' )) {
+        if ( class_exists( 'Disciple_Tools_Post_Type_Template' ) ) {
             new Disciple_Tools_Post_Type_Template( "groups", __( 'Group', 'disciple_tools' ), __( 'Groups', 'disciple_tools' ) );
         }
     }
@@ -742,7 +742,7 @@ class DT_Groups_Base extends DT_Module_Base {
     private static function check_requires_update( $group_id ){
         if ( get_current_user_id() ){
             $requires_update = get_post_meta( $group_id, "requires_update", true );
-            if ( $requires_update == "yes" || $requires_update == true || $requires_update == "1"){
+            if ( $requires_update == "yes" || $requires_update == true || $requires_update == "1" ){
                 //don't remove update needed if the user is a dispatcher (and not assigned to the groups.)
                 if ( DT_Posts::can_view_all( 'groups' ) ){
                     if ( dt_get_user_id_from_assigned_to( get_post_meta( $group_id, "assigned_to", true ) ) === get_current_user_id() ){
@@ -788,7 +788,7 @@ class DT_Groups_Base extends DT_Module_Base {
 
         // set up the MySQL OR string to get multiple posts at once
         $members_post_ids = [];
-        foreach ($fields["members"] as $member) {
+        foreach ( $fields["members"] as $member ) {
             $member_id = $member['ID'];
             $members_post_ids[] = "post_id = $member_id";
         }
@@ -809,7 +809,7 @@ class DT_Groups_Base extends DT_Module_Base {
 
         // order the results by id in a lookup array
         $results_by_post_id = [];
-        foreach ($results as $result) {
+        foreach ( $results as $result ) {
             if ( !key_exists( $result->post_id, $results_by_post_id ) ) {
                 $results_by_post_id[$result->post_id] = [];
             }
@@ -817,13 +817,13 @@ class DT_Groups_Base extends DT_Module_Base {
         }
 
         // pump the member metadata into the members array of the post
-        foreach ($fields["members"] as $key => $member) {
+        foreach ( $fields["members"] as $key => $member ) {
             $member_id = $member["ID"];
             $member_data = key_exists( $member_id, $results_by_post_id ) ? $results_by_post_id[$member_id] : [];
             $data = [
                 "milestones" => [],
             ];
-            foreach ($member_data as $meta) {
+            foreach ( $member_data as $meta ) {
                 if ( $meta->meta_key === 'milestones' && in_array( $meta->meta_value, $default_milestone_keys, true ) ) {
                     $data["milestones"][] = $milestone_settings[$meta->meta_value];
                 } elseif ( $meta->meta_key === 'overall_status' ) {
@@ -1139,7 +1139,7 @@ class DT_Groups_Base extends DT_Module_Base {
     }
 
     public function dt_record_icon( $icon, $post_type, $contact_id ){
-        if ($post_type == 'groups') {
+        if ( $post_type == 'groups' ) {
             $icon = 'fi-torsos-all';
         }
         return $icon;

--- a/dt-mapping/class-migration-engine.php
+++ b/dt-mapping/class-migration-engine.php
@@ -39,7 +39,7 @@ class DT_Mapping_Module_Migration_Engine
         $expected_migration_number = 0;
         $rv = [];
         foreach ( $filenames as $filename ) {
-            if ( $filename[0] !== "." && $filename !== "abstract.php"){
+            if ( $filename[0] !== "." && $filename !== "abstract.php" ){
                 if ( preg_match( '/^([0-9][0-9][0-9][0-9])(-.*)?\.php$/i', $filename, $matches ) ) {
                     $got_migration_number = intval( $matches[1] );
                     if ( $expected_migration_number !== $got_migration_number ) {
@@ -103,7 +103,7 @@ class DT_Mapping_Module_Migration_Engine
             error_log( gmdate( " Y-m-d H:i:s T" ) . " Starting mapping migrating to number $activating_migration_number" );
             try {
                 $migration->up();
-            } catch (Throwable $e) {
+            } catch ( Throwable $e ) {
                 update_option( 'dt_mapping_module_migrate_last_error', [
                     'message' => $e->getMessage(),
                     'code' => $e->getCode(),
@@ -152,8 +152,8 @@ class DT_Mapping_Module_Migration_Lock_Exception extends Exception
          * error logs, but this is a bit more user-friendly.
          */
         $last_migration_error = get_option( 'dt_mapping_module_migrate_last_error' );
-        if ($message === null) {
-            if ($last_migration_error === false) {
+        if ( $message === null ) {
+            if ( $last_migration_error === false ) {
                 $message = "Cannot migrate, as migration lock is held";
             } else {
                 $message =

--- a/dt-mapping/geocode-api/ipstack-api.php
+++ b/dt-mapping/geocode-api/ipstack-api.php
@@ -338,23 +338,23 @@ if ( ! class_exists( 'DT_Ipstack_API' ) ) {
          * @param $ip_result
          * @return array|false
          */
-        public static function convert_ip_result_to_location_grid_meta( $ip_result) {
-            if (empty( $ip_result['longitude'] )) {
+        public static function convert_ip_result_to_location_grid_meta( $ip_result ) {
+            if ( empty( $ip_result['longitude'] ) ) {
                 return false;
             }
             $geocoder = new Location_Grid_Geocoder();
 
             // prioritize the smallest unit
-            if ( !empty( $ip_result['city'] )) {
+            if ( !empty( $ip_result['city'] ) ) {
                 $label = $ip_result['city'] . ', ' . $ip_result['region_name'] . ', ' . $ip_result['country_name'];
                 $level = "district";
-            } elseif ( !empty( $ip_result['region_name'] )) {
+            } elseif ( !empty( $ip_result['region_name'] ) ) {
                 $label = $ip_result['region_name'] . ', ' . $ip_result['country_name'];
                 $level = "region";
-            } elseif ( !empty( $ip_result['country_name'] )) {
+            } elseif ( !empty( $ip_result['country_name'] ) ) {
                 $label = $ip_result['country_name'];
                 $level = "country";
-            } elseif ( !empty( $ip_result['continent_name'] )) {
+            } elseif ( !empty( $ip_result['continent_name'] ) ) {
                 $label = $ip_result['continent_name'];
                 $level = 'world';
             } else {
@@ -364,7 +364,7 @@ if ( ! class_exists( 'DT_Ipstack_API' ) ) {
 
             $grid_id = $geocoder->get_grid_id_by_lnglat( $ip_result['longitude'], $ip_result['latitude'], $ip_result['country_code'] );
 
-            if (empty( $label )) {
+            if ( empty( $label ) ) {
                 $admin0_grid_id = Disciple_Tools_Mapping_Queries::get_by_grid_id( $grid_id['admin0_grid_id'] );
                 $label = $grid_id['name'] . ', ' . $admin0_grid_id['name'];
             }

--- a/dt-mapping/geocode-api/mapbox-api.php
+++ b/dt-mapping/geocode-api/mapbox-api.php
@@ -523,7 +523,7 @@ if ( ! class_exists( 'DT_Mapbox_API' ) ) {
 
             // main theme check
             $is_theme_dt = strpos( $wp_theme->get_template(), "disciple-tools-theme" ) !== false || $wp_theme->name === "Disciple Tools";
-            if ($is_theme_dt) {
+            if ( $is_theme_dt ) {
                 return true;
             }
 

--- a/dt-mapping/globals.php
+++ b/dt-mapping/globals.php
@@ -68,12 +68,12 @@ if ( ! function_exists( 'dt_get_mapbox_endpoint' ) ) {
     }
 }
 if ( ! function_exists( 'dt_array_to_sql' ) ) {
-    function dt_array_to_sql( $values) {
-        if (empty( $values )) {
+    function dt_array_to_sql( $values ) {
+        if ( empty( $values ) ) {
             return 'NULL';
         }
-        foreach ($values as &$val) {
-            if ('\N' === $val) {
+        foreach ( $values as &$val ) {
+            if ( '\N' === $val ) {
                 $val = 'NULL';
             } else {
                 $val = "'" . esc_sql( trim( $val ) ) . "'";

--- a/dt-mapping/location-grid-meta.php
+++ b/dt-mapping/location-grid-meta.php
@@ -12,23 +12,23 @@ if ( ! class_exists( 'Location_Grid_Meta' ) ) {
          * @param $ip_result
          * @return array|false
          */
-        public static function convert_ip_result_to_location_grid_meta( $ip_result) {
-            if (empty( $ip_result['longitude'] )) {
+        public static function convert_ip_result_to_location_grid_meta( $ip_result ) {
+            if ( empty( $ip_result['longitude'] ) ) {
                 return false;
             }
             $geocoder = new Location_Grid_Geocoder();
 
             // prioritize the smallest unit
-            if ( !empty( $ip_result['city'] )) {
+            if ( !empty( $ip_result['city'] ) ) {
                 $label = $ip_result['city'] . ', ' . $ip_result['region_name'] . ', ' . $ip_result['country_name'];
                 $level = "district";
-            } elseif ( !empty( $ip_result['region_name'] )) {
+            } elseif ( !empty( $ip_result['region_name'] ) ) {
                 $label = $ip_result['region_name'] . ', ' . $ip_result['country_name'];
                 $level = "region";
-            } elseif ( !empty( $ip_result['country_name'] )) {
+            } elseif ( !empty( $ip_result['country_name'] ) ) {
                 $label = $ip_result['country_name'];
                 $level = "country";
-            } elseif ( !empty( $ip_result['continent_name'] )) {
+            } elseif ( !empty( $ip_result['continent_name'] ) ) {
                 $label = $ip_result['continent_name'];
                 $level = 'world';
             } else {
@@ -38,7 +38,7 @@ if ( ! class_exists( 'Location_Grid_Meta' ) ) {
 
             $grid_id = $geocoder->get_grid_id_by_lnglat( $ip_result['longitude'], $ip_result['latitude'], $ip_result['country_code'] );
 
-            if (empty( $label )) {
+            if ( empty( $label ) ) {
                 $admin0_grid_id = Disciple_Tools_Mapping_Queries::get_by_grid_id( $grid_id['admin0_grid_id'] );
                 $label = $grid_id['name'] . ', ' . $admin0_grid_id['name'];
             }
@@ -63,10 +63,10 @@ if ( ! class_exists( 'Location_Grid_Meta' ) ) {
          * @param null $location_grid_meta Can be called null and will return array.
          * @return array Returns a structured array in the location grid meta structure.
          */
-        public static function validate_location_grid_meta( &$location_grid_meta = null): array
+        public static function validate_location_grid_meta( &$location_grid_meta = null ): array
         {
 
-            if (empty( $location_grid_meta )) {
+            if ( empty( $location_grid_meta ) ) {
                 $location_grid_meta = [
                     'grid_meta_id' => '',
                     'post_id' => '',
@@ -78,7 +78,7 @@ if ( ! class_exists( 'Location_Grid_Meta' ) ) {
                     'source' => '',
                     'label' => '',
                 ];
-            } else if (is_serialized( $location_grid_meta )) {
+            } else if ( is_serialized( $location_grid_meta ) ) {
                 $location_grid_meta = maybe_unserialize( $location_grid_meta );
             }
 
@@ -97,34 +97,34 @@ if ( ! class_exists( 'Location_Grid_Meta' ) ) {
             return $filtered_array;
         }
 
-        public static function get_location_grid_meta_by_id( $grid_meta_id) {
+        public static function get_location_grid_meta_by_id( $grid_meta_id ) {
             global $wpdb;
             return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->dt_location_grid_meta WHERE grid_meta_id = %d", $grid_meta_id ), ARRAY_A );
         }
 
-        public static function add_location_grid_meta( $post_id, array $location_grid_meta, $postmeta_id_location_grid = null) {
+        public static function add_location_grid_meta( $post_id, array $location_grid_meta, $postmeta_id_location_grid = null ) {
             global $wpdb;
             $geocoder = new Location_Grid_Geocoder();
 
             self::validate_location_grid_meta( $location_grid_meta );
 
-            if ( !isset( $location_grid_meta['lng'] ) || !isset( $location_grid_meta['lat'] )) {
+            if ( !isset( $location_grid_meta['lng'] ) || !isset( $location_grid_meta['lat'] ) ) {
                 return new WP_Error( __METHOD__, 'Missing required lng or lat' );
             }
 
-            if (empty( $location_grid_meta['grid_id'] )) {
+            if ( empty( $location_grid_meta['grid_id'] ) ) {
                 $grid = $geocoder->get_grid_id_by_lnglat( $location_grid_meta['lng'], $location_grid_meta['lat'] );
-                if ($grid) {
+                if ( $grid ) {
                     $location_grid_meta['grid_id'] = $grid['grid_id'];
                 } else {
                     return new WP_Error( __METHOD__, 'Invalid lng or lat. Unable to retrieve grid_id' );
                 }
             }
 
-            if ( !$postmeta_id_location_grid) {
+            if ( !$postmeta_id_location_grid ) {
                 $postmeta_id_location_grid = add_post_meta( $post_id, 'location_grid', $location_grid_meta['grid_id'] );
             }
-            if ( !$postmeta_id_location_grid) {
+            if ( !$postmeta_id_location_grid ) {
                 return new WP_Error( __METHOD__, 'Unable to create location_grid post meta and retrieve a key.' );
             }
 
@@ -153,13 +153,13 @@ if ( ! class_exists( 'Location_Grid_Meta' ) ) {
             ];
 
             $wpdb->insert( $wpdb->dt_location_grid_meta, $data, $format );
-            if ( !$wpdb->insert_id) {
+            if ( !$wpdb->insert_id ) {
                 delete_meta( $postmeta_id_location_grid );
                 return new WP_Error( __METHOD__, 'Failed to insert location_grid_meta record.' );
             }
 
             $location_grid_meta_mid = add_post_meta( $post_id, 'location_grid_meta', $wpdb->insert_id );
-            if ( !$location_grid_meta_mid) {
+            if ( !$location_grid_meta_mid ) {
                 delete_meta( $postmeta_id_location_grid );
                 self::delete_location_grid_meta( $post_id, 'grid_meta_id', $wpdb->insert_id );
                 return new WP_Error( __METHOD__, 'Failed to add location_grid_meta' );
@@ -169,19 +169,19 @@ if ( ! class_exists( 'Location_Grid_Meta' ) ) {
 
         }
 
-        public static function delete_location_grid_meta( int $post_id, $type, int $value, array $existing_post = null) {
+        public static function delete_location_grid_meta( int $post_id, $type, int $value, array $existing_post = null ) {
             global $wpdb;
 
             $status = false;
 
-            if ('all' === $type) {
+            if ( 'all' === $type ) {
                 $wpdb->delete( $wpdb->dt_location_grid_meta, [ "post_id" => $post_id ] );
                 $status = true;
             }
 
-            if ($value) {
+            if ( $value ) {
 
-                switch ($type) {
+                switch ( $type ) {
                     case 'grid_meta_id':
                         $postmeta_id_location_grid = $wpdb->get_var( $wpdb->prepare( "SELECT postmeta_id_location_grid FROM $wpdb->dt_location_grid_meta WHERE grid_meta_id = %d", $value ) );
 
@@ -213,14 +213,14 @@ if ( ! class_exists( 'Location_Grid_Meta' ) ) {
                 return new WP_Error( __METHOD__, 'Missing required lng or lat' );
             }
 
-            if ( empty( $location_grid_meta['grid_id'] )) {
+            if ( empty( $location_grid_meta['grid_id'] ) ) {
                 if ( $location_grid_meta['level'] === 'country' ) {
                     $location_grid_meta['level'] = 'admin0';
                 } else if ( $location_grid_meta['level'] === 'region' ) {
                     $location_grid_meta['level'] = 'admin1';
                 }
                 $grid = $geocoder->get_grid_id_by_lnglat( $location_grid_meta['lng'], $location_grid_meta['lat'], null, $location_grid_meta['level'] );
-                if ($grid) {
+                if ( $grid ) {
                     $location_grid_meta['grid_id'] = $grid['grid_id'];
                     $location_grid_meta['post_type'] = 'users';
                 } else {
@@ -228,10 +228,10 @@ if ( ! class_exists( 'Location_Grid_Meta' ) ) {
                 }
             }
 
-            if ( !$postmeta_id_location_grid) {
+            if ( !$postmeta_id_location_grid ) {
                 $postmeta_id_location_grid = add_user_meta( $user_id, $wpdb->prefix . 'location_grid', $location_grid_meta['grid_id'] );
             }
-            if ( !$postmeta_id_location_grid) {
+            if ( !$postmeta_id_location_grid ) {
                 return new WP_Error( __METHOD__, 'Unable to create location_grid post meta and retrieve a key.' );
             }
 
@@ -260,13 +260,13 @@ if ( ! class_exists( 'Location_Grid_Meta' ) ) {
             ];
 
             $wpdb->insert( $wpdb->dt_location_grid_meta, $data, $format );
-            if ( !$wpdb->insert_id) {
+            if ( !$wpdb->insert_id ) {
                 delete_user_meta( $user_id, $wpdb->prefix . 'location_grid', $location_grid_meta['grid_id'] );
                 return new WP_Error( __METHOD__, 'Failed to insert location_grid_meta record.' );
             }
 
             $location_grid_meta_mid = add_user_meta( $user_id, $wpdb->prefix . 'location_grid_meta', $wpdb->insert_id );
-            if ( !$location_grid_meta_mid) {
+            if ( !$location_grid_meta_mid ) {
                 delete_user_meta( $user_id, $wpdb->prefix . 'location_grid_meta', $wpdb->insert_id );
                 self::delete_user_location_grid_meta( $user_id, 'grid_meta_id', $wpdb->insert_id ); // @todo verify if needed
                 return new WP_Error( __METHOD__, 'Failed to add location_grid_meta' );
@@ -281,7 +281,7 @@ if ( ! class_exists( 'Location_Grid_Meta' ) ) {
 
             $status = false;
 
-            if ('all' === $type) {
+            if ( 'all' === $type ) {
                 $wpdb->delete( $wpdb->dt_location_grid_meta, [
                     "post_id" => $user_id,
                     "post_type" => "users"
@@ -289,9 +289,9 @@ if ( ! class_exists( 'Location_Grid_Meta' ) ) {
                 $status = true;
             }
 
-            if ($grid_meta_id) {
+            if ( $grid_meta_id ) {
 
-                switch ($type) {
+                switch ( $type ) {
                     case 'grid_meta_id':
                         $postmeta_id_location_grid = $wpdb->get_var( $wpdb->prepare( "SELECT postmeta_id_location_grid FROM $wpdb->dt_location_grid_meta WHERE grid_meta_id = %d", $grid_meta_id ) );
 

--- a/dt-mapping/mapping-admin.php
+++ b/dt-mapping/mapping-admin.php
@@ -1873,8 +1873,8 @@ if ( ! class_exists( 'DT_Mapping_Module_Admin' ) ) {
         }
 
 
-        public function dt_sanitize_array_html( $array) {
-            array_walk_recursive($array, function ( &$v) {
+        public function dt_sanitize_array_html( $array ) {
+            array_walk_recursive($array, function ( &$v ) {
                 $v = filter_var( trim( $v ), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES );
             });
             return $array;
@@ -1892,7 +1892,7 @@ if ( ! class_exists( 'DT_Mapping_Module_Admin' ) ) {
                             $selected_location_grid = sanitize_text_field( wp_unslash( $migration_values["geoid"] ) );
                             $migration_type = sanitize_text_field( wp_unslash( $migration_values["migration_type"] ) );
                             $location = get_post( $location_id );
-                            if ( empty( $selected_location_grid )){
+                            if ( empty( $selected_location_grid ) ){
                                 $selected_location_grid = '1';
                             }
                             $location_grid = Disciple_Tools_Mapping_Queries::get_by_grid_id( $selected_location_grid );
@@ -2422,19 +2422,19 @@ if ( ! class_exists( 'DT_Mapping_Module_Admin' ) ) {
             curl_setopt( $ch_start, CURLOPT_SSL_VERIFYPEER, 0 );
             curl_setopt( $ch_start, CURLOPT_FILE, $zip_resource );
             $page = curl_exec( $ch_start );
-            if ( !$page)
+            if ( !$page )
             {
                 error_log( "Error :- ".curl_error( $ch_start ) );
             }
             curl_close( $ch_start );
 
-            if ( !class_exists( 'ZipArchive' )){
+            if ( !class_exists( 'ZipArchive' ) ){
                 error_log( "PHP ZipArchive is not installed or enabled." );
                 return;
             }
             $zip = new ZipArchive();
             $extract_path = $uploads_dir . 'location_grid_download';
-            if ($zip->open( $zip_file ) != "true")
+            if ( $zip->open( $zip_file ) != "true" )
             {
                 error_log( "Error :- Unable to open the Zip File" );
             }
@@ -2751,7 +2751,7 @@ if ( ! class_exists( 'DT_Mapping_Module_Admin' ) ) {
             $uploads_dir = trailingslashit( $dir['basedir'] );
             // load list to array, make geonameid key
             $geonames_ref = [];
-            $geonmes_ref_raw = array_map( function( $v){return str_getcsv( $v, "\t" );
+            $geonmes_ref_raw = array_map( function( $v ){return str_getcsv( $v, "\t" );
             }, file( $uploads_dir . "location_grid_download/geonames_ref_table.tsv" ) );
             if ( empty( $geonmes_ref_raw ) ) {
                 throw new Exception( 'Failed to build array from remote file.' );
@@ -2780,7 +2780,7 @@ if ( ! class_exists( 'DT_Mapping_Module_Admin' ) ) {
                             unset( $filter["query"]["locations"] );
                             foreach ( $filter["labels"] as &$label ){
                                 if ( $label["field"] === "locations" ){
-                                    if ( isset( $migrated[$label["id"]]["selected_location_grid"] )){
+                                    if ( isset( $migrated[$label["id"]]["selected_location_grid"] ) ){
                                         $label["field"] = "location_grid";
                                         $label["id"] = $migrated[$label["id"]]["selected_location_grid"];
                                     }
@@ -2798,8 +2798,8 @@ if ( ! class_exists( 'DT_Mapping_Module_Admin' ) ) {
                             unset( $filter["query"]["locations"] );
                             unset( $filter["query"]["geonames"] );
                             foreach ( $filter["labels"] as &$label ){
-                                if ( $label["field"] === "geonames") {
-                                    if ( isset( $geonames_ref[ $label["id"]] )){
+                                if ( $label["field"] === "geonames" ) {
+                                    if ( isset( $geonames_ref[ $label["id"]] ) ){
                                         $label["field"] = "location_grid";
                                         $label["id"] = $geonames_ref[ $label["id"]]["grid_id"];
                                     }

--- a/dt-mapping/mapping.php
+++ b/dt-mapping/mapping.php
@@ -573,7 +573,7 @@ if ( ! class_exists( 'DT_Mapping_Module' ) ) {
          * @param      $bind_function
          * @param null $grid_id
          */
-        public function drill_down_widget( $bind_function, $grid_id = null) {
+        public function drill_down_widget( $bind_function, $grid_id = null ) {
             $dd_array = $this->drill_down_array( $grid_id );
 
             if ( empty( $dd_array[0]['list'] ) ) {

--- a/dt-mapping/migrations/0004-location-grid-table.php
+++ b/dt-mapping/migrations/0004-location-grid-table.php
@@ -14,7 +14,7 @@ class DT_Mapping_Module_Migration_0004 extends DT_Mapping_Module_Migration {
          */
         global $wpdb;
         $expected_tables = $this->get_expected_tables();
-        foreach ( $expected_tables as $name => $table) {
+        foreach ( $expected_tables as $name => $table ) {
             $rv = $wpdb->query( $table ); // WPCS: unprepared SQL OK
             if ( $rv == false ) {
                 dt_write_log( "Got error when creating table $name: $wpdb->last_error" );

--- a/dt-mapping/migrations/0005-prepare-location-grid-data.php
+++ b/dt-mapping/migrations/0005-prepare-location-grid-data.php
@@ -47,19 +47,19 @@ class DT_Mapping_Module_Migration_0005 extends DT_Mapping_Module_Migration {
         curl_setopt( $ch_start, CURLOPT_SSL_VERIFYPEER, 0 );
         curl_setopt( $ch_start, CURLOPT_FILE, $zip_resource );
         $page = curl_exec( $ch_start );
-        if ( !$page)
+        if ( !$page )
         {
             error_log( "Error :- ".curl_error( $ch_start ) );
         }
         curl_close( $ch_start );
 
-        if ( !class_exists( 'ZipArchive' )){
+        if ( !class_exists( 'ZipArchive' ) ){
             error_log( "PHP ZipArchive is not installed or enabled." );
             throw new Exception( 'PHP ZipArchive is not installed or enabled.' );
         }
         $zip = new ZipArchive();
         $extract_path = $uploads_dir . 'location_grid_download';
-        if ($zip->open( $zip_file ) != "true")
+        if ( $zip->open( $zip_file ) != "true" )
         {
             error_log( "Error :- Unable to open the Zip File" );
         }

--- a/dt-mapping/migrations/0007-migrate-geonames-to-location-grid.php
+++ b/dt-mapping/migrations/0007-migrate-geonames-to-location-grid.php
@@ -69,19 +69,19 @@ class DT_Mapping_Module_Migration_0007 extends DT_Mapping_Module_Migration {
             curl_setopt( $ch_start, CURLOPT_SSL_VERIFYPEER, 0 );
             curl_setopt( $ch_start, CURLOPT_FILE, $zip_resource );
             $page = curl_exec( $ch_start );
-            if ( !$page)
+            if ( !$page )
             {
                 error_log( "Error :- ".curl_error( $ch_start ) );
             }
             curl_close( $ch_start );
 
-            if ( ! class_exists( 'ZipArchive' )){
+            if ( ! class_exists( 'ZipArchive' ) ){
                 error_log( "PHP ZipArchive is not installed or enabled." );
                 throw new Exception( 'PHP ZipArchive is not installed or enabled.' );
             }
             $zip = new ZipArchive();
             $extract_path = $uploads_dir . 'location_grid_download';
-            if ($zip->open( $zip_file ) != "true")
+            if ( $zip->open( $zip_file ) != "true" )
             {
                 error_log( "Error :- Unable to open the Zip File" );
             }
@@ -98,7 +98,7 @@ class DT_Mapping_Module_Migration_0007 extends DT_Mapping_Module_Migration {
 
             // load list to array, make geonameid key
             $geonames_ref = [];
-            $geonmes_ref_raw = array_map( function( $v){return str_getcsv( $v, "\t" );
+            $geonmes_ref_raw = array_map( function( $v ){return str_getcsv( $v, "\t" );
             }, file( $uploads_dir . "location_grid_download/geonames_ref_table.tsv" ) );
             if ( empty( $geonmes_ref_raw ) ) {
                 throw new Exception( 'Failed to build array from remote file.' );

--- a/dt-mapping/migrations/0009-filters.php
+++ b/dt-mapping/migrations/0009-filters.php
@@ -69,7 +69,7 @@ class DT_Mapping_Module_Migration_0009 extends DT_Mapping_Module_Migration {
 
         // load list to array, make geonameid key
         $geonames_ref = [];
-        $geonmes_ref_raw = array_map( function( $v){return str_getcsv( $v, "\t" );
+        $geonmes_ref_raw = array_map( function( $v ){return str_getcsv( $v, "\t" );
         }, file( $uploads_dir . "location_grid_download/geonames_ref_table.tsv" ) );
         if ( empty( $geonmes_ref_raw ) ) {
             throw new Exception( 'Failed to build array from remote file.' );

--- a/dt-mapping/migrations/0010-add-location-grid-meta-tb.php
+++ b/dt-mapping/migrations/0010-add-location-grid-meta-tb.php
@@ -15,7 +15,7 @@ class DT_Mapping_Module_Migration_0010 extends DT_Mapping_Module_Migration {
          */
         global $wpdb;
         $expected_tables = $this->get_expected_tables();
-        foreach ( $expected_tables as $name => $table) {
+        foreach ( $expected_tables as $name => $table ) {
             $rv = $wpdb->query( $table ); // WPCS: unprepared SQL OK
             if ( $rv == false ) {
                 dt_write_log( "Got error when creating table $name: $wpdb->last_error" );

--- a/dt-metrics/charts-base.php
+++ b/dt-metrics/charts-base.php
@@ -131,7 +131,7 @@ abstract class DT_Metrics_Chart_Base
     public function _no_results() {
         return '<p>'. esc_attr__( 'No Results', 'disciple_tools' ) .'</p>';
     }
-    public function _circular_structure_error( $wp_error) {
+    public function _circular_structure_error( $wp_error ) {
         $link = false;
         $data = $wp_error->get_error_data();
 

--- a/dt-metrics/combined/critical-path.php
+++ b/dt-metrics/combined/critical-path.php
@@ -195,7 +195,7 @@ class DT_Metrics_Critical_Path_Chart extends DT_Metrics_Chart_Base
         $data = [];
         $manual_additions = Disciple_Tools_Counter_Outreach::get_monthly_reports_count( $start, $end );
         foreach ( $manual_additions as $addition_key => $addition ) {
-            if ( $addition["section"] == "outreach") {
+            if ( $addition["section"] == "outreach" ) {
                 $data[] = [
                     "description" => $addition["description"],
                     "key" => $addition_key,
@@ -336,7 +336,7 @@ class DT_Metrics_Critical_Path_Chart extends DT_Metrics_Chart_Base
             "type" => "ongoing"
         ];
         foreach ( $manual_additions as $addition_key => $addition ) {
-            if ( $addition["section"] == "movement") {
+            if ( $addition["section"] == "movement" ) {
                 $data[] = [
                     "description" => $addition["description"],
                     "key" => $addition_key,

--- a/dt-metrics/combined/time-charts.php
+++ b/dt-metrics/combined/time-charts.php
@@ -53,7 +53,7 @@ class DT_Metrics_Time_Charts extends DT_Metrics_Chart_Base
         $post_types = array_values( array_diff( $post_types, [ "peoplegroups" ] ) ); //skip people groups for now.
         $this->post_types = $post_types;
         $post_type_options = [];
-        foreach ($post_types as $post_type) {
+        foreach ( $post_types as $post_type ) {
             $post_type_options[$post_type] = DT_Posts::get_label_for_post_type( $post_type );
         }
 
@@ -239,7 +239,7 @@ class DT_Metrics_Time_Charts extends DT_Metrics_Chart_Base
 
         $field_settings = [];
 
-        foreach ($post_field_settings as $key => $setting) {
+        foreach ( $post_field_settings as $key => $setting ) {
             if ( array_key_exists( 'hidden', $setting ) && $setting['hidden'] === true ) {
                 continue;
             }
@@ -256,7 +256,7 @@ class DT_Metrics_Time_Charts extends DT_Metrics_Chart_Base
 
     public function create_select_options_from_field_settings( $field_settings ) {
         $select_options = [];
-        foreach ($field_settings as $key => $setting) {
+        foreach ( $field_settings as $key => $setting ) {
             $select_options[$key] = $setting['name'];
         }
         asort( $select_options );

--- a/dt-metrics/contacts/baptism-tree.php
+++ b/dt-metrics/contacts/baptism-tree.php
@@ -81,7 +81,7 @@ class DT_Metrics_Contacts_Baptism_Tree extends DT_Metrics_Chart_Base
 
     public function get_baptism_generations_tree(){
         $query = dt_queries()->tree( 'multiplying_baptisms_only' );
-        if ( is_wp_error( $query )){
+        if ( is_wp_error( $query ) ){
             return $this->_circular_structure_error( $query );
         }
         if ( empty( $query ) ) {
@@ -91,10 +91,10 @@ class DT_Metrics_Contacts_Baptism_Tree extends DT_Metrics_Chart_Base
         return $this->build_menu( 0, $menu_data, -1 );
     }
 
-    public function build_menu( $parent_id, $menu_data, $gen, $unique_check = []) {
+    public function build_menu( $parent_id, $menu_data, $gen, $unique_check = [] ) {
         $html = '';
 
-        if (isset( $menu_data['parents'][$parent_id] ))
+        if ( isset( $menu_data['parents'][$parent_id] ) )
         {
             $gen++;
 
@@ -104,7 +104,7 @@ class DT_Metrics_Contacts_Baptism_Tree extends DT_Metrics_Chart_Base
             }
 
             $html = '<ul class="ul-gen-'.esc_html( $gen ).'">';
-            foreach ($menu_data['parents'][$parent_id] as $item_id)
+            foreach ( $menu_data['parents'][$parent_id] as $item_id )
             {
                 $html .= '<li class="gen-node li-gen-' . esc_html( $gen ) . ' ' . esc_attr( $first_section ) . '">';
                 $html .= '(' . esc_html( $gen ) . ') ';
@@ -124,7 +124,7 @@ class DT_Metrics_Contacts_Baptism_Tree extends DT_Metrics_Chart_Base
         return $html;
     }
 
-    public function prepare_menu_array( $query) {
+    public function prepare_menu_array( $query ) {
         // prepare special array with parent-child relations
         $menu_data = array(
             'items' => array(),

--- a/dt-metrics/contacts/coaching-tree.php
+++ b/dt-metrics/contacts/coaching-tree.php
@@ -83,7 +83,7 @@ class DT_Metrics_Coaching_Tree extends DT_Metrics_Chart_Base
 
     public function get_baptism_generations_tree(){
         $query = dt_queries()->tree( 'multiplying_coaching_only' );
-        if ( is_wp_error( $query )){
+        if ( is_wp_error( $query ) ){
             return $this->_circular_structure_error( $query );
         }
         if ( empty( $query ) ) {
@@ -93,10 +93,10 @@ class DT_Metrics_Coaching_Tree extends DT_Metrics_Chart_Base
         return $this->build_menu( 0, $menu_data, -1 );
     }
 
-    public function build_menu( $parent_id, $menu_data, $gen, $unique_check = []) {
+    public function build_menu( $parent_id, $menu_data, $gen, $unique_check = [] ) {
         $html = '';
 
-        if (isset( $menu_data['parents'][$parent_id] ))
+        if ( isset( $menu_data['parents'][$parent_id] ) )
         {
             $gen++;
 
@@ -106,7 +106,7 @@ class DT_Metrics_Coaching_Tree extends DT_Metrics_Chart_Base
             }
 
             $html = '<ul class="ul-gen-'. esc_attr( $gen ).'">';
-            foreach ($menu_data['parents'][$parent_id] as $item_id)
+            foreach ( $menu_data['parents'][$parent_id] as $item_id )
             {
                 $html .= '<li class="gen-node li-gen-' . esc_attr( $gen ) . ' ' . esc_attr( $first_section ) . '">';
                 $html .= '(' . esc_attr( $gen ) . ') ';
@@ -126,7 +126,7 @@ class DT_Metrics_Coaching_Tree extends DT_Metrics_Chart_Base
         return $html;
     }
 
-    public function prepare_menu_array( $query) {
+    public function prepare_menu_array( $query ) {
         // prepare special array with parent-child relations
         $menu_data = array(
             'items' => array(),

--- a/dt-metrics/contacts/sources.php
+++ b/dt-metrics/contacts/sources.php
@@ -125,18 +125,18 @@ class DT_Metrics_Sources_Chart extends DT_Metrics_Chart_Base
             return new WP_Error( __FUNCTION__, "Permission required: view all contacts", [ 'status' => 403 ] );
         }
         try {
-            if (isset( $params['from'] ) && isset( $params['to'] ) ) {
+            if ( isset( $params['from'] ) && isset( $params['to'] ) ) {
                 self::check_date_string( $params['from'] );
                 self::check_date_string( $params['to'] );
                 return self::get_source_data_from_db( $params['from'], $params['to'] );
-            } if (isset( $params['start'] ) && isset( $params['end'] ) ) {
+            } if ( isset( $params['start'] ) && isset( $params['end'] ) ) {
                 self::check_date_string( $params['start'] );
                 self::check_date_string( $params['end'] );
                 return self::get_source_data_from_db( $params['start'], $params['end'] );
             } else {
                 return self::get_source_data_from_db();
             }
-        } catch (Exception $e) {
+        } catch ( Exception $e ) {
             error_log( $e );
             return new WP_Error( __FUNCTION__, "got error ", [ 'status' => 500 ] );
         }
@@ -202,16 +202,16 @@ class DT_Metrics_Sources_Chart extends DT_Metrics_Chart_Base
 
         $rv = [];
 
-        foreach ($rows as $row) {
+        foreach ( $rows as $row ) {
             $source = $row['sources'] ?? 'null';
             $status = 'status_' . ( $row['overall_status'] ?? 'null' );
             $rv[$source]['name_of_source'] = $source;
             $rv[$source][$status] = ( $rv[$source][$status] ?? 0 ) + (int) $row['count'];
             $rv[$source]['total'] = ( $rv[$source]['total'] ?? 0 ) + (int) $row['count'];
-            if ( !isset( $rv[$source]['total_active_seeker_path'] )) {
+            if ( !isset( $rv[$source]['total_active_seeker_path'] ) ) {
                 $rv[$source]['total_active_seeker_path'] = 0;
             }
-            if ($row['overall_status'] == 'active') {
+            if ( $row['overall_status'] == 'active' ) {
                 $rv[$source]['total_active_seeker_path'] += (int) $row['count'];
                 $rv[$source]['active_seeker_path_' . ( $row['seeker_path'] ?? 'null' )] = (int) $row['count'];
             }
@@ -226,8 +226,8 @@ class DT_Metrics_Sources_Chart extends DT_Metrics_Chart_Base
 
         $milestones = self::get_sources_milestones( $from, $to );
 
-        foreach ($milestones as $source => $milestone_data) {
-            foreach ($milestone_data as $key => $value) {
+        foreach ( $milestones as $source => $milestone_data ) {
+            foreach ( $milestone_data as $key => $value ) {
                 $rv[$source][$key] = $value;
             }
         }
@@ -275,7 +275,7 @@ class DT_Metrics_Sources_Chart extends DT_Metrics_Chart_Base
         // phpcs:enable
 
         $rv = [];
-        foreach ($rows as $row) {
+        foreach ( $rows as $row ) {
             $source = $row['sources'] ?? 'null';
             $rv[$source]['name_of_source'] = $source;
             $rv[$source]['active_' . $row['milestone']] = (int) $row['count'];

--- a/dt-metrics/counter.php
+++ b/dt-metrics/counter.php
@@ -57,7 +57,7 @@ class Disciple_Tools_Counter
      */
     public static function critical_path( string $step_name = 'all', $start = null, $end = null, $args = [] ) {
 
-        if ( $start === null){
+        if ( $start === null ){
             $start = 0;
         }
         if ( $end === null ){
@@ -693,7 +693,7 @@ class Disciple_Tools_Queries
             $parent_id = $node["parent_id"] ?? $node["parentId"];
             if ( in_array( (int) $parent_id, $node_ids ) ){
                 //if the node is already in the tree
-                if ( in_array( (int) $node["id"], $parents, true )){
+                if ( in_array( (int) $node["id"], $parents, true ) ){
                     return (int) $node["id"]; //return the ID of the node
                 }
                 $node["done"] = true; //lets us look at what nodes where not processed later

--- a/dt-metrics/counters/counter-baptism.php
+++ b/dt-metrics/counters/counter-baptism.php
@@ -77,7 +77,7 @@ class Disciple_Tools_Counter_Baptism extends Disciple_Tools_Counter_Base  {
                 }
             }
             self::$generations[ $start . $end ] = $baptism_generations_this_year;
-            if ( !isset( self::$total[ $start . $end ] )){
+            if ( !isset( self::$total[ $start . $end ] ) ){
                 $total_baptisms = array_sum( $baptism_generations_this_year );
                 self::$total[$start . $end] = $total_baptisms;
             }
@@ -221,8 +221,8 @@ class Disciple_Tools_Counter_Baptism extends Disciple_Tools_Counter_Base  {
                 "ids" => []
             ];
         }
-        foreach ($elements as $element_i => $element) {
-            if ($element['parent_id'] == $parent_id) {
+        foreach ( $elements as $element_i => $element ) {
+            if ( $element['parent_id'] == $parent_id ) {
                 //find and remove if the baptisms has already been counted on a longer path
                 //we keep the shorter path
                 $already_counted_in_deeper_path = false;
@@ -233,7 +233,7 @@ class Disciple_Tools_Counter_Baptism extends Disciple_Tools_Counter_Base  {
                             unset( $counts[ $count_i ]["ids"][array_search( $element['id'], $count["ids"] )] );
                         }
                     } else {
-                        if (in_array( $element['id'], $count["ids"] )){
+                        if ( in_array( $element['id'], $count["ids"] ) ){
                             $already_counted_in_deeper_path = true;
                         }
                     }
@@ -310,7 +310,7 @@ class Disciple_Tools_Counter_Baptism extends Disciple_Tools_Counter_Base  {
                 AND b.p2p_to = %s
             ", $contact_id), ARRAY_A);
             foreach ( $children as $child ){
-                if ( !in_array( $child["contact_id"], $parent_ids )){
+                if ( !in_array( $child["contact_id"], $parent_ids ) ){
                     self::reset_baptism_generations_on_contact_tree( $child["contact_id"], $parent_ids );
                 }
             }

--- a/dt-metrics/counters/counter-connected.php
+++ b/dt-metrics/counters/counter-connected.php
@@ -33,7 +33,7 @@ class Disciple_Tools_Counter_Connected extends Disciple_Tools_Counter_Base  {
         global $wpdb;
 
         $post_type = 'contacts';
-        if ($type == 'groups_to_groups') { $post_type = 'groups'; }
+        if ( $type == 'groups_to_groups' ) { $post_type = 'groups'; }
 
         // Get values
         $total_contacts = wp_count_posts( $post_type )->publish;
@@ -77,8 +77,8 @@ class Disciple_Tools_Counter_Connected extends Disciple_Tools_Counter_Base  {
         ), ARRAY_A );
         $p2p_distinct = array_unique( $p2p_array_to, SORT_REGULAR );
 
-        foreach ($p2p_distinct as $item) {
-            if ($this->get_number_disciples( $item, $p2p_array_to ) >= $min_number) {
+        foreach ( $p2p_distinct as $item ) {
+            if ( $this->get_number_disciples( $item, $p2p_array_to ) >= $min_number ) {
                 $i++;
             };
         }
@@ -110,8 +110,8 @@ class Disciple_Tools_Counter_Connected extends Disciple_Tools_Counter_Base  {
         ), ARRAY_A );
         $p2p_distinct = array_unique( $p2p_array_to, SORT_REGULAR );
 
-        foreach ($p2p_distinct as $item) {
-            if ($this->get_number_disciples( $item, $p2p_array_to ) == $exact_number) {
+        foreach ( $p2p_distinct as $item ) {
+            if ( $this->get_number_disciples( $item, $p2p_array_to ) == $exact_number ) {
                 $i++;
             };
         }
@@ -129,8 +129,8 @@ class Disciple_Tools_Counter_Connected extends Disciple_Tools_Counter_Base  {
     protected function get_number_disciples( $contact, $column ) {
         $i = 0;
 
-        foreach ($column as $item) {
-            if ($item == $contact) {
+        foreach ( $column as $item ) {
+            if ( $item == $contact ) {
                 $i++;
             }
         }

--- a/dt-metrics/counters/counter-generations-status.php
+++ b/dt-metrics/counters/counter-generations-status.php
@@ -34,8 +34,8 @@ class Disciple_Tools_Counter_Generations extends Disciple_Tools_Counter_Base  {
         $i = 0;
         $list = $this->generation_status_list( $type );
 
-        foreach ($list as $item) {
-            if ($item == $level) {
+        foreach ( $list as $item ) {
+            if ( $item == $level ) {
                 $i++; // counts how many records at that generation level
             }
         }
@@ -75,9 +75,9 @@ class Disciple_Tools_Counter_Generations extends Disciple_Tools_Counter_Base  {
         $full_p2p_array = array_unique( array_merge( $full_p2p_array, $p2p_array_to, $p2p_array_from ), SORT_REGULAR );
 
         // Run checks on every contact in discipleship
-        foreach ($full_p2p_array as $contact) {
+        foreach ( $full_p2p_array as $contact ) {
             // Check if contact is first generation. If true, create array item and move to next item in loop.
-            if ($this->zero_generation_check( $contact, $p2p_array_from )) {
+            if ( $this->zero_generation_check( $contact, $p2p_array_from ) ) {
                 $gen_count[ $contact ] = 0;
             }
 
@@ -89,8 +89,8 @@ class Disciple_Tools_Counter_Generations extends Disciple_Tools_Counter_Base  {
                 $gen_ids = [];
                 $i = 1;
 
-                while (true) {
-                    if ( ! $this->zero_generation_check( $target_inc, $p2p_array_from )) { // is initial condition true
+                while ( true ) {
+                    if ( ! $this->zero_generation_check( $target_inc, $p2p_array_from ) ) { // is initial condition true
 
                         // get the parent id & replace target with parent id
                         $parent_id = $this->get_parent_id( $target_inc, $p2p_array );
@@ -121,8 +121,8 @@ class Disciple_Tools_Counter_Generations extends Disciple_Tools_Counter_Base  {
     protected function get_parent_id( $target, $p2p_array ) {
         $parent = '';
 
-        foreach ($p2p_array as $row) {
-            if ($row['p2p_from'] == $target) {
+        foreach ( $p2p_array as $row ) {
+            if ( $row['p2p_from'] == $target ) {
                 $parent = $row['p2p_to'];
             }
         }
@@ -138,8 +138,8 @@ class Disciple_Tools_Counter_Generations extends Disciple_Tools_Counter_Base  {
      * @return bool
      */
     protected function zero_generation_check( $contact, $p2p_array_from ) {
-        foreach ($p2p_array_from as $value) {
-            if ($value == $contact) {
+        foreach ( $p2p_array_from as $value ) {
+            if ( $value == $contact ) {
                 return false;
             }
         }

--- a/dt-metrics/counters/counter-groups.php
+++ b/dt-metrics/counters/counter-groups.php
@@ -238,9 +238,9 @@ class Disciple_Tools_Counter_Groups extends Disciple_Tools_Counter_Base  {
                 "total" => 0
             ];
         }
-        foreach ($elements as $element) {
+        foreach ( $elements as $element ) {
 
-            if ($element['parent_id'] == $parent_id) {
+            if ( $element['parent_id'] == $parent_id ) {
                 if ( in_array( $element['id'], $ids_to_include ) ) {
                     if ( $element["group_type"] === "pre-group" ) {
                         $counts[ $generation ]["pre-group"] ++;

--- a/dt-metrics/groups/tree.php
+++ b/dt-metrics/groups/tree.php
@@ -95,7 +95,7 @@ class DT_Metrics_Groups_Tree extends DT_Metrics_Chart_Base
 
     public function get_group_generations_tree(){
         $query = dt_queries()->tree( 'multiplying_groups_only' );
-        if ( is_wp_error( $query )){
+        if ( is_wp_error( $query ) ){
             return $this->_circular_structure_error( $query );
         }
         if ( empty( $query ) ) {
@@ -105,7 +105,7 @@ class DT_Metrics_Groups_Tree extends DT_Metrics_Chart_Base
         return $this->build_group_tree( 0, $menu_data, 0 );
     }
 
-    public function prepare_menu_array( $query) {
+    public function prepare_menu_array( $query ) {
         // prepare special array with parent-child relations
         $menu_data = array(
             'items' => array(),
@@ -120,10 +120,10 @@ class DT_Metrics_Groups_Tree extends DT_Metrics_Chart_Base
         return $menu_data;
     }
 
-    public function build_group_tree( $parent_id, $menu_data, $gen) {
+    public function build_group_tree( $parent_id, $menu_data, $gen ) {
         $html = '';
 
-        if (isset( $menu_data['parents'][$parent_id] ))
+        if ( isset( $menu_data['parents'][$parent_id] ) )
         {
             $first_section = '';
             if ( $gen === 0 ) {
@@ -132,7 +132,7 @@ class DT_Metrics_Groups_Tree extends DT_Metrics_Chart_Base
 
             $html = '<ul class="ul-gen-'.esc_html( $gen ).'">';
             $gen++;
-            foreach ($menu_data['parents'][$parent_id] as $item_id)
+            foreach ( $menu_data['parents'][$parent_id] as $item_id )
             {
                 $html .= '<li class="gen-node li-gen-' . esc_html( $gen ) . ' ' . esc_html( $first_section ) . '">';
                 $html .= '<span class="' . esc_html( $menu_data['items'][ $item_id ]['group_status'] ) . ' ' . esc_html( $menu_data['items'][ $item_id ]['group_type'] ) . '">(' . esc_html( $gen ) . ') ';

--- a/dt-metrics/personal/baptism-tree.php
+++ b/dt-metrics/personal/baptism-tree.php
@@ -94,7 +94,7 @@ class DT_Metrics_Personal_Baptism_Tree extends DT_Metrics_Chart_Base
         }
 
         $query = dt_queries()->tree( 'multiplying_baptisms_only' );
-        if ( is_wp_error( $query )){
+        if ( is_wp_error( $query ) ){
             return $this->_circular_structure_error( $query );
         }
         $contact_id = Disciple_Tools_Users::get_contact_for_user( get_current_user_id() );
@@ -116,10 +116,10 @@ class DT_Metrics_Personal_Baptism_Tree extends DT_Metrics_Chart_Base
         return $this->build_menu( 0, $menu_data, -1 );
     }
 
-    public function build_menu( $parent_id, $menu_data, $gen, $unique_check = []) {
+    public function build_menu( $parent_id, $menu_data, $gen, $unique_check = [] ) {
         $html = '';
 
-        if (isset( $menu_data['parents'][$parent_id] ))
+        if ( isset( $menu_data['parents'][$parent_id] ) )
         {
             $gen++;
 
@@ -129,7 +129,7 @@ class DT_Metrics_Personal_Baptism_Tree extends DT_Metrics_Chart_Base
             }
 
             $html = '<ul class="ul-gen-'.esc_html( $gen ).'">';
-            foreach ($menu_data['parents'][$parent_id] as $item_id)
+            foreach ( $menu_data['parents'][$parent_id] as $item_id )
             {
                 $html .= '<li class="gen-node li-gen-' . esc_html( $gen ) . ' ' . esc_html( $first_section ) . '">';
                 $html .= '(' . $gen . ') ';
@@ -153,7 +153,7 @@ class DT_Metrics_Personal_Baptism_Tree extends DT_Metrics_Chart_Base
         return $html;
     }
 
-    public function prepare_menu_array( $query) {
+    public function prepare_menu_array( $query ) {
         // prepare special array with parent-child relations
         $menu_data = array(
             'items' => array(),

--- a/dt-metrics/personal/coaching-tree.php
+++ b/dt-metrics/personal/coaching-tree.php
@@ -96,7 +96,7 @@ class DT_Metrics_Personal_Coaching_Tree extends DT_Metrics_Chart_Base
         }
 
         $query = dt_queries()->tree( 'multiplying_coaching_only' );
-        if ( is_wp_error( $query )){
+        if ( is_wp_error( $query ) ){
             return $this->_circular_structure_error( $query );
         }
         if ( empty( $query ) ) {
@@ -120,10 +120,10 @@ class DT_Metrics_Personal_Coaching_Tree extends DT_Metrics_Chart_Base
         return $this->build_menu( 0, $menu_data, -1 );
     }
 
-    public function build_menu( $parent_id, $menu_data, $gen, $unique_check = []) {
+    public function build_menu( $parent_id, $menu_data, $gen, $unique_check = [] ) {
         $html = '';
 
-        if (isset( $menu_data['parents'][$parent_id] ))
+        if ( isset( $menu_data['parents'][$parent_id] ) )
         {
             $gen++;
 
@@ -133,7 +133,7 @@ class DT_Metrics_Personal_Coaching_Tree extends DT_Metrics_Chart_Base
             }
 
             $html = '<ul class="ul-gen-'.esc_html( $gen ).'">';
-            foreach ($menu_data['parents'][$parent_id] as $item_id)
+            foreach ( $menu_data['parents'][$parent_id] as $item_id )
             {
                 $html .= '<li class="gen-node li-gen-' . esc_html( $gen ) . ' ' . esc_html( $first_section ) . '">';
                 $html .= '(' . esc_html( $gen ) . ') ';
@@ -157,7 +157,7 @@ class DT_Metrics_Personal_Coaching_Tree extends DT_Metrics_Chart_Base
         return $html;
     }
 
-    public function prepare_menu_array( $query) {
+    public function prepare_menu_array( $query ) {
         // prepare special array with parent-child relations
         $menu_data = array(
             'items' => array(),

--- a/dt-metrics/personal/group-tree.php
+++ b/dt-metrics/personal/group-tree.php
@@ -107,7 +107,7 @@ class DT_Metrics_Personal_Groups_Tree extends DT_Metrics_Chart_Base
         }
 
         $query = dt_queries()->tree( 'multiplying_groups_only' );
-        if ( is_wp_error( $query )){
+        if ( is_wp_error( $query ) ){
             return $this->_circular_structure_error( $query );
         }
         if ( empty( $query ) ) {
@@ -128,7 +128,7 @@ class DT_Metrics_Personal_Groups_Tree extends DT_Metrics_Chart_Base
         return $this->build_group_tree( 0, $menu_data, 0 );
     }
 
-    public function prepare_menu_array( $query) {
+    public function prepare_menu_array( $query ) {
         // prepare special array with parent-child relations
         $menu_data = array(
             'items' => array(),
@@ -143,10 +143,10 @@ class DT_Metrics_Personal_Groups_Tree extends DT_Metrics_Chart_Base
         return $menu_data;
     }
 
-    public function build_group_tree( $parent_id, $menu_data, $gen) {
+    public function build_group_tree( $parent_id, $menu_data, $gen ) {
         $html = '';
 
-        if (isset( $menu_data['parents'][$parent_id] ))
+        if ( isset( $menu_data['parents'][$parent_id] ) )
         {
             $first_section = '';
             if ( $gen === 0 ) {
@@ -155,7 +155,7 @@ class DT_Metrics_Personal_Groups_Tree extends DT_Metrics_Chart_Base
 
             $html = '<ul class="ul-gen-'.esc_html( $gen ).'">';
             $gen++;
-            foreach ($menu_data['parents'][$parent_id] as $item_id)
+            foreach ( $menu_data['parents'][$parent_id] as $item_id )
             {
                 $html .= '<li class="gen-node li-gen-' . esc_html( $gen ) . ' ' . esc_html( $first_section ) . '">';
                 $html .= '<span class="' . esc_html( $menu_data['items'][ $item_id ]['group_status'] ) . ' ' . esc_html( $menu_data['items'][ $item_id ]['group_type'] ) . '">(' . esc_html( $gen ) . ') ';

--- a/dt-notifications/notifications-comments.php
+++ b/dt-notifications/notifications-comments.php
@@ -28,7 +28,7 @@ class Disciple_Tools_Notifications_Comments
         if ( is_null( $comment ) ) {
             $comment = get_comment( $comment_id );
         }
-        if ( $comment->comment_type === "comment") {
+        if ( $comment->comment_type === "comment" ) {
 
             $comment_with_users       = self::match_mention( $comment->comment_content ); // fail if no match for mention found
             $comment->comment_content = $comment_with_users["comment"];

--- a/dt-notifications/notifications-scheduler.php
+++ b/dt-notifications/notifications-scheduler.php
@@ -98,7 +98,7 @@ class Disciple_Tools_Notifications_Scheduler {
 
         $notifications_by_user_by_post = [];
         // sort the notifications by user, and then by record
-        foreach ($unsent_notifications as $notification) {
+        foreach ( $unsent_notifications as $notification ) {
             $user_id = $notification["user_id"];
             $post_id = $notification["post_id"];
             if ( ! isset( $notifications_by_user_by_post[$user_id] ) ) {
@@ -121,11 +121,11 @@ class Disciple_Tools_Notifications_Scheduler {
 
             $email_body = '';
             $sent_notifications = [];
-            foreach ($notifications_by_post as $post_id => $notifications) {
+            foreach ( $notifications_by_post as $post_id => $notifications ) {
                 $sent_notifications = array_merge( $sent_notifications, $notifications );
 
                 $post_notifications_email = '## ' . dt_make_post_email_subject( $post_id ) . "\r\n";
-                foreach ($notifications as $notification) {
+                foreach ( $notifications as $notification ) {
                     $email_body_for_notification = $this->notifications_manager->get_notification_message_html( $notification, true, true );
                     $post_notifications_email .= "\r\n" . $email_body_for_notification;
                 }
@@ -135,7 +135,7 @@ class Disciple_Tools_Notifications_Scheduler {
             $email_body .= "\r\n" . dt_make_email_footer();
 
             $subject = '';
-            switch ($time_schedule) {
+            switch ( $time_schedule ) {
                 case 'hourly':
                     $subject = esc_html__( "Hourly Digest", "disciple_tools" );
                     break;

--- a/dt-notifications/notifications.php
+++ b/dt-notifications/notifications.php
@@ -471,7 +471,7 @@ class Disciple_Tools_Notifications
         /** Determine which condition meets "this" notification timestamp */
 
         /** The following 6 sprintf() items are the only items in this function that need to be translated in WP */
-        if ($range->minutes < 60) {
+        if ( $range->minutes < 60 ) {
             /** The exact number our minutes if this timestamp is < 60 minutes ago */
             $message = sprintf( _n( '%s minute ago', '%s minutes ago', $range->minutes, 'disciple_tools' ), $range->minutes );
         }
@@ -694,14 +694,14 @@ class Disciple_Tools_Notifications
         // Don't fire off notifications when the contact represents a user.
         if ( $post_type === "contacts" ){
             $contact_type = get_post_meta( $post_id, "type", true );
-            if ($contact_type === "user"){
+            if ( $contact_type === "user" ){
                 return;
             }
         }
 
         if ( isset( $fields["assigned_to"] ) ){
             $user_id = dt_get_user_id_from_assigned_to( $fields["assigned_to"] );
-            if ( $user_id && $user_id != get_current_user_id()){
+            if ( $user_id && $user_id != get_current_user_id() ){
                 $notification = [
                     'user_id'             => $user_id,
                     'source_user_id'      => get_current_user_id(),
@@ -722,7 +722,7 @@ class Disciple_Tools_Notifications
     }
 
     public static function insert_notification_for_post_update( $post_type, $fields, $old_fields, $fields_changed_keys ){
-        if ( isset( $fields["type"] ) && $fields["type"] === "user"){
+        if ( isset( $fields["type"] ) && $fields["type"] === "user" ){
             return;
         }
         $notification_on_fields = [];
@@ -736,7 +736,7 @@ class Disciple_Tools_Notifications
                 ( !isset( $old_fields["requires_update"] ) || $old_fields["requires_update"] != $fields["requires_update"] ) ){
                 $notification_on_fields[] = "requires_update";
             } elseif ( strpos( $key, "contact_" ) === 0 && isset( $fields[$key] ) &&
-                ( !isset( $old_fields[$key] ) || $old_fields[$key] != $fields[$key] )){
+                ( !isset( $old_fields[$key] ) || $old_fields[$key] != $fields[$key] ) ){
                 $notification_on_fields[] = "contact_info_update";
             } elseif ( $key === "milestones" && isset( $fields[$key] ) && sizeof( $fields[$key] ) > sizeof( $old_fields[$key] ?? [] ) ){
                 $notification_on_fields[] = "milestone";

--- a/dt-people-groups/people-groups-post-type.php
+++ b/dt-people-groups/people-groups-post-type.php
@@ -379,7 +379,7 @@ class Disciple_Tools_People_Groups_Post_Type
 
         echo '<input type="hidden" name="dt_' . esc_attr( $this->post_type ) . '_noonce" id="dt_' . esc_attr( $this->post_type ) . '_noonce" value="' . esc_attr( wp_create_nonce( 'update_peoplegroup_info' ) ) . '" />';
         ?>
-        <?php foreach ($dt_available_languages as $language) {
+        <?php foreach ( $dt_available_languages as $language ) {
             echo '<label for="dt_translation_' . esc_attr( $language["language"] ) . '">' . esc_attr( $language["native_name"] ) . '</label><br/>';
             echo '<input type="text" name="dt_translation_' . esc_attr( $language["language"] ) . '" id="dt_translation_' . esc_attr( $language["language"] ) . '" class="text-input" value="' . esc_attr( get_post_meta( $post->ID, $language["language"], true ) ). '" /><br/>';
         }
@@ -563,7 +563,7 @@ class Disciple_Tools_People_Groups_Post_Type
 
         $dt_available_languages = Disciple_Tools_Core_Endpoints::get_settings();
 
-        foreach ($dt_available_languages["available_translations"] as $language) {
+        foreach ( $dt_available_languages["available_translations"] as $language ) {
             if ( isset( $_POST['dt_translation_' . $language["language"]] ) )
             {
                 $translated_text_value = sanitize_text_field( wp_unslash( $_POST['dt_translation_' . $language["language"]] ) );
@@ -620,7 +620,7 @@ class Disciple_Tools_People_Groups_Post_Type
         return $post_types;
     }
     public function dt_get_post_type_settings( $settings, $post_type ){
-        if ( $post_type === $this->post_type){
+        if ( $post_type === $this->post_type ){
             $fields = $this->get_custom_fields_settings();
             $settings = [
                 'fields' => $fields,

--- a/dt-people-groups/people-groups.php
+++ b/dt-people-groups/people-groups.php
@@ -25,7 +25,7 @@ class Disciple_Tools_People_Groups
         $jp_csv = [];
         $handle = fopen( __DIR__ . "/csv/jp.csv", "r" );
         if ( $handle !== false ) {
-            while (( $data = fgetcsv( $handle, 0, "," ) ) !== false) {
+            while ( ( $data = fgetcsv( $handle, 0, "," ) ) !== false ) {
                 $jp_csv[] = $data;
             }
             fclose( $handle );
@@ -41,7 +41,7 @@ class Disciple_Tools_People_Groups
         $imb_csv = [];
         $handle = fopen( __DIR__ . "/csv/imb.csv", "r" );
         if ( $handle !== false ) {
-            while (( $data = fgetcsv( $handle, 0, "," ) ) !== false) {
+            while ( ( $data = fgetcsv( $handle, 0, "," ) ) !== false ) {
                 $imb_csv[] = $data;
             }
             fclose( $handle );
@@ -301,7 +301,7 @@ class Disciple_Tools_People_Groups
      * @return array|WP_Error
      */
     public static function get_people_groups_compact( $search ) {
-        if ( !current_user_can( "access_contacts" )){
+        if ( !current_user_can( "access_contacts" ) ){
             return new WP_Error( __FUNCTION__, "You do not have permission for this", [ 'status' => 403 ] );
         }
         $locale = get_user_locale();
@@ -317,7 +317,7 @@ class Disciple_Tools_People_Groups
         $list = [];
         foreach ( $query->posts as $post ) {
             $translation = get_post_meta( $post->ID, $locale, true );
-            if ($translation !== "") {
+            if ( $translation !== "" ) {
                 $label = $translation;
             } else {
                 $label = $post->post_title;
@@ -346,7 +346,7 @@ class Disciple_Tools_People_Groups
         $meta_query = new WP_Query( $meta_query_args );
         foreach ( $meta_query->posts as $post ) {
             $translation = get_post_meta( $post->ID, $locale, true );
-            if ($translation !== "") {
+            if ( $translation !== "" ) {
                 $label = $translation;
             } else {
                 $label = $post->post_title;

--- a/dt-posts/dt-posts-hooks.php
+++ b/dt-posts/dt-posts-hooks.php
@@ -14,7 +14,7 @@ class DT_Posts_Hooks {
      * @return mixed
      */
     public static function dt_get_custom_fields_translation( $fields ) {
-        if (is_admin()) {
+        if ( is_admin() ) {
             return $fields;
         } else {
             $user_locale = get_user_locale();
@@ -45,7 +45,7 @@ class DT_Posts_Hooks {
      * @return mixed
      */
     public static function dt_get_field_options_translation( $field_options ) {
-        if (is_admin()) {
+        if ( is_admin() ) {
             return $field_options;
         }
         $user_locale = get_user_locale();
@@ -63,7 +63,7 @@ class DT_Posts_Hooks {
         } else {
             $user_locale = get_user_locale();
             foreach ( $custom_tiles as $post_type => $tile_keys ) {
-                foreach ( $tile_keys as $key => $value) {
+                foreach ( $tile_keys as $key => $value ) {
                     if ( !empty( $custom_tiles[$post_type][$key][$user_locale] ) ) {
                         $custom_tiles[$post_type][$key]['label'] = $custom_tiles[$post_type][$key][$user_locale];
                     }

--- a/dt-posts/dt-posts.php
+++ b/dt-posts/dt-posts.php
@@ -95,7 +95,7 @@ class DT_Posts extends Disciple_Tools_Posts {
         }
 
         $post_date = null;
-        if ( isset( $fields["post_date"] )){
+        if ( isset( $fields["post_date"] ) ){
             $post_date = $fields["post_date"];
             unset( $fields["post_date"] );
         }
@@ -155,7 +155,7 @@ class DT_Posts extends Disciple_Tools_Posts {
                 $post_user_meta[$field_key] = $field_value;
                 unset( $fields[ $field_key ] );
             }
-            if ( $field_type === 'date' && !is_numeric( $field_value )){
+            if ( $field_type === 'date' && !is_numeric( $field_value ) ){
                 if ( $is_private ) {
                     $post_user_meta[$field_key] = strtotime( $field_value );
                     unset( $fields[ $field_key ] );
@@ -207,36 +207,36 @@ class DT_Posts extends Disciple_Tools_Posts {
             $post["post_date"] = $post_date;
         }
         $post_id = wp_insert_post( $post );
-        if ( is_wp_error( $post_id )){
+        if ( is_wp_error( $post_id ) ){
             return $post_id;
         }
         $potential_error = self::update_post_contact_methods( $post_settings, $post_id, $contact_methods_and_connections );
-        if ( is_wp_error( $potential_error )){
+        if ( is_wp_error( $potential_error ) ){
             return $potential_error;
         }
 
         $potential_error = self::update_connections( $post_settings, $post_id, $contact_methods_and_connections, null );
-        if ( is_wp_error( $potential_error )){
+        if ( is_wp_error( $potential_error ) ){
             return $potential_error;
         }
 
         $potential_error = self::update_multi_select_fields( $post_settings["fields"], $post_id, $multi_select_fields, null );
-        if ( is_wp_error( $potential_error )){
+        if ( is_wp_error( $potential_error ) ){
             return $potential_error;
         }
 
         $potential_error = self::update_location_grid_fields( $post_settings["fields"], $post_id, $location_meta, $post_type, null );
-        if (is_wp_error( $potential_error )) {
+        if ( is_wp_error( $potential_error ) ) {
             return $potential_error;
         }
 
         $potential_error = self::update_post_user_meta_fields( $post_settings["fields"], $post_id, $post_user_meta, [] );
-        if ( is_wp_error( $potential_error )){
+        if ( is_wp_error( $potential_error ) ){
             return $potential_error;
         }
 
         $potential_error = self::update_post_user_select( $post_type, $post_id, $user_select_fields );
-        if ( is_wp_error( $potential_error )){
+        if ( is_wp_error( $potential_error ) ){
             return $potential_error;
         }
 
@@ -354,32 +354,32 @@ class DT_Posts extends Disciple_Tools_Posts {
         }
 
         $potential_error = self::update_post_contact_methods( $post_settings, $post_id, $fields, $existing_post );
-        if ( is_wp_error( $potential_error )){
+        if ( is_wp_error( $potential_error ) ){
             return $potential_error;
         }
 
         $potential_error = self::update_connections( $post_settings, $post_id, $fields, $existing_post );
-        if ( is_wp_error( $potential_error )){
+        if ( is_wp_error( $potential_error ) ){
             return $potential_error;
         }
 
         $potential_error = self::update_multi_select_fields( $post_settings["fields"], $post_id, $fields, $existing_post );
-        if ( is_wp_error( $potential_error )){
+        if ( is_wp_error( $potential_error ) ){
             return $potential_error;
         }
 
         $potential_error = self::update_location_grid_fields( $post_settings["fields"], $post_id, $fields, $post_type, $existing_post );
-        if (is_wp_error( $potential_error )) {
+        if ( is_wp_error( $potential_error ) ) {
             return $potential_error;
         }
 
         $potential_error = self::update_post_user_meta_fields( $post_settings["fields"], $post_id, $fields, $existing_post );
-        if ( is_wp_error( $potential_error )){
+        if ( is_wp_error( $potential_error ) ){
             return $potential_error;
         }
 
         $potential_error = self::update_post_user_select( $post_type, $post_id, $fields );
-        if ( is_wp_error( $potential_error )){
+        if ( is_wp_error( $potential_error ) ){
             return $potential_error;
         }
 
@@ -498,9 +498,9 @@ class DT_Posts extends Disciple_Tools_Posts {
             if ( !isset( $all_post_user_meta[$meta_row["post_id"]] ) ){
                 $all_post_user_meta[$meta_row["post_id"]] = [];
             }
-            if ($field_settings[$meta_row['meta_key']]['type'] === 'task') {
+            if ( $field_settings[$meta_row['meta_key']]['type'] === 'task' ) {
                 $all_post_user_meta[$meta_row["post_id"]][] = $meta_row;
-            } else if (isset( $field_settings[$meta_row['meta_key']]['private'] ) && $field_settings[$meta_row['meta_key']]['private']) {
+            } else if ( isset( $field_settings[$meta_row['meta_key']]['private'] ) && $field_settings[$meta_row['meta_key']]['private'] ) {
                 $all_post_user_meta[$meta_row["post_id"]][] = $meta_row;
             }
         }
@@ -819,7 +819,7 @@ class DT_Posts extends Disciple_Tools_Posts {
 
             foreach ( $posts as $post ) {
                 $translation = get_post_meta( $post->ID, $locale, true );
-                if ($translation !== "") {
+                if ( $translation !== "" ) {
                     $label = $translation;
                 } else {
                     $label = $post->post_title;
@@ -888,7 +888,7 @@ class DT_Posts extends Disciple_Tools_Posts {
             }
         }
 
-        if ( !$silent && !is_wp_error( $created_comment_id )){
+        if ( !$silent && !is_wp_error( $created_comment_id ) ){
             Disciple_Tools_Notifications_Comments::insert_notification_for_comment( $created_comment_id );
         }
         if ( !is_wp_error( $created_comment_id ) ){
@@ -913,7 +913,7 @@ class DT_Posts extends Disciple_Tools_Posts {
         $update = wp_update_comment( $comment );
         if ( $update === 1 ){
             return $comment_id;
-        } else if ( is_wp_error( $update )) {
+        } else if ( is_wp_error( $update ) ) {
               return $update;
         } else {
             return new WP_Error( __FUNCTION__, "Error updating comment with id: " . $comment_id, [ 'status' => 500 ] );
@@ -937,8 +937,8 @@ class DT_Posts extends Disciple_Tools_Posts {
         }
         // If the reaction exists for this user, then delete it
         $reactions = get_comment_meta( $comment_id, $reaction );
-        foreach ($reactions as $reaction_user_id) {
-            if ($reaction_user_id == $user_id) {
+        foreach ( $reactions as $reaction_user_id ) {
+            if ( $reaction_user_id == $user_id ) {
                 delete_comment_meta( $comment_id, $reaction, $reaction_user_id );
                 return true;
             }
@@ -999,7 +999,7 @@ class DT_Posts extends Disciple_Tools_Posts {
         // phpcs:enable
 
         $comments_meta_dict = [];
-        foreach ($comments_meta as $meta) {
+        foreach ( $comments_meta as $meta ) {
             if ( !array_key_exists( $meta->comment_id, $comments_meta_dict ) ) {
                 $comments_meta_dict[$meta->comment_id] = [];
             }
@@ -1420,14 +1420,14 @@ class DT_Posts extends Disciple_Tools_Posts {
         foreach ( $fields as $field_key => $field ){
             if ( $field["type"] === "key_select" || $field["type"] === "multi_select" ){
                 foreach ( $field["default"] as $option_key => $option_value ){
-                    if ( !is_array( $option_value )){
+                    if ( !is_array( $option_value ) ){
                         $fields[$field_key]["default"][$option_key] = [ "label" => $option_value ];
                     }
                 }
             }
         }
         $custom_field_options = dt_get_option( "dt_field_customizations" );
-        if ( isset( $custom_field_options[$post_type] )){
+        if ( isset( $custom_field_options[$post_type] ) ){
             foreach ( $custom_field_options[$post_type] as $key => $field ){
                 $field_type = $field["type"] ?? $fields[$key]["type"] ?? "";
                 if ( $field_type ) {
@@ -1546,7 +1546,7 @@ class DT_Posts extends Disciple_Tools_Posts {
             }
         }
 
-        uasort($tile_options[$post_type], function( $a, $b) {
+        uasort($tile_options[$post_type], function( $a, $b ) {
             return ( $a['tile_priority'] ?? 100 ) <=> ( $b['tile_priority'] ?? 100 );
         });
         foreach ( $tile_options[$post_type] as $tile_key => &$tile_value ){

--- a/dt-posts/posts.php
+++ b/dt-posts/posts.php
@@ -276,16 +276,16 @@ class Disciple_Tools_Posts
 
         // Build variables
         $p2p_type = $activity->meta_key;
-        if ($p2p_type === "baptizer_to_baptized"){
-            if ($action === "connected to"){
+        if ( $p2p_type === "baptizer_to_baptized" ){
+            if ( $action === "connected to" ){
                 $object_note_to = sprintf( esc_html_x( 'Baptized %s', 'Baptized contact1', 'disciple_tools' ), $from_title );
                 $object_note_from = sprintf( esc_html_x( 'Baptized by %s', 'Baptized by contact1', 'disciple_tools' ), $to_title );
             } else {
                 $object_note_to = sprintf( esc_html_x( 'Did not baptize %s', 'Did not baptize contact1', 'disciple_tools' ), $from_title );
                 $object_note_from = sprintf( esc_html_x( 'Not baptized by %s', 'Not baptized by contact1', 'disciple_tools' ), $to_title );
             }
-        } else if ($p2p_type === "contacts_to_groups"){
-            if ($action == "connected to"){
+        } else if ( $p2p_type === "contacts_to_groups" ){
+            if ( $action == "connected to" ){
                 $object_note_to = sprintf( esc_html_x( '%s added to members', 'contact1 added to members', 'disciple_tools' ), $from_title );
                 $object_note_from = sprintf( esc_html_x( 'Added to group %s', 'Added to group group1', 'disciple_tools' ), $to_title );
             } else {
@@ -293,48 +293,48 @@ class Disciple_Tools_Posts
                 $object_note_from = sprintf( esc_html_x( 'Removed from group %s', 'Removed from group group1', 'disciple_tools' ), $to_title );
             }
         }
-        else if ( $p2p_type === "contacts_to_contacts"){
-            if ($action === "connected to"){
+        else if ( $p2p_type === "contacts_to_contacts" ){
+            if ( $action === "connected to" ){
                 $object_note_to = sprintf( esc_html_x( 'Coaching %s', 'Coaching contact1', 'disciple_tools' ), $from_title );
                 $object_note_from = sprintf( esc_html_x( 'Coached by %s', 'Coached by contact1', 'disciple_tools' ), $to_title );
             } else {
                 $object_note_to = sprintf( esc_html_x( 'No longer coaching %s', 'No longer coaching contact1', 'disciple_tools' ), $from_title );
                 $object_note_from = sprintf( esc_html_x( 'No longer coached by %s', 'No longer coached by contact1', 'disciple_tools' ), $to_title );
             }
-        } else if ( $p2p_type === "contacts_to_subassigned"){
-            if ($action === "connected to"){
+        } else if ( $p2p_type === "contacts_to_subassigned" ){
+            if ( $action === "connected to" ){
                 $object_note_to = sprintf( esc_html_x( 'Sub-assigned %s', 'Sub-assigned contact1', 'disciple_tools' ), $from_title );
                 $object_note_from = sprintf( esc_html_x( 'Sub-assigned on %s', 'Sub-assigned on contact1', 'disciple_tools' ), $to_title );
             } else {
                 $object_note_to = sprintf( esc_html_x( 'Removed sub-assigned %s', 'Removed sub-assigned contact1', 'disciple_tools' ), $from_title );
                 $object_note_from = sprintf( esc_html_x( 'No longer sub-assigned on %s', 'No longer sub-assigned on contact1', 'disciple_tools' ), $to_title );
             }
-        } else if ( $p2p_type === "contacts_to_peoplegroups" || $p2p_type === "groups_to_peoplegroups"){
-            if ($action == "connected to"){
+        } else if ( $p2p_type === "contacts_to_peoplegroups" || $p2p_type === "groups_to_peoplegroups" ){
+            if ( $action == "connected to" ){
                 $object_note_to = sprintf( esc_html_x( '%1$s added as people group on %2$s', 'Shaikh added as people group on contact1', 'disciple_tools' ), $to_title, $from_title );
                 $object_note_from = sprintf( esc_html_x( '%s added to people groups', 'Shaikh added to people groups', 'disciple_tools' ), $to_title );
             } else {
                 $object_note_to = sprintf( esc_html_x( '%1$s removed from people groups on %2$s', 'Shaikh removed from people groups on contact1', 'disciple_tools' ), $to_title, $from_title );
                 $object_note_from = sprintf( esc_html_x( '%s removed from people groups', 'Shaikh removed from people groups', 'disciple_tools' ), $to_title );
             }
-        } else if ( $p2p_type === "groups_to_leaders"){
-            if ($action == "connected to"){
+        } else if ( $p2p_type === "groups_to_leaders" ){
+            if ( $action == "connected to" ){
                 $object_note_to = sprintf( esc_html_x( '%1$s added as leader on %2$s', 'contact1 added as leader on group1', 'disciple_tools' ), $to_title, $from_title );
                 $object_note_from = sprintf( esc_html_x( '%s added to leaders', 'contact1 added to leaders', 'disciple_tools' ), $to_title );
             } else {
                 $object_note_to = sprintf( esc_html_x( '%1$s removed from leaders on %2$s', 'contact1 removed from leaders on group1', 'disciple_tools' ), $to_title, $from_title );
                 $object_note_from = sprintf( esc_html_x( '%s removed from leaders', 'contact1 removed from leaders', 'disciple_tools' ), $to_title );
             }
-        } else if ( $p2p_type === "groups_to_coaches"){
-            if ($action == "connected to"){
+        } else if ( $p2p_type === "groups_to_coaches" ){
+            if ( $action == "connected to" ){
                 $object_note_to = sprintf( esc_html_x( '%1$s added as coach on %2$s', 'contact1 added as coach on group1', 'disciple_tools' ), $to_title, $from_title );
                 $object_note_from = sprintf( esc_html_x( '%s added to coaches', 'contact1 added to coaches', 'disciple_tools' ), $to_title );
             } else {
                 $object_note_to = sprintf( esc_html_x( '%1$s removed from coaches on %2$s', 'contact1 removed from coaches on group2', 'disciple_tools' ), $to_title, $from_title );
                 $object_note_from = sprintf( esc_html_x( '%s removed from coaches', 'contact1 removed from coaches', 'disciple_tools' ), $to_title );
             }
-        } else if ( $p2p_type === "groups_to_groups"){
-            if ($action == "connected to"){
+        } else if ( $p2p_type === "groups_to_groups" ){
+            if ( $action == "connected to" ){
                 $object_note_to = sprintf( esc_html_x( '%s added to child groups', 'group2 added to child groups', 'disciple_tools' ), $from_title );
                 $object_note_from = sprintf( esc_html_x( '%s added to parent groups', 'group1 added to parent groups', 'disciple_tools' ), $to_title );
             } else {
@@ -342,16 +342,16 @@ class Disciple_Tools_Posts
                 $object_note_from = sprintf( esc_html_x( '%s removed from parent groups', 'group1 removed from parent groups', 'disciple_tools' ), $to_title );
             }
         }
-        else if ( $p2p_type === "groups_to_peers"){
-            if ($action == "connected to"){
+        else if ( $p2p_type === "groups_to_peers" ){
+            if ( $action == "connected to" ){
                 $object_note_to = sprintf( esc_html_x( '%s added to peer groups', 'group1 added to peer groups', 'disciple_tools' ), $from_title );
                 $object_note_from = sprintf( esc_html_x( '%s added to peer groups', 'group1 added to peer groups', 'disciple_tools' ), $to_title );
             } else {
                 $object_note_to = sprintf( esc_html_x( '%s removed from peer groups', 'group1 removed from peer groups', 'disciple_tools' ), $from_title );
                 $object_note_from = sprintf( esc_html_x( '%s removed from peer groups', 'group1 removed from peer groups', 'disciple_tools' ), $to_title );
             }
-        } else if ( $p2p_type === "contacts_to_relation"){
-            if ($action == "connected to"){
+        } else if ( $p2p_type === "contacts_to_relation" ){
+            if ( $action == "connected to" ){
                 $object_note_to = sprintf( esc_html_x( 'Connected to %s', 'Connected to contact1', 'disciple_tools' ), $from_title );
                 $object_note_from = sprintf( esc_html_x( 'Connected to %s', 'Connected to contact1', 'disciple_tools' ), $to_title );
             } else {
@@ -359,7 +359,7 @@ class Disciple_Tools_Posts
                 $object_note_from = sprintf( esc_html_x( 'Removed connection to %s', 'Removed connection to contact1', 'disciple_tools' ), $to_title );
             }
         } else {
-            if ($action == "connected to"){
+            if ( $action == "connected to" ){
                 $object_note_to = sprintf( esc_html_x( 'Connected to %s', 'Connected to contact1', 'disciple_tools' ), $from_title );
                 $object_note_from = sprintf( esc_html_x( 'Connected to %s', 'Connected to contact1', 'disciple_tools' ), $to_title );
             } else {
@@ -380,19 +380,19 @@ class Disciple_Tools_Posts
         $message = "";
         if ( $activity->action == "field_update" ){
             if ( isset( $fields[$activity->meta_key] ) ){
-                if ( $activity->meta_key === "assigned_to"){
+                if ( $activity->meta_key === "assigned_to" ){
                     $meta_array = explode( '-', $activity->meta_value ); // Separate the type and id
                     if ( isset( $meta_array[1] ) ) {
                         $user = get_user_by( "ID", $meta_array[1] );
                         $message = sprintf( _x( 'Assigned to: %s', 'Assigned to: User1', 'disciple_tools' ), ( $user ? $user->display_name : __( "Nobody", 'disciple_tools' ) ) );
                     }
                 }
-                if ( $fields[$activity->meta_key]["type"] === "text"){
+                if ( $fields[$activity->meta_key]["type"] === "text" ){
                     if ( !empty( $activity->meta_value ) ){
                         $message = sprintf( _x( '%1$s changed to %2$s', "field1 changed to 'text'", 'disciple_tools' ), $fields[$activity->meta_key]["name"], $activity->meta_value );
                     }
                 }
-                if ( $fields[$activity->meta_key]["type"] === "textarea"){
+                if ( $fields[$activity->meta_key]["type"] === "textarea" ){
                     if ( !empty( $activity->meta_value ) ){
                         $message = sprintf( _x( '%1$s changed to %2$s', "field1 changed to 'text'", 'disciple_tools' ), $fields[$activity->meta_key]["name"], $activity->meta_value );
                     }
@@ -433,7 +433,7 @@ class Disciple_Tools_Posts
                         $message = $fields[$activity->meta_key]["name"] . ": " . __( "No", 'disciple_tools' );
                     }
                 }
-                if ($fields[$activity->meta_key]["type"] === "number"){
+                if ( $fields[$activity->meta_key]["type"] === "number" ){
                     $message = $fields[$activity->meta_key]["name"] . ": " . $activity->meta_value;
                 }
                 if ( $fields[$activity->meta_key]["type"] === "date" ){
@@ -481,15 +481,15 @@ class Disciple_Tools_Posts
                     if ( !empty( $name ) && !empty( $original ) ){
                         $object_note = $name . ' "'. $original .'" ';
                         if ( is_array( $meta_value ) ){
-                            foreach ($meta_value as $k => $v){
+                            foreach ( $meta_value as $k => $v ){
                                 $prev_value = $activity->old_value;
-                                if (is_array( $prev_value ) && isset( $prev_value[ $k ] ) && $prev_value[ $k ] == $v){
+                                if ( is_array( $prev_value ) && isset( $prev_value[ $k ] ) && $prev_value[ $k ] == $v ){
                                     continue;
                                 }
-                                if ($k === "verified") {
+                                if ( $k === "verified" ) {
                                     $object_note .= $v ? _x( "verified", 'message', 'disciple_tools' ) : _x( "not verified", 'message', 'disciple_tools' );
                                 }
-                                if ($k === "invalid") {
+                                if ( $k === "invalid" ) {
                                     $object_note .= $v ? _x( "invalidated", 'message', 'disciple_tools' ) : _x( "not invalidated", 'message', 'disciple_tools' );
                                 }
                                 $object_note .= ', ';
@@ -507,7 +507,7 @@ class Disciple_Tools_Posts
                     if ( isset( $channel[1] ) ) {
                         $channel_key = "";
                         for ( $i = 1; $i < $channel_key_count; $i++ ) {
-                            if ($channel_key) {
+                            if ( $channel_key ) {
                                 $channel_key = $channel_key . '_' . $channel[$i];
                             } else {
                                 $channel_key = $channel[$i];
@@ -526,7 +526,7 @@ class Disciple_Tools_Posts
                     }
                 } else if ( $activity->meta_key == "title" ){
                     $message = sprintf( _x( "Name changed to: %s", 'message', 'disciple_tools' ), $activity->meta_value );
-                } else if ( $activity->meta_key === "_sample"){
+                } else if ( $activity->meta_key === "_sample" ){
                     $message = _x( "Created from Demo Plugin", 'message', 'disciple_tools' );
                 } else {
                     $message = $activity->meta_key . ": " . $activity->meta_value;
@@ -541,7 +541,7 @@ class Disciple_Tools_Posts
         } elseif ( $activity->object_subtype === "p2p" ){
             $message = self::format_connection_message( $activity->meta_id, $activity, $activity->action, $post_type_settings["fields"] );
         } elseif ( $activity->object_subtype === "share" ){
-            if ($activity->action === "share"){
+            if ( $activity->action === "share" ){
                 $message = sprintf( _x( "Shared with %s", 'message', 'disciple_tools' ), dt_get_user_display_name( $activity->meta_value ) );
             } else if ( $activity->action === "remove" ){
                 $message = sprintf( _x( "Unshared with %s", 'message', 'disciple_tools' ), dt_get_user_display_name( $activity->meta_value ) );
@@ -980,7 +980,7 @@ class Disciple_Tools_Posts
                 } else {
                     return new WP_Error( __FUNCTION__, "One or more fields do not exist", [ 'key' => $query_key, 'status' => 400 ] );
                 }
-                if ( !empty( $where_sql )){
+                if ( !empty( $where_sql ) ){
                     $index_pos++;
 
                     $args["where_sql"] .= ( ( $index_pos > 1 ) ? $operator : " " ) . " (";
@@ -1021,24 +1021,24 @@ class Disciple_Tools_Posts
         $post_fields = $post_settings["fields"];
 
         $search = "";
-        if ( isset( $query["text"] )){
+        if ( isset( $query["text"] ) ){
             $search = sanitize_text_field( $query["text"] );
             unset( $query["text"] );
         }
         $offset = 0;
-        if ( isset( $query["offset"] )){
+        if ( isset( $query["offset"] ) ){
             $offset = esc_sql( sanitize_text_field( $query["offset"] ) );
             unset( $query["offset"] );
         }
         $limit = 100;
-        if ( isset( $query["limit"] )){
+        if ( isset( $query["limit"] ) ){
             $limit = esc_sql( sanitize_text_field( $query["limit"] ) );
             $limit = MIN( $limit, 1000 );
             unset( $query["limit"] );
         }
         $sort = "";
         $sort_dir = "asc";
-        if ( isset( $query["sort"] )){
+        if ( isset( $query["sort"] ) ){
             $sort = esc_sql( sanitize_text_field( $query["sort"] ) );
             if ( strpos( $sort, "-" ) === 0 ){
                 $sort_dir = "desc";
@@ -1047,11 +1047,11 @@ class Disciple_Tools_Posts
             unset( $query["sort"] );
         }
         $fields_to_search = [];
-        if ( isset( $query["fields_to_search"] )){
+        if ( isset( $query["fields_to_search"] ) ){
             $fields_to_search = $query["fields_to_search"];
             unset( $query ["fields_to_search"] );
         }
-        if ( isset( $query["combine"] )){
+        if ( isset( $query["combine"] ) ){
             unset( $query["combine"] ); //remove deprecated combine
         }
 
@@ -1062,7 +1062,7 @@ class Disciple_Tools_Posts
         $joins = "";
         $post_query = "";
 
-        if ( !empty( $search )){
+        if ( !empty( $search ) ){
             $other_search_fields = apply_filters( "dt_search_extra_post_meta_fields", [] );
 
             if ( empty( $fields_to_search ) ) {
@@ -1103,7 +1103,7 @@ class Disciple_Tools_Posts
                     AND meta_value LIKE '%" . esc_sql( $search ) . "%'
                     ) ";
                 } else {
-                    if ( in_array( 'comment', $fields_to_search )) {
+                    if ( in_array( 'comment', $fields_to_search ) ) {
                         if ( substr( $post_query, -6 ) !== 'AND ( ' ) {
                             $post_query .= "OR ";
                         }
@@ -1141,7 +1141,7 @@ class Disciple_Tools_Posts
         }
 
         $sort_sql = "";
-        if ( $sort === "name" || $sort === "post_title"){
+        if ( $sort === "name" || $sort === "post_title" ){
             $sort_sql = "p.post_title  " . $sort_dir;
         } elseif ( $sort === "post_date" ){
             $sort_sql = "p.post_date  " . $sort_dir;
@@ -1166,7 +1166,7 @@ class Disciple_Tools_Posts
                 }
                 $sort_sql .= "else 98 end ";
                 $sort_sql .= $sort_dir;
-            } elseif ( $post_fields[$sort]["type"] === "multi_select" && !empty( $post_fields[$sort]["default"] )){
+            } elseif ( $post_fields[$sort]["type"] === "multi_select" && !empty( $post_fields[$sort]["default"] ) ){
                 $sort_sql = "CASE ";
                 $joins = "";
                 $keys = array_reverse( array_keys( $post_fields[$sort]["default"] ) );
@@ -1217,7 +1217,7 @@ class Disciple_Tools_Posts
         ];
         $permissions = apply_filters( "dt_filter_access_permissions", $permissions, $post_type );
 
-        if ( $check_permissions && !empty( $permissions )){
+        if ( $check_permissions && !empty( $permissions ) ){
             $query[] = $permissions;
         }
 
@@ -1432,7 +1432,7 @@ class Disciple_Tools_Posts
 
         foreach ( $fields as $field_key => $field ){
             if ( isset( $field_settings[$field_key] ) && ( in_array( $field_settings[$field_key]["type"], [ "multi_select", "tags" ] ) ) ){
-                if ( !isset( $field["values"] )){
+                if ( !isset( $field["values"] ) ){
                     return new WP_Error( __FUNCTION__, "missing values field on: " . $field_key, [ 'status' => 400 ] );
                 }
                 if ( isset( $field["force_values"] ) && $field["force_values"] == true ){
@@ -1440,7 +1440,7 @@ class Disciple_Tools_Posts
                     $existing_contact[ $field_key ] = [];
                 }
                 foreach ( $field["values"] as $value ){
-                    if ( isset( $value["value"] )){
+                    if ( isset( $value["value"] ) ){
                         if ( isset( $value["delete"] ) && $value["delete"] == true ){
                             if ( isset( $field_settings[ $field_key ] ) && isset( $field_settings[$field_key]['private'] ) && $field_settings[$field_key]['private'] ) {
                                 if ( !$current_user_id ){
@@ -1507,7 +1507,7 @@ class Disciple_Tools_Posts
                     $existing_post[ $field_key ] = [];
                 }
                 foreach ( $field["values"] as $value ){
-                    if ( isset( $value["value"] )){
+                    if ( isset( $value["value"] ) ){
                         if ( isset( $value["delete"] ) && $value["delete"] == true ){
                             delete_post_meta( $post_id, $field_key, $value["value"] );
                         } else {
@@ -1631,7 +1631,7 @@ class Disciple_Tools_Posts
                             $location_meta_grid['label'] = $full_name;
 
                             $potential_error = Location_Grid_Meta::add_location_grid_meta( $post_id, $location_meta_grid );
-                            if (is_wp_error( $potential_error )) {
+                            if ( is_wp_error( $potential_error ) ) {
                                 return $potential_error;
                             }
                         }
@@ -1707,8 +1707,8 @@ class Disciple_Tools_Posts
                 }
             }
             foreach ( $values as $field ){
-                if ( isset( $field["delete"] ) && $field["delete"] == true){
-                    if ( !isset( $field["key"] )){
+                if ( isset( $field["delete"] ) && $field["delete"] == true ){
+                    if ( !isset( $field["key"] ) ){
                         return new WP_Error( __FUNCTION__, "missing key on: " . $details_key, [ 'status' => 400 ] );
                     }
                     //delete field
@@ -1754,7 +1754,7 @@ class Disciple_Tools_Posts
         global $wpdb;
         foreach ( $fields as $field_key => $field ) {
             if ( isset( $field_settings[ $field_key ] ) && ( $field_settings[ $field_key ]["type"] === "task" ) ) {
-                if ( !isset( $field["values"] )){
+                if ( !isset( $field["values"] ) ){
                     return new WP_Error( __FUNCTION__, "missing values field on: " . $field_key, [ 'status' => 400 ] );
                 }
 
@@ -1850,7 +1850,7 @@ class Disciple_Tools_Posts
                         $field_value = false;
                     }
                 }
-                if ( $field_settings[ $field_key ]["type"] === "date" && !is_numeric( $fields[$field_key] )) {
+                if ( $field_settings[ $field_key ]["type"] === "date" && !is_numeric( $fields[$field_key] ) ) {
                         $field_value = strtotime( $fields[$field_key] );
                 } else {
                     $field_value = $fields[$field_key];
@@ -1961,12 +1961,12 @@ class Disciple_Tools_Posts
             $details = isset( $old_details ) ? $old_details : [];
             $new_value = false;
             foreach ( $values as $detail_key => $detail_value ) {
-                if ( !isset( $details[$detail_key] ) || $details[$detail_key] !== $detail_value){
+                if ( !isset( $details[$detail_key] ) || $details[$detail_key] !== $detail_value ){
                     $new_value = true;
                 }
                 $details[ $detail_key ] = $detail_value;
             }
-            if ($new_value){
+            if ( $new_value ){
                 update_post_meta( $post_id, $details_key, $details );
             }
         }
@@ -1978,19 +1978,19 @@ class Disciple_Tools_Posts
         //update connections (groups, locations, etc)
         foreach ( $post_settings["connection_types"] as $connection_type ){
             if ( isset( $fields[$connection_type] ) ){
-                if ( !isset( $fields[$connection_type]["values"] )){
+                if ( !isset( $fields[$connection_type]["values"] ) ){
                     return new WP_Error( __FUNCTION__, "Missing values field on connection: " . $connection_type, [ 'status' => 500 ] );
                 }
                 $existing_connections = [];
                 if ( isset( $existing_contact[$connection_type] ) ){
-                    foreach ( $existing_contact[$connection_type] as $connection){
+                    foreach ( $existing_contact[$connection_type] as $connection ){
                         $existing_connections[] = isset( $connection->ID ) ? $connection->ID : $connection["ID"];
                     }
                 }
                 //check for new connections
                 $connection_field = $fields[$connection_type];
                 $new_connections = [];
-                foreach ($connection_field["values"] as $connection_value ){
+                foreach ( $connection_field["values"] as $connection_value ){
                     if ( isset( $connection_value["value"] ) && !is_numeric( $connection_value["value"] ) ){
                         if ( filter_var( $connection_value["value"], FILTER_VALIDATE_EMAIL ) ){
                             $user = get_user_by( "email", $connection_value["value"] );
@@ -2010,17 +2010,17 @@ class Disciple_Tools_Posts
                         }
                     }
 
-                    if ( isset( $connection_value["value"] ) && is_numeric( $connection_value["value"] )){
+                    if ( isset( $connection_value["value"] ) && is_numeric( $connection_value["value"] ) ){
                         if ( isset( $connection_value["delete"] ) && $connection_value["delete"] == true ){
-                            if ( in_array( $connection_value["value"], $existing_connections )){
+                            if ( in_array( $connection_value["value"], $existing_connections ) ){
                                 $potential_error = self::remove_connection_from_post( $post_settings["post_type"], $post_id, $connection_type, $connection_value["value"] );
                                 if ( is_wp_error( $potential_error ) ) {
                                     return $potential_error;
                                 }
                             }
-                        } else if ( !empty( $connection_value["value"] )) {
+                        } else if ( !empty( $connection_value["value"] ) ) {
                             $new_connections[] = $connection_value["value"];
-                            if ( !in_array( $connection_value["value"], $existing_connections )){
+                            if ( !in_array( $connection_value["value"], $existing_connections ) ){
                                 $potential_error = self::add_connection_to_post( $post_settings["post_type"], $post_id, $connection_type, $connection_value["value"], $connection_value["meta"] ?? [] );
                                 $existing_connections[] = $connection_value["value"];
                                 if ( is_wp_error( $potential_error ) ) {
@@ -2038,8 +2038,8 @@ class Disciple_Tools_Posts
                 }
                 //check for deleted connections
                 if ( isset( $connection_field["force_values"] ) && $connection_field["force_values"] == true ){
-                    foreach ($existing_connections as $connection_value ){
-                        if ( !in_array( $connection_value, $new_connections )){
+                    foreach ( $existing_connections as $connection_value ){
+                        if ( !in_array( $connection_value, $new_connections ) ){
                             $potential_error = self::remove_connection_from_post( $post_settings["post_type"], $post_id, $connection_type, $connection_value );
                             if ( is_wp_error( $potential_error ) ) {
                                 return $potential_error;
@@ -2168,7 +2168,7 @@ class Disciple_Tools_Posts
             $meta_fields = get_post_custom( $post_id );
         }
         foreach ( $meta_fields as $key => $value ) {
-            if ( empty( $fields_to_return ) || in_array( $key, $fields_to_return ) || strpos( $key, "contact_" ) === 0) {
+            if ( empty( $fields_to_return ) || in_array( $key, $fields_to_return ) || strpos( $key, "contact_" ) === 0 ) {
                 //if is contact details and is in a channel
                 $key_without_ramdomizers = null;
                 if ( strpos( $key, "contact_" ) === 0 ){
@@ -2287,7 +2287,7 @@ class Disciple_Tools_Posts
         }
 
         if ( class_exists( "DT_Mapbox_API" ) && DT_Mapbox_API::get_key() ) {
-            if ( isset( $fields['location_grid_meta'] )){
+            if ( isset( $fields['location_grid_meta'] ) ){
                 $ids = dt_get_keys_map( $fields['location_grid'] ?? [], 'id' );
                 foreach ( $fields['location_grid_meta'] as $meta ) {
                     foreach ( ( $fields['location_grid'] ?? [] ) as $index => $grid ){
@@ -2399,7 +2399,7 @@ class Disciple_Tools_Posts
         $ids_sql = dt_array_to_sql( $post_ids );
         $p2p_types = [];
         $connection_fields = [];
-        foreach ( $field_settings as $field_key => $field_value){
+        foreach ( $field_settings as $field_key => $field_value ){
             if ( $field_value["type"] === "connection" && ( empty( $fields_to_return ) || in_array( $field_key, $fields_to_return ) ) && !empty( $records ) ){
                 $p2p_types[$field_value["p2p_key"]] = $field_value;
                 $p2p_types[$field_value["p2p_key"]]["field_key"] = $field_key;

--- a/dt-reports/magic-url-base.php
+++ b/dt-reports/magic-url-base.php
@@ -228,8 +228,8 @@ abstract class DT_Magic_Url_Base {
 
         global $wp_styles;
         if ( isset( $wp_styles ) ) {
-            foreach ($wp_styles->queue as $key => $item) {
-                if ( !in_array( $item, $allowed_css )) {
+            foreach ( $wp_styles->queue as $key => $item ) {
+                if ( !in_array( $item, $allowed_css ) ) {
                     unset( $wp_styles->queue[$key] );
                 }
             }

--- a/dt-reports/magic-url-class.php
+++ b/dt-reports/magic-url-class.php
@@ -151,7 +151,7 @@ if ( ! class_exists( 'DT_Magic_URL' ) ) {
             $url = [];
             $root = $this->root;
             $types = self::list_types();
-            foreach ( $types as $type){
+            foreach ( $types as $type ){
                 $url[] = $root . '/'. $type;
             }
             return $url;
@@ -399,7 +399,7 @@ if ( ! class_exists( 'DT_Magic_URL' ) ) {
             if ( empty( $parts['public_key'] ) ) { // fail if not specific contact
                 return false;
             }
-            if ( empty( $parts['post_id'] )) { // fail if no post id
+            if ( empty( $parts['post_id'] ) ) { // fail if no post id
                 return false;
             }
             return $parts;

--- a/dt-users/template-new-user.php
+++ b/dt-users/template-new-user.php
@@ -197,7 +197,7 @@ $gender_fields = DT_Posts::get_post_settings( "contacts" )["fields"]["gender"];
                                                 </label></dt>
                                                 <dd>
                                                     <select class="select-field" id="gender" style="width:auto; display: block" data-optional>
-                                                        <?php foreach ($gender_fields["default"] as $option_key => $option_value): ?>
+                                                        <?php foreach ( $gender_fields["default"] as $option_key => $option_value ): ?>
                                                             <option value="<?php echo esc_html( $option_key )?>">
                                                                 <?php echo esc_html( $option_value["label"] ) ?>
                                                             </option>

--- a/dt-users/user-hooks-and-config.php
+++ b/dt-users/user-hooks-and-config.php
@@ -85,7 +85,7 @@ class DT_User_Hooks_And_Configuration {
     public function wpmu_activate_user( $user_id, $password, $meta ){
         if ( isset( $meta["invited_by"] ) && !empty( $meta["invited_by"] ) ){
             $contact_id = get_user_option( "corresponds_to_contact", $user_id );
-            if ( $contact_id && !is_wp_error( $contact_id )){
+            if ( $contact_id && !is_wp_error( $contact_id ) ){
                 DT_Posts::add_shared( "contacts", $contact_id, $meta["invited_by"], null, false, false );
             }
         }
@@ -147,7 +147,7 @@ class DT_User_Hooks_And_Configuration {
         if ( isset( $_POST["dt_locale"] ) ) {
             $userdata = get_user_by( 'id', $user_id );
 
-            if ( isset( $_POST["dt_locale"] )) {
+            if ( isset( $_POST["dt_locale"] ) ) {
                 if ( $_POST["dt_locale"] === "" ) {
                     $locale = "en_US";
                 } else {
@@ -481,7 +481,7 @@ class DT_User_Hooks_And_Configuration {
                         <input type="hidden" class="regular-text corresponds_to_contact_id" name="corresponds_to_contact_id" value="<?php echo esc_html( $contact_id )?>" />
                         <?php if ( $contact_id ) : ?>
                             <span class="description"><a href="<?php echo esc_html( get_site_url() . '/contacts/' . $contact_id )?>" target="_blank"><?php esc_html_e( "View Contact", 'disciple_tools' ) ?></a></span>
-                        <?php else :?>
+                        <?php else : ?>
                             <span class="description"><?php esc_html_e( "Add the name of the contact record this user corresponds to.", 'disciple_tools' ) ?>
                                 <a target="_blank" href="https://disciple.tools/user-docs/getting-started-info/users/inviting-users/"><?php esc_html_e( "Learn more.", "disciple_tools" ) ?></a>
                             </span>

--- a/dt-users/user-management.php
+++ b/dt-users/user-management.php
@@ -277,13 +277,13 @@ class DT_User_Management
                 'overall_status' => [ '-closed', '-paused' ],
                 'sort' => 'last_modified'
             ], false );
-            if (sizeof( $update_needed["posts"] ) > 5) {
+            if ( sizeof( $update_needed["posts"] ) > 5 ) {
                 $update_needed["posts"] = array_slice( $update_needed["posts"], 0, 5 );
             }
-            if (sizeof( $to_accept["posts"] ) > 10) {
+            if ( sizeof( $to_accept["posts"] ) > 10 ) {
                 $to_accept["posts"] = array_slice( $to_accept["posts"], 0, 10 );
             }
-            foreach ($update_needed["posts"] as &$contact) {
+            foreach ( $update_needed["posts"] as &$contact ) {
                 $now = time();
                 $last_modified = get_post_meta( $contact->ID, "last_modified", true );
                 $days_different = (int) round( ( $now - (int) $last_modified ) / ( 60 * 60 * 24 ) );

--- a/dt-users/user-metrics.php
+++ b/dt-users/user-metrics.php
@@ -85,7 +85,7 @@ class DT_User_Metrics {
 
         if ( ! empty( $user_activity ) ) {
 
-            foreach ($user_activity as $a) {
+            foreach ( $user_activity as $a ) {
                 $post_settings = DT_Posts::get_post_settings( $a->post_type );
                 $post_fields = DT_Posts::get_post_field_settings( $a->post_type );
                 $a->object_note = DT_Posts::format_activity_message( $a, $post_settings );
@@ -97,21 +97,21 @@ class DT_User_Metrics {
                     $a->object_subtype = "name";
                 }
 
-                if ($a->action === 'field_update' || $a->action === 'connected to' || $a->action === 'disconnected from') {
+                if ( $a->action === 'field_update' || $a->action === 'connected to' || $a->action === 'disconnected from' ) {
                     $a->object_note_short = __( "Updated fields", 'disciple_tools' );
                     $a->field = $a->action === 'field_update' ? $post_fields[ $a->object_subtype ]["name"] : null;
                 }
-                if ($a->action == 'comment') {
+                if ( $a->action == 'comment' ) {
                     $a->object_note_short = __( "Made %n comments", "disciple_tools" );
                 }
-                if ($a->action == 'created') {
+                if ( $a->action == 'created' ) {
                     $a->object_note = __( 'Created record', 'disciple_tools' );
                 }
-                if ($a->action === "logged_in") {
+                if ( $a->action === "logged_in" ) {
                     $a->object_note_short = __( "Logged In %n times", 'disciple_tools' );
                     $a->object_note = __( "Logged In", 'disciple_tools' );
                 }
-                if ($a->action === 'assignment_decline') {
+                if ( $a->action === 'assignment_decline' ) {
                     $a->object_note = sprintf( _x( "Declined assignment on %s", 'Declined assignment on Bob', 'disciple_tools' ), $a->object_name );
                 }
             }
@@ -370,14 +370,14 @@ class DT_User_Metrics {
             $one_year
         ), ARRAY_A );
         $days_active = [];
-        foreach ($days_active_results as $a) {
+        foreach ( $days_active_results as $a ) {
             $days_active[$a["day"]] = $a;
         }
         $first = isset( $days_active_results[0]['day'] ) ? strtotime( $days_active_results[0]['day'] ) : time();
         $first_week_start = gmdate( 'Y-m-d', strtotime( '-' . gmdate( 'w', $first ) . ' days', $first ) );
         $current = strtotime( $first_week_start );
         $daily_activity = [];
-        while ($current < time()) {
+        while ( $current < time() ) {
 
             $activity = $days_active[gmdate( 'Y-m-d', $current )]["activity_count"] ?? 0;
 

--- a/dt-users/users-endpoints.php
+++ b/dt-users/users-endpoints.php
@@ -140,7 +140,7 @@ class Disciple_Tools_Users_Endpoints
             $search = $params['s'];
         }
         $get_all = 0;
-        if ( isset( $params["get_all"] )){
+        if ( isset( $params["get_all"] ) ){
             $get_all = $params["get_all"] === "1";
         }
         return Disciple_Tools_Users::get_assignable_users_compact( $search, $get_all );
@@ -195,7 +195,7 @@ class Disciple_Tools_Users_Endpoints
 
     public function save_user_filter( WP_REST_Request $request ){
         $params = $request->get_params();
-        if ( isset( $params["filter"], $params["post_type"] )){
+        if ( isset( $params["filter"], $params["post_type"] ) ){
             return Disciple_Tools_Users::save_user_filter( $params["filter"], $params["post_type"] );
         } else {
             return new WP_Error( "missing_error", "Missing filters", [ 'status' => 400 ] );
@@ -214,7 +214,7 @@ class Disciple_Tools_Users_Endpoints
         $params = $request->get_params();
 
         $user_id = get_current_user_id();
-        if ( isset( $params["password"] ) && $user_id){
+        if ( isset( $params["password"] ) && $user_id ){
             dt_write_log( $params["password"] );
 
             wp_set_password( $params["password"], $user_id );
@@ -239,16 +239,16 @@ class Disciple_Tools_Users_Endpoints
             }
             $user_login = $params["user-user_login"] ?? $params["user-email"];
             $user_login = $params["user-username"] ?? $user_login;
-            if (isset( $params["user-password"] ) ) {
+            if ( isset( $params["user-password"] ) ) {
                 $password = $params["user-password"];
             }
-            if (isset( $params["user-optional-fields"] ) ) {
+            if ( isset( $params["user-optional-fields"] ) ) {
                 $optional_fields = $params["user-optional-fields"];
             }
-            if (isset( $params["locale"] ) ) {
+            if ( isset( $params["locale"] ) ) {
                 $locale = $params["locale"];
             }
-            if (isset( $params["return_contact"] ) ) {
+            if ( isset( $params["return_contact"] ) ) {
                 $return_contact = true;
             }
             return Disciple_Tools_Users::create_user( $user_login, $params["user-email"], $params["user-display"], $user_roles, $params["corresponds_to_contact"] ?? null, $locale ?? null, $return_contact ?? false, $password, $optional_fields );

--- a/dt-users/users.php
+++ b/dt-users/users.php
@@ -116,14 +116,14 @@ class Disciple_Tools_Users
             $assure_unique = [];
             foreach ( $dispatchers as $index ){
                 $id = $index->user_id;
-                if ( $id && !in_array( $id, $assure_unique )){
+                if ( $id && !in_array( $id, $assure_unique ) ){
                     $assure_unique[] = $id;
                     $users[] = get_user_by( "ID", $id );
                 }
             }
             foreach ( $users_ids as $index ){
                 $id = $index[0];
-                if ( $id && !in_array( $id, $assure_unique )){
+                if ( $id && !in_array( $id, $assure_unique ) ){
                     $assure_unique[] = $id;
                     $users[] = get_user_by( "ID", $id );
                 }
@@ -215,7 +215,7 @@ class Disciple_Tools_Users
      * @return int|WP_Error|null the contact ID
      */
     public static function get_contact_for_user( $user_id ){
-        if ( !current_user_can( "access_contacts" )){
+        if ( !current_user_can( "access_contacts" ) ){
             return new WP_Error( 'no_permission', __( "Insufficient permissions", 'disciple_tools' ), [ 'status' => 403 ] );
         }
         $contact_id = get_user_option( "corresponds_to_contact", $user_id );
@@ -351,7 +351,7 @@ class Disciple_Tools_Users
         update_user_meta( $user_id, $wpdb->prefix . 'workload_status', 'active' );
 
         if ( $optional_fields ) {
-            foreach ($optional_fields as $key => $value) {
+            foreach ( $optional_fields as $key => $value ) {
                 if ( $key === "gender" ) {
                     update_user_option( $user_id, 'user_gender', $value );
                 } else {
@@ -385,7 +385,7 @@ class Disciple_Tools_Users
         $user = get_user_by( 'id', $user_id );
         $corresponds_to_contact = get_user_option( "corresponds_to_contact", $user_id );
         if ( $user && $user->has_cap( 'access_contacts' ) && is_user_member_of_blog( $user_id ) ) {
-            if ( empty( $corresponds_to_contact )){
+            if ( empty( $corresponds_to_contact ) ){
                 $args = [
                     'post_type'  => 'contacts',
                     'relation'   => 'AND',
@@ -406,7 +406,7 @@ class Disciple_Tools_Users
                     update_user_option( $user_id, "corresponds_to_contact", $corresponds_to_contact );
                 }
             }
-            if ( empty( $corresponds_to_contact )){
+            if ( empty( $corresponds_to_contact ) ){
                 $args = [
                     'post_type'  => 'contacts',
                     'relation'   => 'AND',
@@ -431,7 +431,7 @@ class Disciple_Tools_Users
                     "type"                => "user",
                     "corresponds_to_user" => $user_id,
                 ], true, false );
-                if ( !is_wp_error( $new_user_contact )){
+                if ( !is_wp_error( $new_user_contact ) ){
                     update_user_option( $user_id, "corresponds_to_contact", $new_user_contact["ID"] );
                     return $new_user_contact["ID"];
                 }
@@ -650,7 +650,7 @@ class Disciple_Tools_Users
         }
         if ( !empty( $body["add_languages"] ) ){
             $languages = get_user_option( "user_languages", $user->ID ) ?: [];
-            if ( !in_array( $body["add_languages"], $languages )){
+            if ( !in_array( $body["add_languages"], $languages ) ){
                 $languages[] = $body["add_languages"];
             }
             update_user_option( $user->ID, "user_languages", $languages );
@@ -658,7 +658,7 @@ class Disciple_Tools_Users
         }
         if ( !empty( $body["remove_languages"] ) ){
             $languages = get_user_option( "user_languages", $user->ID );
-            if ( in_array( $body["remove_languages"], $languages )){
+            if ( in_array( $body["remove_languages"], $languages ) ){
                 unset( $languages[array_search( $body["remove_languages"], $languages )] );
             }
             update_user_option( $user->ID, "user_languages", $languages );
@@ -666,7 +666,7 @@ class Disciple_Tools_Users
         }
         if ( !empty( $body["add_people_groups"] ) ){
             $people_groups = get_user_option( "user_people_groups", $user->ID ) ?: [];
-            if ( !in_array( $body["add_people_groups"], $people_groups )){
+            if ( !in_array( $body["add_people_groups"], $people_groups ) ){
                 $people_groups[] = $body["add_people_groups"];
             }
             update_user_option( $user->ID, "user_people_groups", $people_groups );
@@ -674,7 +674,7 @@ class Disciple_Tools_Users
         }
         if ( !empty( $body["remove_people_groups"] ) ){
             $people_groups = get_user_option( "user_people_groups", $user->ID );
-            if ( in_array( $body["remove_people_groups"], $people_groups )){
+            if ( in_array( $body["remove_people_groups"], $people_groups ) ){
                 unset( $people_groups[array_search( $body["remove_people_groups"], $people_groups )] );
             }
             update_user_option( $user->ID, "user_people_groups", $people_groups );
@@ -688,7 +688,7 @@ class Disciple_Tools_Users
         }
         try {
             do_action( 'dt_update_user', $user, $body );
-        } catch (Exception $e) {
+        } catch ( Exception $e ) {
             return new WP_Error( __FUNCTION__, $e->getMessage(), [ 'status' => $e->getCode() ] );
         }
         return true;
@@ -716,7 +716,7 @@ class Disciple_Tools_Users
         if ( $value === '' ){
             $status = update_metadata( 'user', $user_id, $preference_key, $default ? '0' : '1' );
             $label = $default ? "false" : "true";
-        } elseif ( $value === '0'){
+        } elseif ( $value === '0' ){
             $status = update_metadata( 'user', $user_id, $preference_key, "1" );
             $label = "true";
         } else {
@@ -1006,7 +1006,7 @@ class Disciple_Tools_Users
             $geocoder = new Location_Grid_Geocoder();
 
             $grid = $geocoder->query_by_grid_id( $location_grid_meta["grid_id"] );
-            if ($grid) {
+            if ( $grid ) {
                 $lgm = [];
 
                 Location_Grid_Meta::validate_location_grid_meta( $lgm );
@@ -1019,14 +1019,14 @@ class Disciple_Tools_Users
                 $lgm['label'] = $geocoder->_format_full_name( $grid );
 
                 $umeta_id = Location_Grid_Meta::add_user_location_grid_meta( $user_id, $lgm );
-                if (is_wp_error( $umeta_id )) {
+                if ( is_wp_error( $umeta_id ) ) {
                     return $umeta_id;
                 }
             }
         // use lng lat as base value
         } else {
 
-            if (empty( $location_grid_meta['lng'] ) || empty( $location_grid_meta['lat'] )) {
+            if ( empty( $location_grid_meta['lng'] ) || empty( $location_grid_meta['lat'] ) ) {
                 return new WP_Error( __METHOD__, 'Missing required lng or lat' );
             }
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -155,9 +155,9 @@
     <!-- <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.ExtraSpaceBeforeCloseParenthesis" /> -->
     <!-- <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.ExtraSpaceBeforeOpenParenthesis" /> -->
     <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterCloseParenthesis" />
-    <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis" />
+<!--    <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis" />-->
     <!-- <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterStructureOpen" /> -->
-    <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis" />
+<!--    <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis" />-->
     <!-- <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeOpenParenthesis" /> -->
     <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBetweenStructureColon" />
     <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.OpenBraceNotSameLine" />

--- a/single-template.php
+++ b/single-template.php
@@ -12,7 +12,7 @@ if ( ! current_user_can( 'access_' . $dt_post_type ) ) {
 ( function () {
     $post_type = get_post_type();
     $post_id = get_the_ID();
-    if ( !DT_Posts::can_view( $post_type, $post_id )){
+    if ( !DT_Posts::can_view( $post_type, $post_id ) ){
         get_template_part( "403" );
         die();
     }
@@ -87,7 +87,7 @@ if ( ! current_user_can( 'access_' . $dt_post_type ) ) {
                         $order = $tiles['status']["order"] ?? [];
                         foreach ( $post_settings["fields"] as $key => $option ){
                             if ( isset( $option["tile"] ) && $option["tile"] === 'status' ){
-                                if ( !in_array( $key, $order )){
+                                if ( !in_array( $key, $order ) ){
                                     $order[] = $key;
                                 }
                             }
@@ -142,7 +142,7 @@ if ( ! current_user_can( 'access_' . $dt_post_type ) ) {
                             $order = $tiles['details']["order"] ?? [];
                             foreach ( $post_settings["fields"] as $key => $option ){
                                 if ( isset( $option["tile"] ) && $option["tile"] === 'details' && $option['type'] === "communication_channel" ){
-                                    if ( !in_array( $key, $order )){
+                                    if ( !in_array( $key, $order ) ){
                                         $order[] = $key;
                                     }
                                 }
@@ -153,7 +153,7 @@ if ( ! current_user_can( 'access_' . $dt_post_type ) ) {
                                 }
 
                                 $field = $post_settings["fields"][$field_key];
-                                if ( isset( $field["tile"] ) && $field["tile"] === 'details'){
+                                if ( isset( $field["tile"] ) && $field["tile"] === 'details' ){
                                     ?>
                                     <div class="detail-snippet" id="collapsed-detail-<?php echo esc_html( $field_key ); ?>">
                                         <?php if ( isset( $field["icon"] ) ) : ?>
@@ -190,7 +190,7 @@ if ( ! current_user_can( 'access_' . $dt_post_type ) ) {
                                     continue;
                                 }
 
-                                if ( isset( $field["tile"] ) && $field["tile"] === 'details'){
+                                if ( isset( $field["tile"] ) && $field["tile"] === 'details' ){
                                     ?>
                                         <div class="detail-snippet" id="collapsed-detail-<?php echo esc_html( $field_key ); ?>">
                                             <?php if ( isset( $field["icon"] ) ) : ?>
@@ -218,7 +218,7 @@ if ( ! current_user_can( 'access_' . $dt_post_type ) ) {
                                 $order = $tiles['details']["order"] ?? [];
                                 foreach ( $post_settings["fields"] as $key => $option ){
                                     if ( isset( $option["tile"] ) && $option["tile"] === 'details' ){
-                                        if ( !in_array( $key, $order )){
+                                        if ( !in_array( $key, $order ) ){
                                             $order[] = $key;
                                         }
                                     }
@@ -234,7 +234,7 @@ if ( ! current_user_can( 'access_' . $dt_post_type ) ) {
                                         continue;
                                     }
 
-                                    if ( isset( $field["tile"] ) && $field["tile"] === 'details'){ ?>
+                                    if ( isset( $field["tile"] ) && $field["tile"] === 'details' ){ ?>
                                         <div class="cell small-12 medium-6">
                                             <?php render_field_for_display( $field_key, $post_settings["fields"], $dt_post ); ?>
                                         </div>
@@ -301,7 +301,7 @@ if ( ! current_user_can( 'access_' . $dt_post_type ) ) {
                                                     }
 
                                                     $field = $post_settings["fields"][$field_key];
-                                                    if ( isset( $field["tile"] ) && $field["tile"] === $tile_key){
+                                                    if ( isset( $field["tile"] ) && $field["tile"] === $tile_key ){
                                                         render_field_for_display( $field_key, $post_settings["fields"], $dt_post, true );
                                                     }
                                                 }

--- a/template-merge-details.php
+++ b/template-merge-details.php
@@ -45,28 +45,28 @@ $dt_data = array(
     'contact_facebook' => array()
 );
 
-foreach (array_keys( $dt_fields ) as $key) {
-    foreach ($dt_contact[$key] ?? [] as $vals) {
-        if ( !isset( $c_fields[$key] )) {
+foreach ( array_keys( $dt_fields ) as $key ) {
+    foreach ( $dt_contact[$key] ?? [] as $vals ) {
+        if ( !isset( $c_fields[$key] ) ) {
             $c_fields[$key] = array();
         }
         array_push( $c_fields[$key], $vals['value'] );
     }
-    foreach ($dt_duplicate_contact[$key] ?? [] as $vals) {
-        if ( !isset( $d_fields[$key] )) {
+    foreach ( $dt_duplicate_contact[$key] ?? [] as $vals ) {
+        if ( !isset( $d_fields[$key] ) ) {
             $d_fields[$key] = array();
         }
         array_push( $d_fields[$key], $vals['value'] );
     }
 }
 
-foreach (array_keys( $dt_fields ) as $field) {
+foreach ( array_keys( $dt_fields ) as $field ) {
     $max = max( array( count( $c_fields[$field] ?? [] ), count( $d_fields[$field] ?? [] ) ) );
-    for ($i = 0; $i < $max; $i++) {
+    for ( $i = 0; $i < $max; $i++ ) {
         $hide = false;
         $o_value = $c_fields[$field][$i] ?? null;
         $d_value = $d_fields[$field][$i] ?? null;
-        if (in_array( $o_value, $d_fields[$field] ?? [] )) { $hide = true; }
+        if ( in_array( $o_value, $d_fields[$field] ?? [] ) ) { $hide = true; }
         array_push($dt_data[$field], array(
             'original' => array(
                 'hide' => $hide,
@@ -155,7 +155,7 @@ $dt_edit_row = "<span class='row-edit'><a onclick='editRow(this, edit);' title='
                 </div>
 
                 <?php
-                foreach ($dt_fields as $dt_key => $dt_field) {
+                foreach ( $dt_fields as $dt_key => $dt_field ) {
                     foreach ( $dt_data[$dt_key] as $dt_idx => $dt_type ) : ?>
                         <div class='line-wrap'>
                             <div class='merge-column'><span class='bold'><?php echo esc_html( $dt_field ); ?></span></div>

--- a/template-settings.php
+++ b/template-settings.php
@@ -634,7 +634,7 @@ $apps_list = apply_filters( 'dt_settings_apps_list', $apps_list = [] );
                                     </label></td>
                                     <td>
                                         <select class="select-field" id="<?php echo esc_html( $field_key ); ?>" style="width:auto; display: block">
-                                            <?php foreach ($contact_fields[$field_key]["default"] as $option_key => $option_value):
+                                            <?php foreach ( $contact_fields[$field_key]["default"] as $option_key => $option_value ):
                                                 $selected = $user_field === $option_key; ?>
                                                 <option value="<?php echo esc_html( $option_key )?>" <?php echo esc_html( $selected ? "selected" : "" )?>>
                                                 <?php echo esc_html( $option_value["label"] ) ?>

--- a/tests/dt-posts/posts/unit-test-format-activity-message.php
+++ b/tests/dt-posts/posts/unit-test-format-activity-message.php
@@ -20,7 +20,7 @@ class DT_Posts_Posts_Format_Activity_Message extends WP_UnitTestCase {
                     "name" => 'My Field'
                 ]
             ]
-        ]);
+        ] );
         // Replace this with some actual testing code.
         $this->assertEquals( "tag-name added to My Field", $message );
     }
@@ -40,7 +40,7 @@ class DT_Posts_Posts_Format_Activity_Message extends WP_UnitTestCase {
                     "name" => 'My Field'
                 ]
             ]
-        ]);
+        ] );
         // Replace this with some actual testing code.
         $this->assertEquals( "old-tag removed from My Field", $message );
     }


### PR DESCRIPTION
This avoids inconsistencies like 
`if ( $test){}` 