### PR TITLE
Added "Uninstall" Button in DT_Extensions Menu

### DIFF
--- a/dt-core/admin/menu/tabs/tab-featured-extensions.php
+++ b/dt-core/admin/menu/tabs/tab-featured-extensions.php
@@ -233,14 +233,20 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
                                 <?php endif;
 
                             } elseif ( $this->partial_array_search( $active_plugins, $plugin->slug ) == -1 && isset( $_POST["activate"] ) == false ) {
-                                ?>    
+                                if ( current_user_can( "install_plugins" ) ) {
+                                    ?>    
                                     <li>
                                         <button class="button" onclick="activate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Activate', 'disciple_tools' ) ?></button>
                                     </li>
                                     <li>
                                         <button class="button" onclick="uninstall('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Uninstall', 'disciple_tools' ) ?></button>
                                     </li>
-                                <?php
+                                    <?php
+                                } else { ?>
+                                    <li>
+                                        <span>To install this plugin ask your network administrator</span>
+                                    </li>
+                                <?php }
                             } else {
                                 ?>
                                     <li>

--- a/dt-core/admin/menu/tabs/tab-featured-extensions.php
+++ b/dt-core/admin/menu/tabs/tab-featured-extensions.php
@@ -30,8 +30,13 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
         $nonce = wp_create_nonce( 'portal-nonce' );
         ?>
         <script type="text/javascript">
-            function install(plug) {
-                jQuery('#wpbody-content').replaceWith("<p><?php esc_html_e( 'installing', 'disciple_tools' ); ?>...</p>");
+            function install(plug, is_multisite = false) {
+                if ( is_multisite ) {
+                    jQuery('#wpbody-content').replaceWith("<p><?php esc_html_e( 'network installing', 'disciple_tools' ); ?>...</p>");    
+                } else {
+                    jQuery('#wpbody-content').replaceWith("<p><?php esc_html_e( 'installing', 'disciple_tools' ); ?>...</p>");
+                }
+
                 jQuery.post("",
                     {
                         install: plug,
@@ -42,8 +47,13 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
                     });
             }
 
-            function uninstall(plug) {
-                jQuery('#wpbody-content').replaceWith("<p><?php esc_html_e( 'uninstalling', 'disciple_tools' ); ?></p>");
+            function uninstall(plug, is_multisite = false ) {
+                if ( is_multisite ) {
+                    jQuery('#wpbody-content').replaceWith("<p><?php esc_html_e( 'network uninstalling', 'disciple_tools' ); ?>...</p>");
+                } else {
+                    jQuery('#wpbody-content').replaceWith("<p><?php esc_html_e( 'uninstalling', 'disciple_tools' ); ?>...</p>");
+                }
+
                 jQuery.post("",
                     {
                         uninstall: plug,
@@ -76,7 +86,7 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
                     function (data, status) {
                         location.reload();
                     });
-            }
+            }         
         </script>
         <?php
     }
@@ -126,7 +136,8 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
             //activate the plugin
             activate_plugin( sanitize_text_field( wp_unslash( $_POST["activate"] ) ) );
             exit;
-        } elseif ( isset( $_POST ) && isset( $_POST['install'] ) && is_admin() && isset( $_POST['_ajax_nonce'] )
+        }
+            elseif ( isset( $_POST['install'] ) && is_admin() && isset( $_POST['_ajax_nonce'] )
             && check_ajax_referer( 'portal-nonce', sanitize_key( $_POST['_ajax_nonce'] ) )
             && ( ( is_multisite() && is_super_admin() ) || ( ! is_multisite() && current_user_can( 'manage_dt' ) ) ) ) {
             //check for admin or multisite super admin
@@ -135,7 +146,7 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
             exit;
         }
 
-        elseif ( isset( $_POST ) && isset( $_POST['uninstall'] ) && is_admin() && isset( $_POST['_ajax_nonce'] )
+        elseif ( isset( $_POST['uninstall'] ) && is_admin() && isset( $_POST['_ajax_nonce'] )
             && check_ajax_referer( 'portal-nonce', sanitize_key( $_POST['_ajax_nonce'] ) )
             && ( ( is_multisite() && is_super_admin() ) || ( ! is_multisite() && current_user_can( 'manage_dt' ) ) ) ) {
             //check for admin or multisite super admin
@@ -221,7 +232,17 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
                             if ( $result_name == -1 ) {
                                 if ( isset( $plugin->download_url ) && current_user_can( "install_plugins" ) ) : ?>
                                 <li>
-                                    <button class="button" onclick="install('<?php echo esc_html( $plugin->download_url ); ?>')"><?php echo esc_html__( 'Install', 'disciple_tools' ) ?></button>
+                                    <?php
+                                        if ( is_multisite() ) {
+                                            ?>
+                                                <button class="button" onclick="install('<?php echo esc_attr( $plugin->download_url ); ?>', true )"><?php echo esc_html__( 'Network Install', 'disciple_tools' ); ?></button>
+                                            <?php
+                                        } else {
+                                            ?>
+                                                <button class="button" onclick="install('<?php echo esc_attr( $plugin->download_url ); ?>')"><?php echo esc_html__( 'Install', 'disciple_tools' ) ?></button>
+                                            <?php
+                                        }
+                                    ?>
                                 </li>
                                 <?php else : ?>
                                     <li>
@@ -232,17 +253,46 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
                             } elseif ( $this->partial_array_search( $active_plugins, $plugin->slug ) == -1 && isset( $_POST["activate"] ) == false ) {
                                 ?>
                                     <li>
-                                        <button class="button" onclick="activate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Activate', 'disciple_tools' ) ?></button>
+                                        <?php
+                                            if ( is_multisite() ) {
+                                                ?>
+                                                    <a href="<?php echo esc_attr( network_admin_url() ); ?>plugins.php" class="button"><?php echo esc_html__( 'Network Activate', 'disciple_tools' ); ?></a>
+                                                <?php
+                                            } else {
+                                                ?>
+                                                    <button class="button" onclick="activate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Activate', 'disciple_tools' ) ?></button>
+                                                <?php
+                                            }
+                                        ?>
                                     </li>
                                     <li>
-                                        <button class="button" onclick="uninstall('<?php echo esc_html( $plugin->slug ); ?>/<?php echo esc_html( $plugin->slug );?>.php')"><?php echo esc_html__( 'Uninstall', 'disciple_tools' ) ?></button>
-                                        <!-- <a class="button" href="http://localhost:10033/wp-admin/plugins.php?action=delete-selected&checked%5B0%5D=disciple-tools-demo-content%2Fdisciple-tools-demo-content.php&plugin_status=all&paged=1&s&_wpnonce=0d0ef6e4f1"><?php echo esc_html__( 'Uninstall', 'disciple_tools' ) ?></a> -->
+                                        <?php
+                                            if ( is_multisite() ) {
+                                                ?>
+                                                    <button class="button" onclick="uninstall('<?php echo esc_attr( $result_name ); ?>', true )"><?php echo esc_html__( 'Network Uninstall', 'disciple_tools' ); ?></button>
+                                                <?php
+                                            } else {
+                                                ?>
+                                                    <button class="button" onclick="uninstall('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Uninstall', 'disciple_tools' ) ?></button>
+                                                <?php
+                                            }
+                                        ?>
                                     </li>
                                 <?php
                             } else {
                                 ?>
                                 <li>
-                                    <button class="button" onclick="deactivate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Deactivate', 'disciple_tools' ) ?></button>
+                                    <?php
+                                        if ( is_multisite() ) {
+                                            ?>
+                                                <a href="<?php echo esc_attr( network_admin_url() ); ?>plugins.php" class="button"><?php echo esc_html__( 'Network Deactivate', 'disciple_tools' ); ?></a>
+                                            <?php
+                                        } else {
+                                            ?>
+                                                <button class="button" onclick="deactivate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Deactivate', 'disciple_tools' ) ?></button>
+                                            <?php
+                                        }
+                                    ?>
                                 </li>
                                 <?php
                             }

--- a/dt-core/admin/menu/tabs/tab-featured-extensions.php
+++ b/dt-core/admin/menu/tabs/tab-featured-extensions.php
@@ -31,11 +31,7 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
         ?>
         <script type="text/javascript">
             function install(plug, is_multisite = false) {
-                if ( is_multisite ) {
-                    jQuery('#wpbody-content').replaceWith("<p><?php esc_html_e( 'network installing', 'disciple_tools' ); ?>...</p>");    
-                } else {
-                    jQuery('#wpbody-content').replaceWith("<p><?php esc_html_e( 'installing', 'disciple_tools' ); ?>...</p>");
-                }
+                jQuery('#wpbody-content').replaceWith("<p><?php esc_html_e( 'installing', 'disciple_tools' ); ?>...</p>");
 
                 jQuery.post("",
                     {
@@ -48,11 +44,7 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
             }
 
             function uninstall(plug, is_multisite = false ) {
-                if ( is_multisite ) {
-                    jQuery('#wpbody-content').replaceWith("<p><?php esc_html_e( 'network uninstalling', 'disciple_tools' ); ?>...</p>");
-                } else {
                     jQuery('#wpbody-content').replaceWith("<p><?php esc_html_e( 'uninstalling', 'disciple_tools' ); ?>...</p>");
-                }
 
                 jQuery.post("",
                     {
@@ -137,7 +129,7 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
             activate_plugin( sanitize_text_field( wp_unslash( $_POST["activate"] ) ) );
             exit;
         }
-            elseif ( isset( $_POST['install'] ) && is_admin() && isset( $_POST['_ajax_nonce'] )
+        elseif ( isset( $_POST['install'] ) && is_admin() && isset( $_POST['_ajax_nonce'] )
             && check_ajax_referer( 'portal-nonce', sanitize_key( $_POST['_ajax_nonce'] ) )
             && ( ( is_multisite() && is_super_admin() ) || ( ! is_multisite() && current_user_can( 'manage_dt' ) ) ) ) {
             //check for admin or multisite super admin
@@ -231,23 +223,9 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
                             $result_name = $this->partial_array_search( $all_plugins, $plugin->slug );
                             if ( $result_name == -1 ) {
                                 if ( isset( $plugin->download_url ) && current_user_can( "install_plugins" ) ) : ?>
-                                
-                                    <?php
-                                        if ( is_multisite() ) {
-                                            ?>
-                                            <li>
-                                                <button class="button" onclick="install('<?php echo esc_attr( $plugin->download_url ); ?>', true )"><?php echo esc_html__( 'Network Install', 'disciple_tools' ); ?></button>
-                                            </li>
-                                            <?php
-                                        } else {
-                                            ?>
-                                            <li>
-                                                <button class="button" onclick="install('<?php echo esc_attr( $plugin->download_url ); ?>')"><?php echo esc_html__( 'Install', 'disciple_tools' ) ?></button>
-                                            </li>
-                                            <?php
-                                        }
-                                    ?>
-                                
+                                    <li>
+                                        <button class="button" onclick="install('<?php echo esc_attr( $plugin->download_url ); ?>')"><?php echo esc_html__( 'Install', 'disciple_tools' ) ?></button>
+                                    </li>                               
                                 <?php else : ?>
                                     <li>
                                         <span>To install this plugin ask your network administrator</span>
@@ -255,64 +233,21 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
                                 <?php endif;
 
                             } elseif ( $this->partial_array_search( $active_plugins, $plugin->slug ) == -1 && isset( $_POST["activate"] ) == false ) {
-                                ?>
-                                        <?php
-                                            if ( is_multisite() ) {
-                                                ?>
-                                                <li>
-                                                    <a href="<?php echo esc_attr( network_admin_url() ); ?>plugins.php" class="button"><?php echo esc_html__( 'Network Activate', 'disciple_tools' ); ?></a>
-                                                </li>
-                                                <li>
-                                                    <button class="button" onclick="activate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Single Activate', 'disciple_tools' ) ?></button>  
-                                                </li>
-                                                <?php
-                                            } else {
-                                                ?>
-                                                <li>
-                                                    <button class="button" onclick="activate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Activate', 'disciple_tools' ) ?></button>
-                                                </li>
-                                                <?php
-                                            }
-                                        ?>
-                                        <?php
-                                            if ( is_multisite() ) {
-                                                ?>
-                                                <li>
-                                                    <button class="button" onclick="uninstall('<?php echo esc_attr( $result_name ); ?>', true )"><?php echo esc_html__( 'Network Uninstall', 'disciple_tools' ); ?></button>
-                                                </li>
-                                                <?php
-                                            } else {
-                                                ?>
-                                                <li>
-                                                    <button class="button" onclick="uninstall('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Uninstall', 'disciple_tools' ) ?></button>
-                                                </li>
-                                                <?php
-                                            }
-                                        ?>
+                                ?>    
+                                    <li>
+                                        <button class="button" onclick="activate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Activate', 'disciple_tools' ) ?></button>
+                                    </li>
+                                    <li>
+                                        <button class="button" onclick="uninstall('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Uninstall', 'disciple_tools' ) ?></button>
+                                    </li>
                                 <?php
                             } else {
                                 ?>
-                                    <?php
-                                        if ( is_multisite() ) {
-                                            ?>
-                                            <li>
-                                                <a href="<?php echo esc_attr( network_admin_url() ); ?>plugins.php" class="button"><?php echo esc_html__( 'Network Deactivate', 'disciple_tools' ); ?></a>
-                                            </li>
-                                            <li>
-                                                <button class="button" onclick="deactivate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Single Deactivate', 'disciple_tools' ) ?></button>
-                                            </li>
-                                            <?php
-                                        } else {
-                                            ?>
-                                            <li>
-                                                <button class="button" onclick="deactivate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Deactivate', 'disciple_tools' ) ?></button>
-                                            </li>
-                                            <?php
-                                        }
-                                    ?>
+                                    <li>
+                                        <button class="button" onclick="deactivate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Deactivate', 'disciple_tools' ) ?></button>
+                                    </li>          
                                 <?php
                             }
-                            
                             if ( in_array( 'proof-of-concept', explode( ',', $plugin->categories ) ) ): ?>
                             <li>
                                 <a class="warning-pill">POC</a>

--- a/dt-core/admin/menu/tabs/tab-featured-extensions.php
+++ b/dt-core/admin/menu/tabs/tab-featured-extensions.php
@@ -31,12 +31,23 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
         ?>
         <script type="text/javascript">
             function install(plug) {
-                jQuery("#wpbody-content").replaceWith("<p><?php esc_html_e( 'installing', 'disciple_tools' ) ?>...</p>");
+                jQuery('#wpbody-content').replaceWith("<p><?php esc_html_e( 'installing', 'disciple_tools' ); ?>...</p>");
                 jQuery.post("",
                     {
                         install: plug,
                         _ajax_nonce: "<?php echo esc_attr( $nonce ); ?>"
+                    },
+                    function (data, status) {
+                        location.reload();
+                    });
+            }
 
+            function uninstall(plug) {
+                jQuery('#wpbody-content').replaceWith("<p><?php esc_html_e( 'uninstalling', 'disciple_tools' ); ?></p>");
+                jQuery.post("",
+                    {
+                        uninstall: plug,
+                        _ajax_nonce: "<?php echo esc_attr( $nonce ); ?>"
                     },
                     function (data, status) {
                         location.reload();
@@ -44,7 +55,7 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
             }
 
             function deactivate(plug) {
-                jQuery("#wpbody-content").replaceWith("<p><?php esc_html_e( 'deactivating', 'disciple_tools' ) ?>...</p>");
+                jQuery('#wpbody-content').replaceWith("<p><?php esc_html_e( 'deactivating', 'disciple_tools' ); ?>...</p>");
                 jQuery.post("",
                     {
                         deactivate: plug,
@@ -56,7 +67,7 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
             }
 
             function activate(plug) {
-                jQuery("#wpbody-content").replaceWith("<p><?php esc_html_e( 'activating', 'disciple_tools' ) ?>...</p>");
+                jQuery('#wpbody-content').replaceWith("<p><?php esc_html_e( 'activating', 'disciple_tools' ); ?>...</p>");
                 jQuery.post("",
                     {
                         activate: plug,
@@ -115,18 +126,30 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
             //activate the plugin
             activate_plugin( sanitize_text_field( wp_unslash( $_POST["activate"] ) ) );
             exit;
-        } elseif ( isset( $_POST ) && isset( $_POST["install"] ) && is_admin() && isset( $_POST["_ajax_nonce"] )
-            && check_ajax_referer( 'portal-nonce', sanitize_key( $_POST["_ajax_nonce"] ) )
-            && ( ( is_multisite() && is_super_admin() ) || ( ! is_multisite() && current_user_can( "manage_dt" ) ) ) ) {
+        } elseif ( isset( $_POST ) && isset( $_POST['install'] ) && is_admin() && isset( $_POST['_ajax_nonce'] )
+            && check_ajax_referer( 'portal-nonce', sanitize_key( $_POST['_ajax_nonce'] ) )
+            && ( ( is_multisite() && is_super_admin() ) || ( ! is_multisite() && current_user_can( 'manage_dt' ) ) ) ) {
             //check for admin or multisite super admin
             //install plugin
-            $this->install_plugin( sanitize_text_field( wp_unslash( $_POST["install"] ) ) );
+            $this->install_plugin( sanitize_text_field( wp_unslash( $_POST['install'] ) ) );
             exit;
-        } elseif ( isset( $_POST["deactivate"] ) && is_admin() && isset( $_POST["_ajax_nonce"] ) && check_ajax_referer( 'portal-nonce', sanitize_key( $_POST["_ajax_nonce"] ) ) && current_user_can( "manage_dt" ) ) {
+        }
+
+        elseif ( isset( $_POST ) && isset( $_POST['uninstall'] ) && is_admin() && isset( $_POST['_ajax_nonce'] )
+            && check_ajax_referer( 'portal-nonce', sanitize_key( $_POST['_ajax_nonce'] ) )
+            && ( ( is_multisite() && is_super_admin() ) || ( ! is_multisite() && current_user_can( 'manage_dt' ) ) ) ) {
+            //check for admin or multisite super admin
+            //uninstall plugin
+            delete_plugins( [ sanitize_text_field( wp_unslash( $_POST['uninstall'] ) ) ] );
+            exit;
+        }
+
+        elseif ( isset( $_POST["deactivate"] ) && is_admin() && isset( $_POST["_ajax_nonce"] ) && check_ajax_referer( 'portal-nonce', sanitize_key( $_POST["_ajax_nonce"] ) ) && current_user_can( "manage_dt" ) ) {
             //deactivate the plugin
             deactivate_plugins( sanitize_text_field( wp_unslash( $_POST["deactivate"] ) ), true );
             exit;
         }
+
         $network_active_plugins = get_site_option( 'active_sitewide_plugins', [] );
         $active_plugins = get_option( 'active_plugins', [] );
         foreach ( $network_active_plugins as $plugin => $time ){
@@ -193,40 +216,47 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
                     </div>
                     <div class="action-links">
                         <ul class="plugin-action-buttons">
-                            <li>
                             <?php
                             $result_name = $this->partial_array_search( $all_plugins, $plugin->slug );
                             if ( $result_name == -1 ) {
                                 if ( isset( $plugin->download_url ) && current_user_can( "install_plugins" ) ) : ?>
-                                <button class="button"
-                                        onclick="install('<?php echo esc_html( $plugin->download_url ); ?>')"><?php echo esc_html__( 'Install', 'disciple_tools' ) ?></button>
+                                <li>
+                                    <button class="button" onclick="install('<?php echo esc_html( $plugin->download_url ); ?>')"><?php echo esc_html__( 'Install', 'disciple_tools' ) ?></button>
+                                </li>
                                 <?php else : ?>
-                                    <span>To install this plugin ask your network administrator</span>
+                                    <li>
+                                        <span>To install this plugin ask your network administrator</span>
+                                    </li>
                                 <?php endif;
 
                             } elseif ( $this->partial_array_search( $active_plugins, $plugin->slug ) == -1 && isset( $_POST["activate"] ) == false ) {
                                 ?>
-                                <button class="button"
-                                        onclick="activate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Activate', 'disciple_tools' ) ?></button>
+                                    <li>
+                                        <button class="button" onclick="activate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Activate', 'disciple_tools' ) ?></button>
+                                    </li>
+                                    <li>
+                                        <button class="button" onclick="uninstall('<?php echo esc_html( $plugin->slug ); ?>/<?php echo esc_html( $plugin->slug );?>.php')"><?php echo esc_html__( 'Uninstall', 'disciple_tools' ) ?></button>
+                                        <!-- <a class="button" href="http://localhost:10033/wp-admin/plugins.php?action=delete-selected&checked%5B0%5D=disciple-tools-demo-content%2Fdisciple-tools-demo-content.php&plugin_status=all&paged=1&s&_wpnonce=0d0ef6e4f1"><?php echo esc_html__( 'Uninstall', 'disciple_tools' ) ?></a> -->
+                                    </li>
                                 <?php
                             } else {
                                 ?>
-                                <button class="button"
-                                        onclick="deactivate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Deactivate', 'disciple_tools' ) ?></button>
+                                <li>
+                                    <button class="button" onclick="deactivate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Deactivate', 'disciple_tools' ) ?></button>
+                                </li>
                                 <?php
                             }
-                            ?>
-                            </li>
-                            <?php if ( in_array( 'proof-of-concept', explode( ',', $plugin->categories ) ) ): ?>
+                            
+                            if ( in_array( 'proof-of-concept', explode( ',', $plugin->categories ) ) ): ?>
                             <li>
                                 <a class="warning-pill">POC</a>
                             </li>
                         <?php elseif ( in_array( 'beta', explode( ',', $plugin->categories ) ) ): ?>
                             <li>
-
                                 <a class="warning-pill">BETA</a>
                             </li>
-                    <?php endif; ?>
+                    <?php endif;?>
+
                         </ul>
                     </div>
                     <div class="desc column-description">

--- a/dt-core/admin/menu/tabs/tab-featured-extensions.php
+++ b/dt-core/admin/menu/tabs/tab-featured-extensions.php
@@ -231,19 +231,23 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
                             $result_name = $this->partial_array_search( $all_plugins, $plugin->slug );
                             if ( $result_name == -1 ) {
                                 if ( isset( $plugin->download_url ) && current_user_can( "install_plugins" ) ) : ?>
-                                <li>
+                                
                                     <?php
                                         if ( is_multisite() ) {
                                             ?>
+                                            <li>
                                                 <button class="button" onclick="install('<?php echo esc_attr( $plugin->download_url ); ?>', true )"><?php echo esc_html__( 'Network Install', 'disciple_tools' ); ?></button>
+                                            </li>
                                             <?php
                                         } else {
                                             ?>
+                                            <li>
                                                 <button class="button" onclick="install('<?php echo esc_attr( $plugin->download_url ); ?>')"><?php echo esc_html__( 'Install', 'disciple_tools' ) ?></button>
+                                            </li>
                                             <?php
                                         }
                                     ?>
-                                </li>
+                                
                                 <?php else : ?>
                                     <li>
                                         <span>To install this plugin ask your network administrator</span>
@@ -252,48 +256,60 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
 
                             } elseif ( $this->partial_array_search( $active_plugins, $plugin->slug ) == -1 && isset( $_POST["activate"] ) == false ) {
                                 ?>
-                                    <li>
                                         <?php
                                             if ( is_multisite() ) {
                                                 ?>
+                                                <li>
                                                     <a href="<?php echo esc_attr( network_admin_url() ); ?>plugins.php" class="button"><?php echo esc_html__( 'Network Activate', 'disciple_tools' ); ?></a>
+                                                </li>
+                                                <li>
+                                                    <button class="button" onclick="activate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Single Activate', 'disciple_tools' ) ?></button>  
+                                                </li>
                                                 <?php
                                             } else {
                                                 ?>
+                                                <li>
                                                     <button class="button" onclick="activate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Activate', 'disciple_tools' ) ?></button>
+                                                </li>
                                                 <?php
                                             }
                                         ?>
-                                    </li>
-                                    <li>
                                         <?php
                                             if ( is_multisite() ) {
                                                 ?>
+                                                <li>
                                                     <button class="button" onclick="uninstall('<?php echo esc_attr( $result_name ); ?>', true )"><?php echo esc_html__( 'Network Uninstall', 'disciple_tools' ); ?></button>
+                                                </li>
                                                 <?php
                                             } else {
                                                 ?>
+                                                <li>
                                                     <button class="button" onclick="uninstall('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Uninstall', 'disciple_tools' ) ?></button>
+                                                </li>
                                                 <?php
                                             }
                                         ?>
-                                    </li>
                                 <?php
                             } else {
                                 ?>
-                                <li>
                                     <?php
                                         if ( is_multisite() ) {
                                             ?>
+                                            <li>
                                                 <a href="<?php echo esc_attr( network_admin_url() ); ?>plugins.php" class="button"><?php echo esc_html__( 'Network Deactivate', 'disciple_tools' ); ?></a>
+                                            </li>
+                                            <li>
+                                                <button class="button" onclick="deactivate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Single Deactivate', 'disciple_tools' ) ?></button>
+                                            </li>
                                             <?php
                                         } else {
                                             ?>
+                                            <li>
                                                 <button class="button" onclick="deactivate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Deactivate', 'disciple_tools' ) ?></button>
+                                            </li>
                                             <?php
                                         }
                                     ?>
-                                </li>
                                 <?php
                             }
 

--- a/dt-core/admin/menu/tabs/tab-featured-extensions.php
+++ b/dt-core/admin/menu/tabs/tab-featured-extensions.php
@@ -246,7 +246,7 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
                                 </li>
                                 <?php
                             }
-                            
+
                             if ( in_array( 'proof-of-concept', explode( ',', $plugin->categories ) ) ): ?>
                             <li>
                                 <a class="warning-pill">POC</a>

--- a/dt-core/admin/menu/tabs/tab-featured-extensions.php
+++ b/dt-core/admin/menu/tabs/tab-featured-extensions.php
@@ -30,7 +30,7 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
         $nonce = wp_create_nonce( 'portal-nonce' );
         ?>
         <script type="text/javascript">
-            function install(plug, is_multisite = false) {
+            function install(plug) {
                 jQuery('#wpbody-content').replaceWith("<p><?php esc_html_e( 'installing', 'disciple_tools' ); ?>...</p>");
 
                 jQuery.post("",
@@ -43,7 +43,7 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
                     });
             }
 
-            function uninstall(plug, is_multisite = false ) {
+            function uninstall(plug) {
                     jQuery('#wpbody-content').replaceWith("<p><?php esc_html_e( 'uninstalling', 'disciple_tools' ); ?>...</p>");
 
                 jQuery.post("",

--- a/dt-core/admin/menu/tabs/tab-featured-extensions.php
+++ b/dt-core/admin/menu/tabs/tab-featured-extensions.php
@@ -312,7 +312,7 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
                                     ?>
                                 <?php
                             }
-
+                            
                             if ( in_array( 'proof-of-concept', explode( ',', $plugin->categories ) ) ): ?>
                             <li>
                                 <a class="warning-pill">POC</a>

--- a/dt-core/admin/menu/tabs/tab-featured-extensions.php
+++ b/dt-core/admin/menu/tabs/tab-featured-extensions.php
@@ -233,20 +233,18 @@ class Disciple_Tools_Tab_Featured_Extensions extends Disciple_Tools_Abstract_Men
                                 <?php endif;
 
                             } elseif ( $this->partial_array_search( $active_plugins, $plugin->slug ) == -1 && isset( $_POST["activate"] ) == false ) {
+                                ?>
+                                <li>
+                                    <button class="button" onclick="activate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Activate', 'disciple_tools' ) ?></button>
+                                </li>
+                                <?php
                                 if ( current_user_can( "install_plugins" ) ) {
                                     ?>    
-                                    <li>
-                                        <button class="button" onclick="activate('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Activate', 'disciple_tools' ) ?></button>
-                                    </li>
                                     <li>
                                         <button class="button" onclick="uninstall('<?php echo esc_html( $result_name ); ?>')"><?php echo esc_html__( 'Uninstall', 'disciple_tools' ) ?></button>
                                     </li>
                                     <?php
-                                } else { ?>
-                                    <li>
-                                        <span>To install this plugin ask your network administrator</span>
-                                    </li>
-                                <?php }
+                                }
                             } else {
                                 ?>
                                     <li>


### PR DESCRIPTION
Now, if a plugin is installed but not active, the user can uninstall it from the DT Extensions menu.

<img width="1282" alt="uninstall button" src="https://user-images.githubusercontent.com/36511666/156048783-e0cdac09-09a1-4503-bc28-5c0774bf01b2.png">

This solves the following issue:
https://github.com/DiscipleTools/disciple-tools-theme/issues/1530
