### PR TITLE
feat: allow use of seperate definition to WP_DEBUG to turn on logs

### DIFF
--- a/dt-core/global-functions.php
+++ b/dt-core/global-functions.php
@@ -39,7 +39,11 @@ if ( ! defined( 'DT_FUNCTIONS_READY' ) ){
          * @param $log
          */
         function dt_write_log( $log ) {
-            if ( true === WP_DEBUG ) {
+            if ( !defined( 'DT_WRITE_LOG' ) ) {
+                define( 'DT_WRITE_LOG', false );
+            }
+
+            if ( true === WP_DEBUG || true === DT_WRITE_LOG ) {
                 global $dt_write_log_microtime;
                 $now = microtime( true );
                 if ( $dt_write_log_microtime > 0 ) {


### PR DESCRIPTION
I've hit this several times over the last couple of days.

I would like to just turn on the DT logs without turning on the full WP_DEBUG experience which shouldn't be left on in production and can risk users getting strange errors on the front and back end of the WP site.

I propose adding another definition such as DT_WRITE_LOG to allow the system to write dt logs without having to turn on WP_DEBUG.

Obviously this shouldn't be left on either, but it allows you to get a partial debug experience in production if needed without affecting the user