### PR TITLE
Mapping v2a

### DIFF
--- a/dt-mapping/class-migration-engine.php
+++ b/dt-mapping/class-migration-engine.php
@@ -15,7 +15,7 @@ class DT_Mapping_Module_Migration_Engine
      * Current Migration number for the mapping system
      * @var int
      */
-    public static $migration_number = 12;
+    public static $migration_number = 13;
     /** End Current Migration Number */
 
     protected static $migrations = null;

--- a/dt-mapping/globals.php
+++ b/dt-mapping/globals.php
@@ -41,7 +41,7 @@ if ( ! function_exists( 'dt_get_location_grid_mirror' ) ) {
             $array = [
                 'key'   => 'google',
                 'label' => 'Google',
-                'url'   => 'https://storage.googleapis.com/location-grid-mirror/',
+                'url'   => 'https://storage.googleapis.com/location-grid-mirror-v2/',
             ];
             update_option( 'dt_location_grid_mirror', $array, true );
             $mirror = $array;

--- a/dt-mapping/mapping-admin.php
+++ b/dt-mapping/mapping-admin.php
@@ -1061,12 +1061,12 @@ if ( ! class_exists( 'DT_Mapping_Module_Admin' ) ) {
                 'google' => [
                     'key'   => 'google',
                     'label' => 'Google',
-                    'url'   => 'https://storage.googleapis.com/location-grid-mirror/',
+                    'url'   => 'https://storage.googleapis.com/location-grid-mirror-v2/',
                 ],
                 'amazon' => [
                     'key'   => 'amazon',
                     'label' => 'Amazon',
-                    'url'   => 'https://location-grid-mirror.s3.amazonaws.com/',
+                    'url'   => 'https://location-grid-mirror-v2.s3.amazonaws.com/',
                 ],
                 'other'  => [
                     'key'   => 'other',

--- a/dt-mapping/mapping.js
+++ b/dt-mapping/mapping.js
@@ -255,7 +255,7 @@ function location_grid_map( div, grid_id = 'world' ) {
   function build_map( response ) {
     title.html(response.self.name)
 
-    jQuery.getJSON( MAPPINGDATA.settings.mapping_source_url + 'collection/' + grid_id+'.geojson', function( data ) { // get geojson data
+    jQuery.getJSON( MAPPINGDATA.settings.mapping_source_url + 'collection-left-hand/' + grid_id+'.geojson', function( data ) { // get geojson data
 
       // load geojson with additional parameters
       let mapData = data
@@ -404,7 +404,7 @@ function mini_map( div, marker_data ) {
   }
 
   if ( window.am4geodata_worldLow === undefined ) {
-    let mapUrl = MAPPINGDATA.settings.mapping_source_url + 'collection/world.geojson'
+    let mapUrl = MAPPINGDATA.settings.mapping_source_url + 'collection-left-hand/world.geojson'
     jQuery.getJSON( mapUrl, function( data ) {
       window.am4geodata_worldLow = data
       build_minimap()

--- a/dt-mapping/migrations/0013-migrate-to-v2.php
+++ b/dt-mapping/migrations/0013-migrate-to-v2.php
@@ -11,23 +11,21 @@ class DT_Mapping_Module_Migration_0013 extends DT_Mapping_Module_Migration {
      */
     public function up() {
         $current = get_option( 'dt_location_grid_mirror' );
-        if ( isset( $current['key'] ) && ! 'other' === $current['key'] ) {
-            if ( 'google' === $current['key'] ) {
-                $array = [
-                    'key'   => 'google',
-                    'label' => 'Google',
-                    'url'   => 'https://storage.googleapis.com/location-grid-mirror-v2/',
-                ];
-            }
-            else if ( 'amazon' === $current['key'] ) {
-                $array = [
-                    'key'   => 'amazon',
-                    'label' => 'Amazon',
-                    'url'   => 'https://location-grid-mirror-v2.s3.amazonaws.com/',
-                ];
-            }
-            update_option( 'dt_location_grid_mirror', $array, true );
+        if ( isset( $current['key'] ) && 'amazon' === $current['key'] ) {
+            $array = [
+                'key'   => 'amazon',
+                'label' => 'Amazon',
+                'url'   => 'https://location-grid-mirror-v2.s3.amazonaws.com/',
+            ];
         }
+        else {
+            $array = [
+                'key'   => 'google',
+                'label' => 'Google',
+                'url'   => 'https://storage.googleapis.com/location-grid-mirror-v2/',
+            ];
+        }
+        update_option( 'dt_location_grid_mirror', $array, true );
     }
 
     /**

--- a/dt-mapping/migrations/0013-migrate-to-v2.php
+++ b/dt-mapping/migrations/0013-migrate-to-v2.php
@@ -1,0 +1,53 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly
+
+/**
+ * Class DT_Mapping_Module_Migration_0013
+ */
+class DT_Mapping_Module_Migration_0013 extends DT_Mapping_Module_Migration {
+
+    /**
+     * @throws \Exception  Got error when creating table $name.
+     */
+    public function up() {
+        $current = get_option( 'dt_location_grid_mirror' );
+        if ( isset( $current['key'] ) && ! 'other' === $current['key'] ) {
+            if ( 'google' === $current['key'] ) {
+                $array = [
+                    'key'   => 'google',
+                    'label' => 'Google',
+                    'url'   => 'https://storage.googleapis.com/location-grid-mirror-v2/',
+                ];
+            }
+            else if ( 'amazon' === $current['key'] ) {
+                $array = [
+                    'key'   => 'amazon',
+                    'label' => 'Amazon',
+                    'url'   => 'https://location-grid-mirror-v2.s3.amazonaws.com/',
+                ];
+            }
+            update_option( 'dt_location_grid_mirror', $array, true );
+        }
+    }
+
+    /**
+     * @throws \Exception  Got error when dropping table $name.
+     */
+    public function down() {
+
+    }
+
+    /**
+     * @return array
+     */
+    public function get_expected_tables(): array {
+        return [];
+    }
+
+    /**
+     * Test function
+     */
+    public function test() {
+    }
+
+}

--- a/dt-metrics/common/maps_library.js
+++ b/dt-metrics/common/maps_library.js
@@ -466,7 +466,7 @@ let area_map = {
 
           done.push(parent_id);
           // get geojson collection
-          jQuery.get( mapbox_library_api.obj.settings.map_mirror + 'collection/' + parent_id + '.geojson', null, null, 'json')
+          jQuery.get( mapbox_library_api.obj.settings.map_mirror + 'collection-left-hand/' + parent_id + '.geojson', null, null, 'json')
           .done(function (geojson) {
             // add data to geojson properties
             let highest_value = 1


### PR DESCRIPTION
1 of 3 Upgrades. Please approve in order. 
- This version bump migrates up the base google and amazon urls to point to the v2 polygon set.
- This version updates a couple hardcoded subdirectory endpoints for the Amchart metrics.

This step is 1 or 2 upgrades. This will move all DT instances to v2 assets, while continuing to support legacy Amchart 4 charts. It also includes tile sets, m49 sets, and the json_db static database. 