### PR TITLE
This allows you to run phpcs on PHP 8.

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -21,6 +21,16 @@
        right settings for this project.
   -->
 
+  <!--
+	Suppress all PHP run-time notices across all PHP versions, thus preventing
+	errors caused by WordPress Coding Standards not supporting PHP 8.0+ yet.
+	Once WPCS supports PHP8, this can be removed.
+	See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035
+
+  This was taken from https://github.com/Automattic/wp-calypso/pull/71062
+	-->
+	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
+
   <file>.</file>
 
   <exclude-pattern>dt-core/dependencies/*</exclude-pattern>


### PR DESCRIPTION
It was taken from https://github.com/Automattic/wp-calypso/pull/71062