### PR TITLE
Declare default D.T capabilities for posts

### DIFF
--- a/dt-posts/custom-post-type.php
+++ b/dt-posts/custom-post-type.php
@@ -26,6 +26,7 @@ class Disciple_Tools_Post_Type_Template {
         add_filter( 'dt_registered_post_types', [ $this, 'dt_registered_post_types' ], 10, 1 );
         add_filter( 'dt_details_additional_section_ids', [ $this, 'dt_details_additional_section_ids' ], 10, 2 );
         add_action( 'init', [ $this, 'register_p2p_connections' ], 50, 0 );
+        add_filter( 'dt_capabilities', [ $this, 'dt_capabilities' ], 100, 1 );
     }
 
     public function register_post_type(){
@@ -295,6 +296,36 @@ class Disciple_Tools_Post_Type_Template {
                 }
             }
         }
+    }
+    /**
+     * Declare Default D.T post roles
+     */
+    public function dt_capabilities( $capabilities ){
+        $capabilities['access_' . $this->post_type] = [
+            'source' => $this->plural,
+            'description' => 'The user can access the UI for ' . $this->plural,
+        ];
+//        $capabilities['update_'  . $this->post_type] = [
+//            'source' => $this->plural,
+//            'description' => 'The user can edit existing ' . $this->plural,
+//        ];
+        $capabilities['create_'  . $this->post_type] = [
+            'source' => $this->plural,
+            'description' => 'The user can create ' . $this->plural
+        ];
+        $capabilities['view_any_'  . $this->post_type] = [
+            'source' => $this->plural,
+            'description' => 'The user can view any ' . $this->singular
+        ];
+        $capabilities['update_any_'  . $this->post_type] = [
+            'source' => $this->plural,
+            'description' => 'The user can update any ' . $this->singular
+        ];
+        $capabilities['delete_any_'  . $this->post_type] = [
+            'source' => $this->plural,
+            'description' => 'The user can delete any ' . $this->singular
+        ];
+        return $capabilities;
     }
 }
 


### PR DESCRIPTION
This PR would create a "source" for each of the post types and declare the default "CRUD" permissions.
![image](https://user-images.githubusercontent.com/24901539/201326483-6a54d903-805e-4c67-acaf-466cecb078bf.png)
