### PR TITLE
Feat/allow other pages to use translation modal

### DIFF
--- a/dt-core/admin/admin-enqueue-scripts.php
+++ b/dt-core/admin/admin-enqueue-scripts.php
@@ -66,7 +66,15 @@ function dt_people_groups_post_type_scripts() {
  * Loads scripts and styles for the assets page.
  */
 function dt_options_scripts() {
-    if ( isset( $_GET["page"] ) && ( $_GET["page"] === 'dt_options' || $_GET["page"] === 'dt_utilities' || $_GET["page"] === 'dt_extensions' ) ) {
+    $allowed_pages = [
+        'dt_options',
+        'dt_utilities',
+        'dt_extensions',
+    ];
+
+    $allowed_pages = apply_filters( 'dt_options_script_pages', $allowed_pages );
+
+    if ( isset( $_GET["page"] ) && ( in_array( $_GET["page"], $allowed_pages, true ) ) ) {
         wp_enqueue_script( 'dt_options_script', disciple_tools()->admin_js_url . 'dt-options.js', [
             'jquery',
             'jquery-ui-core',

--- a/dt-core/admin/admin-functions.php
+++ b/dt-core/admin/admin-functions.php
@@ -1,0 +1,5 @@
+<?php
+
+function dt_display_translation_dialog() {
+    echo '<dialog id="dt_translation_dialog"></dialog>';
+}

--- a/dt-core/admin/menu/tabs/tab-custom-fields.php
+++ b/dt-core/admin/menu/tabs/tab-custom-fields.php
@@ -156,7 +156,7 @@ class Disciple_Tools_Tab_Custom_Fields extends Disciple_Tools_Abstract_Menu_Base
             $this->box( 'bottom' );
 
             /* Translation Dialog */
-            echo '<dialog id="dt_translation_dialog"></dialog>';
+            dt_display_translation_dialog();
 
             if ( empty( $field_key ) && $show_add_field ){
                 $this->box( 'top', __( "Create new field", 'disciple_tools' ) );

--- a/dt-core/admin/menu/tabs/tab-custom-lists.php
+++ b/dt-core/admin/menu/tabs/tab-custom-lists.php
@@ -70,7 +70,7 @@ class Disciple_Tools_Tab_Custom_Lists extends Disciple_Tools_Abstract_Menu_Base
             $this->template( 'begin' );
 
             /* Translation Dialog */
-            echo '<dialog id="dt_translation_dialog"></dialog>';
+            dt_display_translation_dialog();
 
             /* Worker Profile */
             $this->box( 'top', 'User (Worker) Contact Profile' );

--- a/dt-core/admin/menu/tabs/tab-custom-tiles.php
+++ b/dt-core/admin/menu/tabs/tab-custom-tiles.php
@@ -87,7 +87,7 @@ class Disciple_Tools_Tab_Custom_Tiles extends Disciple_Tools_Abstract_Menu_Base
             $this->template( 'begin' );
 
             /* Translation Dialog */
-            echo '<dialog id="dt_translation_dialog"></dialog>';
+            dt_display_translation_dialog();
 
             $this->box( 'top', __( 'Edit Tiles', 'disciple_tools' ) );
             $this->post_type_select( $post_type );

--- a/functions.php
+++ b/functions.php
@@ -392,6 +392,7 @@ if ( version_compare( phpversion(), '7.0', '<' ) ) {
 
                 // Administration
                 require_once( 'dt-core/admin/admin-enqueue-scripts.php' ); // Load admin scripts
+                require_once( 'dt-core/admin/admin-functions.php' ); // Load admin functions
                 require_once( 'dt-core/admin/admin-theme-design.php' ); // Configures elements of the admin enviornment
                 require_once( 'dt-core/admin/config-dashboard.php' );
                 $this->config_dashboard = Disciple_Tools_Dashboard::instance();


### PR DESCRIPTION
Adds a filter to allow other admin pages to use translation modal scripts

Also adds the translation modal html into it's own function to be re-used around the site.