### PR TITLE
chore: add a list of recommended extensions from the ones that I'm using :)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ node_modules/
 .DS_Store
 dt-people-groups/json/*
 composer.phar
-.vscode/*
 CodeSniffer.conf
 phpcbf.phar
 phpcs.phar

--- a/.vscode/.gitignore
+++ b/.vscode/.gitignore
@@ -1,0 +1,2 @@
+launch.json
+settings.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,16 @@
+{
+    "recommendations": [
+        "DEVSENSE.phptools-vscode",
+        "ikappas.phpcs",
+        "johnbillion.vscode-wordpress-hooks",
+        "formulahendry.auto-close-tag",
+        "formulahendry.auto-rename-tag",
+        "naumovs.color-highlight",
+        "EditorConfig.EditorConfig",
+        "mrorz.language-gettext",
+        "eamodio.gitlens",
+        "2gua.rainbow-brackets",
+        "shardulm94.trailing-spaces",
+        "dbaeumer.vscode-eslint",
+    ]
+}


### PR DESCRIPTION
This vscode specific file will bring a pop-up (hopefully) on someones vscode when they add disciple-tools-theme to their workspace, and give them the option to install the recommended extensions for this workspace.

I've included some php, wordpress and js specific ones as well as some other useful tools that help me every day such as 

* php tools, which adds
  * php debug
  * php intellisense
* phpcs which highlights your code according to the phpcs.xml in the theme/plugin
* wordpress hooks intellisense - autocompletes wp hook names when writing filters/actions
* eslint for highlighting js eslint issues 

* bracket colourisation
* git lens
* autocompleting html tags
* autorenaming closing html tags
* highlighting translation files nicely
* highlighting those annoying trailing spaces or tabs (shudder)
* making use of the .editorconfig file so helpfully placed in each plugin and theme root