### PR TITLE
Bug fix: PHP8 Deprecated:  strtolower(): Passing null to parameter #1…

### DIFF
--- a/dt-core/logging/class-activity-api.php
+++ b/dt-core/logging/class-activity-api.php
@@ -72,7 +72,7 @@ class Disciple_Tools_Activity_Log_API {
             $user = wp_get_current_user();
         }
         if ( $user ) {
-            $args['user_caps'] = strtolower( key( $user->caps ) );
+            $args['user_caps'] = strtolower( key( $user->caps ) ?? 'system' );
             if ( empty( $args['user_id'] ) ) {
                 $args['user_id'] = $user->ID;
             }


### PR DESCRIPTION
Bug fix: PHP8 Deprecated:  strtolower(): Passing null to parameter ($string) of type string is deprecated. Using Null Coalescing Operator to provide string.

This is happening in a context where using a magic link and the user capabilities are not established.

<img width="1788" alt="Screen Shot 2022-09-19 at 9 35 52 AM" src="https://user-images.githubusercontent.com/7318348/191056487-4ecf1f5b-be71-4a1d-aeaf-9491c9b42fb7.png">
