### PR TITLE
Firing a JS event when the groups page member UI is updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ package-lock.json
 */development-only/*
 
 /composer.lock
+/.phpunit.result.cache

--- a/dt-groups/groups.js
+++ b/dt-groups/groups.js
@@ -181,6 +181,7 @@ jQuery(document).ready(function($) {
     memberCountInput.val( post.member_count )
     leaderCountInput.val( post.leader_count )
     window.masonGrid.masonry('layout')
+    document.dispatchEvent(new CustomEvent("dt-member-list-populated", {detail: post}))
   }
   populateMembersList()
 


### PR DESCRIPTION
I'm not firing it with jQuery's `trigger` because jQuery events can't be read by the vanilla JS's `addEventListener`. From what I'm reading, jQuery's `on` will fire on custom DOM events.