### PR TITLE
Contact status fixes

### DIFF
--- a/dt-contacts/access-module.php
+++ b/dt-contacts/access-module.php
@@ -701,6 +701,10 @@ class DT_Contacts_Access extends DT_Module_Base {
             if ( isset( $fields["overall_status"], $fields["reason_closed"] ) && $fields["overall_status"] === "closed" ){
                 $fields["requires_update"] = false;
             }
+            //if a contact type is changed to access, set the status to active if there is no status
+            if ( isset( $fields["type"] ) && $fields["type"] === "access" && !isset( $existing_post["overall_status"] ) && !isset( $fields["overall_status"] ) ){
+                $fields["overall_status"] = "active";
+            }
         }
         return $fields;
     }

--- a/dt-contacts/access-module.php
+++ b/dt-contacts/access-module.php
@@ -701,9 +701,16 @@ class DT_Contacts_Access extends DT_Module_Base {
             if ( isset( $fields["overall_status"], $fields["reason_closed"] ) && $fields["overall_status"] === "closed" ){
                 $fields["requires_update"] = false;
             }
-            //if a contact type is changed to access, set the status to active if there is no status
-            if ( isset( $fields["type"] ) && $fields["type"] === "access" && !isset( $existing_post["overall_status"] ) && !isset( $fields["overall_status"] ) ){
-                $fields["overall_status"] = "active";
+            //if a contact type is changed to access
+            if ( isset( $fields["type"] ) && $fields["type"] === "access" ){
+                //set the status to active if there is no status
+                if ( !isset( $existing_post["overall_status"] ) && !isset( $fields["overall_status"] ) ){
+                    $fields["overall_status"] = "active";
+                }
+                //assign the contact to the user
+                if ( !isset( $existing_post["assigned_to"] ) && !isset( $fields["assigned_to"] ) && get_current_user_id() ){
+                    $fields["assigned_to"] = get_current_user_id();
+                }
             }
         }
         return $fields;

--- a/dt-contacts/contacts_access.js
+++ b/dt-contacts/contacts_access.js
@@ -56,7 +56,7 @@ jQuery(document).ready(function($) {
           updateCriticalPath(response.seeker_path.key)
         }
       }
-      if (key === "overall_status" ){
+      if (key === "overall_status" || key === "assigned_to"){
         setStatus(response)
       }
     })


### PR DESCRIPTION
Update Contact Status field when Assigned To has changed
If a contact type is changed to access:
- assign the contact to the user
- set the status to active if there is no status