### PR TITLE
Fixing error when mapbox-search-widget isn’t registered.

### DIFF
--- a/dt-reports/magic-url-base.php
+++ b/dt-reports/magic-url-base.php
@@ -349,7 +349,9 @@ abstract class DT_Magic_Url_Base {
                 }
             }
         }
-        unset( $wp_scripts->registered['mapbox-search-widget']->extra['group'] ); //lets the mapbox geocoder work
+        if ( isset( $wp_scripts->registered['mapbox-search-widget'] ) && is_object( $wp_scripts->registered['mapbox-search-widget'] ) ){
+            unset( $wp_scripts->registered['mapbox-search-widget']->extra['group'] ); //lets the mapbox geocoder work
+        }
     }
 
     /**


### PR DESCRIPTION
<img width="1583" alt="Screen Shot 2022-05-10 at 10 00 34 AM" src="https://user-images.githubusercontent.com/5910297/167666031-9912427c-607f-44d4-8e36-a5f3b129d04d.png">

I'm not sure why it isn't registered. The key exists for me locally. I only get this error in our staging environment.