### PR TITLE
use `list_all_` permission for viewing compact list

### DIFF
--- a/dt-posts/dt-posts.php
+++ b/dt-posts/dt-posts.php
@@ -881,8 +881,9 @@ class DT_Posts extends Disciple_Tools_Posts {
             if ( !empty( $search_string ) ){
                 $query['name'] = [ $search_string ];
             }
-            // skip permission check because we checked list_all_ above
-            $posts_list = self::search_viewable_post( $post_type, $query, false );
+            // if user can't list_all_, check permissions so they don't get access to things they shouldn't
+            $check_permissions = !self::can_list_all( $post_type );
+            $posts_list = self::search_viewable_post( $post_type, $query, $check_permissions );
             if ( is_wp_error( $posts_list ) ){
                 return $posts_list;
             }

--- a/dt-posts/dt-posts.php
+++ b/dt-posts/dt-posts.php
@@ -791,7 +791,7 @@ class DT_Posts extends Disciple_Tools_Posts {
      * @return array|WP_Error|WP_Query
      */
     public static function get_viewable_compact( string $post_type, string $search_string, array $args = [] ) {
-        if ( !self::can_list_all( $post_type ) ) {
+        if ( !self::can_access( $post_type ) && !self::can_list_all( $post_type ) ) {
             return new WP_Error( __FUNCTION__, sprintf( 'You do not have access to these %s', $post_type ), [ 'status' => 403 ] );
         }
         global $wpdb;

--- a/dt-posts/dt-posts.php
+++ b/dt-posts/dt-posts.php
@@ -791,7 +791,7 @@ class DT_Posts extends Disciple_Tools_Posts {
      * @return array|WP_Error|WP_Query
      */
     public static function get_viewable_compact( string $post_type, string $search_string, array $args = [] ) {
-        if ( !self::can_access( $post_type ) ) {
+        if ( !self::can_list_all( $post_type ) ) {
             return new WP_Error( __FUNCTION__, sprintf( 'You do not have access to these %s', $post_type ), [ 'status' => 403 ] );
         }
         global $wpdb;
@@ -881,7 +881,8 @@ class DT_Posts extends Disciple_Tools_Posts {
             if ( !empty( $search_string ) ){
                 $query['name'] = [ $search_string ];
             }
-            $posts_list = self::search_viewable_post( $post_type, $query );
+            // skip permission check because we checked list_all_ above
+            $posts_list = self::search_viewable_post( $post_type, $query, false );
             if ( is_wp_error( $posts_list ) ){
                 return $posts_list;
             }

--- a/dt-posts/posts.php
+++ b/dt-posts/posts.php
@@ -51,7 +51,7 @@ class Disciple_Tools_Posts
     }
 
     public static function can_list_all( string $post_type ) {
-        return current_user_can( 'list_' . $post_type );
+        return current_user_can( 'list_all_' . $post_type );
     }
 
     /**


### PR DESCRIPTION
The `list_all_[post_type]` permission was not properly being used at all and was mis-named in the code. This updates `get_viewable_compact` to check the `list_all_` permission and then skip further permission checks in `search_viewable_post`