### PR TITLE
Quick actions translate

### DIFF
--- a/dt-core/admin/menu/tabs/tab-custom-lists.php
+++ b/dt-core/admin/menu/tabs/tab-custom-lists.php
@@ -605,7 +605,8 @@ class Disciple_Tools_Tab_Custom_Lists extends Disciple_Tools_Abstract_Menu_Base
                     foreach ( $fields as $field_key => $field_settings ) :
                         if ( ! isset( $field_settings['section'] ) || substr( $field_settings['section'], 0, 13 ) !== 'quick_buttons' ) {
                             continue;
-                        }?>
+                        }
+                    ?>
                         <tr>
                             <td>
                                 <img style="width: 20px; vertical-align: middle;" src="<?php echo esc_attr( $field_settings['icon'] ); ?>" class="quick-action-menu">
@@ -630,7 +631,7 @@ class Disciple_Tools_Tab_Custom_Lists extends Disciple_Tools_Abstract_Menu_Base
                                     <?php
                                     $number_of_translations = 0;
                                     foreach ( $langs as $lang => $val ) {
-                                        if ( !empty( $channel_option['translations'][$val['language']] ) ) {
+                                        if ( !empty( $fields[$field_key]['translations'][$val['language']] ) ) {
                                             $number_of_translations ++;
                                         }
                                     }
@@ -643,7 +644,7 @@ class Disciple_Tools_Tab_Custom_Lists extends Disciple_Tools_Abstract_Menu_Base
                                     <?php foreach ( $langs as $lang => $val ) : ?>
                                         <tr>
                                             <td><label for="field_label[<?php echo esc_html( $field_key ) ?>][<?php echo esc_html( $val['language'] )?>]"><?php echo esc_html( $val['native_name'] )?></label></td>
-                                            <td><input name="field_label[<?php echo esc_html( $field_key ) ?>][<?php echo esc_html( $val['language'] )?>]" type="text" value="<?php echo esc_html( $field_option["translations"][$val['language']] ?? "" );?>"/></td>
+                                            <td><input name="field_label[<?php echo esc_html( $field_key ) ?>][<?php echo esc_html( $val['language'] )?>]" type="text" value="<?php echo esc_html( $fields[$field_key]["translations"][$val['language']] ?? "" );?>"/></td>
                                         </tr>
                                     <?php endforeach; ?>
                                     </table>

--- a/dt-core/admin/menu/tabs/tab-custom-lists.php
+++ b/dt-core/admin/menu/tabs/tab-custom-lists.php
@@ -691,32 +691,34 @@ class Disciple_Tools_Tab_Custom_Lists extends Disciple_Tools_Abstract_Menu_Base
                 self::admin_notice( __( 'Something went wrong', 'disciple_tools' ), 'error' );
                 return;
             }
+        }
 
-            $langs = dt_get_available_languages();
-            $custom_field_options = dt_get_option( 'dt_field_customizations' );
-            $custom_contact_fields = DT_Posts::get_post_field_settings( 'contacts' );
+        $fields = DT_Posts::get_post_field_settings( 'contacts' );
+        $langs = dt_get_available_languages();
+        $custom_field_options = dt_get_option( 'dt_field_customizations' );
+        $custom_contact_fields = $custom_field_options['contacts'];
 
-            foreach ( $custom_contact_fields as $field_key => $field_settings ) {
-                foreach ( $langs as $lang => $val ) {
-                    $langcode = $val['language'];
-                    if ( isset( $_POST['field_label'][$field_key][$langcode] ) ) {
-                        $translated_label = sanitize_text_field( wp_unslash( $_POST['field_label'][$field_key][$langcode] ) );
-                        // Add new translation
-                        if ( !empty( $translated_label ) ) {
-                            $custom_contact_fields[$field_key]['translations'][$langcode] = $translated_label;
-                        }
+        foreach ( $custom_contact_fields as $field_key => $field_settings ) {
+            foreach ( $langs as $lang => $val ) {
+                $langcode = $val['language'];
+                if ( isset( $_POST['field_label'][$field_key][$langcode] ) ) {
+                    $translated_label = sanitize_text_field( wp_unslash( $_POST['field_label'][$field_key][$langcode] ) );
+                    // Add new translation
+                    if ( !empty( $translated_label ) ) {
+                        $custom_contact_fields[$field_key]['translations'][$langcode] = $translated_label;
+                    }
 
-                        // Remove translation
-                        if ( ( empty( $translated_label ) && !empty( $custom_contact_fields[$field_key]['translations'][$langcode] ) ) ) {
-                            $custom_contact_fields[$field_key]['translations'][$langcode] = $translated_label;
-                        }
+                    // Remove translation
+                    if ( ( empty( $translated_label ) && !empty( $custom_contact_fields[$field_key]['translations'][$langcode] ) ) ) {
+                        $custom_contact_fields[$field_key]['translations'][$langcode] = $translated_label;
                     }
                 }
             }
-            $custom_field_options['contacts'] = $custom_contact_fields;
-
-            update_option( 'dt_field_customizations', null );
         }
+
+        $custom_field_options['contacts'] = $custom_contact_fields;
+        update_option( 'dt_field_customizations', $custom_field_options );
+
 
         // Add a new custom field
         if ( ! empty( $_POST['add_custom_quick_action_label'] ) ) {

--- a/dt-core/admin/menu/tabs/tab-custom-lists.php
+++ b/dt-core/admin/menu/tabs/tab-custom-lists.php
@@ -709,7 +709,7 @@ class Disciple_Tools_Tab_Custom_Lists extends Disciple_Tools_Abstract_Menu_Base
                 }
             }
             $custom_field_options['contacts'] = $custom_contact_fields;
-            if ( ! get_option( 'dt_site_custom_lists' ) ) {
+            if ( ! get_option( 'dt_field_customizations' ) ) {
                 add_option( 'dt_field_customizations', $custom_field_options );
             } else {
                 update_option( 'dt_field_customizations', $custom_field_options );

--- a/dt-core/admin/menu/tabs/tab-custom-lists.php
+++ b/dt-core/admin/menu/tabs/tab-custom-lists.php
@@ -597,6 +597,7 @@ class Disciple_Tools_Tab_Custom_Lists extends Disciple_Tools_Abstract_Menu_Base
                     <td><?php esc_html_e( 'Name', 'disciple_tools' ) ?></td>
                     <td><?php esc_html_e( 'Icon link (must be https)', 'disciple_tools' ) ?></td>
                     <td></td>
+                    <td><?php esc_html_e( "Translation", 'disciple_tools' ) ?></td>
                     <td><?php esc_html_e( 'Delete', 'disciple_tools' ) ?></td>
                 </tr>
                 </thead>
@@ -623,6 +624,21 @@ class Disciple_Tools_Tab_Custom_Lists extends Disciple_Tools_Abstract_Menu_Base
                             <td>
                                 <button class="button file-upload-display-uploader" data-form="quick_actions_box"
                                         data-icon-input="edit_field_icon[<?php echo esc_attr( $field_key ); ?>]"><?php esc_html_e( 'Upload Icon', 'disciple_tools' ); ?></button>
+                            </td>
+                            <td>
+                                <?php $langs = dt_get_available_languages(); ?>
+                                <button class="button small expand_translations">
+                                    <?php
+                                    $number_of_translations = 0;
+                                    foreach ( $langs as $lang => $val ) {
+                                        if ( !empty( $channel_option['translations'][$val['language']] ) ) {
+                                            $number_of_translations ++;
+                                        }
+                                    }
+                                    ?>
+                                    <img style="height: 15px; vertical-align: middle" src="<?php echo esc_html( get_template_directory_uri() . "/dt-assets/images/languages.svg" ); ?>">
+                                    (<?php echo esc_html( $number_of_translations ); ?>)
+                                </button>
                             </td>
                             <td>
                                 <?php

--- a/dt-core/admin/menu/tabs/tab-custom-lists.php
+++ b/dt-core/admin/menu/tabs/tab-custom-lists.php
@@ -606,7 +606,7 @@ class Disciple_Tools_Tab_Custom_Lists extends Disciple_Tools_Abstract_Menu_Base
                         if ( ! isset( $field_settings['section'] ) || substr( $field_settings['section'], 0, 13 ) !== 'quick_buttons' ) {
                             continue;
                         }
-                    ?>
+                        ?>
                         <tr>
                             <td>
                                 <img style="width: 20px; vertical-align: middle;" src="<?php echo esc_attr( $field_settings['icon'] ); ?>" class="quick-action-menu">
@@ -693,7 +693,7 @@ class Disciple_Tools_Tab_Custom_Lists extends Disciple_Tools_Abstract_Menu_Base
             $langs = dt_get_available_languages();
             $custom_field_options = dt_get_option( 'dt_field_customizations' );
             $custom_contact_fields = $custom_field_options['contacts'];
-    
+
             $fields = $custom_field_options['contacts'];
             foreach ( $fields as $field_key => $field_settings ) {
                 foreach ( $langs as $lang => $val ) {
@@ -707,7 +707,7 @@ class Disciple_Tools_Tab_Custom_Lists extends Disciple_Tools_Abstract_Menu_Base
                 }
             }
             $custom_field_options['contacts'] = $custom_contact_fields;
-            update_option( 'dt_field_customizations', $custom_field_options);
+            update_option( 'dt_field_customizations', $custom_field_options );
         }
 
 

--- a/dt-core/admin/menu/tabs/tab-custom-lists.php
+++ b/dt-core/admin/menu/tabs/tab-custom-lists.php
@@ -698,7 +698,7 @@ class Disciple_Tools_Tab_Custom_Lists extends Disciple_Tools_Abstract_Menu_Base
         $custom_field_options = dt_get_option( 'dt_field_customizations' );
         $custom_contact_fields = $custom_field_options['contacts'];
 
-        foreach ( $custom_contact_fields as $field_key => $field_settings ) {
+        foreach ( $fields as $field_key => $field_settings ) {
             foreach ( $langs as $lang => $val ) {
                 $langcode = $val['language'];
                 if ( isset( $_POST['field_label'][$field_key][$langcode] ) ) {

--- a/dt-core/admin/menu/tabs/tab-custom-lists.php
+++ b/dt-core/admin/menu/tabs/tab-custom-lists.php
@@ -686,11 +686,12 @@ class Disciple_Tools_Tab_Custom_Lists extends Disciple_Tools_Abstract_Menu_Base
     }
 
     public function process_quick_actions_box(){
-        if ( isset( $_POST['quick_actions_box_nonce'] ) ) {
-            if ( !wp_verify_nonce( sanitize_key( $_POST['quick_actions_box_nonce'] ), 'quick_actions_box' ) ){
-                self::admin_notice( __( 'Something went wrong', 'disciple_tools' ), 'error' );
-                return;
-            }
+        if ( !isset( $_POST['quick_actions_box_nonce'] ) ){
+            return;
+        }
+        if ( !wp_verify_nonce( sanitize_key( $_POST['quick_actions_box_nonce'] ), 'quick_actions_box' ) ){
+            self::admin_notice( __( 'Something went wrong', 'disciple_tools' ), 'error' );
+            return;
         }
 
         $fields = DT_Posts::get_post_field_settings( 'contacts' );
@@ -793,10 +794,10 @@ class Disciple_Tools_Tab_Custom_Lists extends Disciple_Tools_Abstract_Menu_Base
             }
 
             update_option( 'dt_field_customizations', $custom_field_options, true );
-                    wp_cache_delete( "contacts_field_settings" );
+            wp_cache_delete( "contacts_field_settings" );
 
-                    self::admin_notice( __( 'Quick Action edited successfully', 'disciple_tools' ), 'success' );
-                    return;
+            self::admin_notice( __( 'Quick Action edited successfully', 'disciple_tools' ), 'success' );
+            return;
         }
     }
 }

--- a/dt-core/admin/menu/tabs/tab-custom-lists.php
+++ b/dt-core/admin/menu/tabs/tab-custom-lists.php
@@ -594,6 +594,7 @@ class Disciple_Tools_Tab_Custom_Lists extends Disciple_Tools_Abstract_Menu_Base
                 <tr>
                     <td></td>
                     <td><?php esc_html_e( 'Name', 'disciple_tools' ) ?></td>
+                    <td><?php esc_html_e( 'Key', 'disciple_tools' ); ?></td>
                     <td><?php esc_html_e( 'Icon link (must be https)', 'disciple_tools' ) ?></td>
                     <td></td>
                     <td><?php esc_html_e( "Translation", 'disciple_tools' ) ?></td>
@@ -620,6 +621,7 @@ class Disciple_Tools_Tab_Custom_Lists extends Disciple_Tools_Abstract_Menu_Base
                                     echo '<input type="hidden" name="edit_field[' . esc_attr( $field_key ) . ']" value="'. esc_html( $field_settings['name'] ) . '">';
                                 } ?>
                             </td>
+                            <td><?php echo esc_html( $field_key ); ?></td>
                             <td class="quick-action-menu"><input type="text" name="edit_field_icon[<?php echo esc_attr( $field_key ); ?>]" value="<?php echo esc_html( $field_settings['icon'] ) ?>"></td>
                             <td>
                                 <button class="button file-upload-display-uploader" data-form="quick_actions_box"

--- a/dt-core/admin/menu/tabs/tab-custom-lists.php
+++ b/dt-core/admin/menu/tabs/tab-custom-lists.php
@@ -694,28 +694,29 @@ class Disciple_Tools_Tab_Custom_Lists extends Disciple_Tools_Abstract_Menu_Base
 
             $langs = dt_get_available_languages();
             $custom_field_options = dt_get_option( 'dt_field_customizations' );
-            $custom_contact_fields = $custom_field_options['contacts'];
+            $custom_contact_fields = DT_Posts::get_post_field_settings( 'contacts' );
 
-            $fields = $custom_field_options['contacts'];
-            foreach ( $fields as $field_key => $field_settings ) {
+            foreach ( $custom_contact_fields as $field_key => $field_settings ) {
                 foreach ( $langs as $lang => $val ) {
                     $langcode = $val['language'];
                     if ( isset( $_POST['field_label'][$field_key][$langcode] ) ) {
                         $translated_label = sanitize_text_field( wp_unslash( $_POST['field_label'][$field_key][$langcode] ) );
-                        if ( ( empty( $translated_label ) && !empty( $custom_contact_fields[$field_key]['translations'][$langcode] ) ) || !empty( $translated_label ) ) {
+                        // Add new translation
+                        if ( !empty( $translated_label ) ) {
+                            $custom_contact_fields[$field_key]['translations'][$langcode] = $translated_label;
+                        }
+
+                        // Remove translation
+                        if ( ( empty( $translated_label ) && !empty( $custom_contact_fields[$field_key]['translations'][$langcode] ) ) ) {
                             $custom_contact_fields[$field_key]['translations'][$langcode] = $translated_label;
                         }
                     }
                 }
             }
             $custom_field_options['contacts'] = $custom_contact_fields;
-            if ( ! get_option( 'dt_field_customizations' ) ) {
-                add_option( 'dt_field_customizations', $custom_field_options );
-            } else {
-                update_option( 'dt_field_customizations', $custom_field_options );
-            }
-        }
 
+            update_option( 'dt_field_customizations', null );
+        }
 
         // Add a new custom field
         if ( ! empty( $_POST['add_custom_quick_action_label'] ) ) {

--- a/dt-core/admin/menu/tabs/tab-custom-lists.php
+++ b/dt-core/admin/menu/tabs/tab-custom-lists.php
@@ -709,7 +709,11 @@ class Disciple_Tools_Tab_Custom_Lists extends Disciple_Tools_Abstract_Menu_Base
                 }
             }
             $custom_field_options['contacts'] = $custom_contact_fields;
-            update_option( 'dt_field_customizations', $custom_field_options );
+            if ( ! get_option( 'dt_site_custom_lists' ) ) {
+                add_option( 'dt_field_customizations', $custom_field_options );
+            } else {
+                update_option( 'dt_field_customizations', $custom_field_options );
+            }
         }
 
 


### PR DESCRIPTION
_Responds to https://github.com/DiscipleTools/disciple-tools-theme/issues/1608_

Added translation feature to the Quick Actions buttons.

Works for Standard Quick Actions and Custom Quick Actions.

**Admin Settings Page**
<img width="800" src="https://user-images.githubusercontent.com/36511666/163064060-7cbf2996-6b40-4739-a735-66e3d0e5ce68.png">
<br>
**English Quick Answers (including a custom action)**
<img width="500" src="https://user-images.githubusercontent.com/36511666/163064489-fde75c72-bf2d-4cdc-b132-333c4ccb3b6d.png">
<br>
**Spanish Quick Answers (including a custom action)**
<img width="500" src="https://user-images.githubusercontent.com/36511666/163064611-c3144bfd-af9f-4256-8ea5-9a2b6eca4234.png">


