### PR TITLE
Change the request referrer header to `strict-origin-when-cross-origin` which is the new default since 2022

### DIFF
--- a/dt-core/configuration/restrict-site-access.php
+++ b/dt-core/configuration/restrict-site-access.php
@@ -209,7 +209,7 @@ function dt_security_headers_insert() {
         header( 'X-XSS-Protection: 1; mode=block' );
     }
     if ( !$referer_disabled ){
-        header( 'Referrer-Policy: strict-origin-when-cross-origin' );
+        header( 'Referrer-Policy: same-origin' );
     }
     if ( !$content_type_disabled ){
         header( 'X-Content-Type-Options: nosniff' );

--- a/dt-core/configuration/restrict-site-access.php
+++ b/dt-core/configuration/restrict-site-access.php
@@ -209,7 +209,7 @@ function dt_security_headers_insert() {
         header( 'X-XSS-Protection: 1; mode=block' );
     }
     if ( !$referer_disabled ){
-        header( 'Referrer-Policy: same-origin' );
+        header( 'Referrer-Policy: strict-origin-when-cross-origin' );
     }
     if ( !$content_type_disabled ){
         header( 'X-Content-Type-Options: nosniff' );

--- a/dt-mapping/geocode-api/mapbox-search-widget.js
+++ b/dt-mapping/geocode-api/mapbox-search-widget.js
@@ -379,7 +379,10 @@ function mapbox_autocomplete(address){
   let key = dtMapbox.map_key
   let url = root + encodeURI( address ) + settings + key
 
-  jQuery.get( url, function( data ) {
+  fetch( url, {
+    referrerPolicy: "strict-origin-when-cross-origin"
+  }).then(response => response.json())
+  .then( data => {
     if( data.features.length < 1 ) {
       // destroy lists
       console.log('no results')

--- a/dt-mapping/geocode-api/mapbox-users-search-widget.js
+++ b/dt-mapping/geocode-api/mapbox-users-search-widget.js
@@ -183,7 +183,10 @@ function mapbox_autocomplete(address){
 
   let url = root + encodeURI( address ) + settings + key
 
-  jQuery.get( url, function( data ) {
+  fetch( url, {
+    referrerPolicy: "strict-origin-when-cross-origin"
+  }).then(response => response.json())
+  .then( data => {
     if( data.features.length < 1 ) {
       // destroy lists
       return


### PR DESCRIPTION
Mapbox needs the referrer header in order to work when restricting the key to only work on certain urls.
See:
https://docs.mapbox.com/mapbox-gl-js/guides/browsers-and-testing/#referrer-policies

The current policy is `same-origin` which means any outside link a D.T user clicks on to open does not include the referrer header.
![image](https://user-images.githubusercontent.com/24901539/198996481-18cdf307-1658-471a-a2bb-5aac045099d6.png)

For mapbox api token restriction to work we would need to change the referrer-policy to `strict-origin-when-cross-origin`
![image](https://user-images.githubusercontent.com/24901539/198996597-0246748e-312a-4269-95a4-8461736752aa.png)

