### PR TITLE
Fix tile label translations

### DIFF
--- a/dt-posts/dt-posts-hooks.php
+++ b/dt-posts/dt-posts-hooks.php
@@ -66,8 +66,8 @@ class DT_Posts_Hooks {
             $user_locale = get_user_locale();
             foreach ( $custom_tiles as $post_type => $tile_keys ) {
                 foreach ( $tile_keys as $key => $value ) {
-                    if ( !empty( $custom_tiles[$post_type][$key][$user_locale] ) ) {
-                        $custom_tiles[$post_type][$key]['label'] = $custom_tiles[$post_type][$key][$user_locale];
+                    if ( isset( $custom_tiles[$post_type][$key]["translations"][$user_locale] ) && !empty( $custom_tiles[$post_type][$key]["translations"][$user_locale] ) ) {
+                        $custom_tiles[$post_type][$key]['label'] = $custom_tiles[$post_type][$key]["translations"][$user_locale];
                     }
                 }
             }


### PR DESCRIPTION
@kodinkat I noticed this function and the a key that was missing:
dt_get_custom_tile_translations()

Thoughts vs https://github.com/DiscipleTools/disciple-tools-theme/pull/1706 ?