### PR TITLE
Adds a post type check on an ajaxComplete event.

### DIFF
--- a/dt-assets/js/shared-functions.js
+++ b/dt-assets/js/shared-functions.js
@@ -220,8 +220,8 @@ function handleAjaxError(err) {
 jQuery(document)
   .ajaxComplete((event, xhr, settings) => {
     if ( xhr && xhr.responseJSON && settings.type === "POST" ) {
-      // Event that a contact record has been updated
-      if ( xhr.responseJSON.ID && xhr.responseJSON.post_type ) {
+      // Event that a contact record has been updated, check to make sure the post type that is being updated is the same as the current page post type.
+      if ( xhr.responseJSON.ID && xhr.responseJSON.post_type &&  xhr.responseJSON.post_type === window.detailsSettings.post_type ) {
         let request = settings.data ? JSON.parse(settings.data) : {};
         $(document).trigger("dt_record_updated", [xhr.responseJSON, request]);
       }


### PR DESCRIPTION
This fixes a bug when using the Prayer Request plugin and for proposed updates in the Meetings plugin. When those post types were created from a contact or group record page it caused the name of the record to update in the details summary tile. It wasn't making the change in the DB, just adjusting the DOM. Previously the assumption was that if there was a record update from a record page it was related to the current record, in the case of these plugins this was not the case.