### PR TITLE
fix: default registered post types should always be contacts and groups?

### DIFF
--- a/dt-core/core-endpoints.php
+++ b/dt-core/core-endpoints.php
@@ -138,7 +138,7 @@ class Disciple_Tools_Core_Endpoints {
         // If logging for a post, validate user has permission
         if ( isset( $params['object_type'] ) && !empty( $params['object_type'] ) ) {
             $type = $params['object_type'];
-            $post_types = apply_filters( 'dt_registered_post_types', [ 'contacts', 'groups' ] );
+            $post_types = DT_Posts::get_post_types();
             if ( array_search( $type, $post_types ) !== false ) {
                 $post_id = isset( $params['object_id'] ) ? $params['object_id'] : null;
 

--- a/dt-posts/dt-posts.php
+++ b/dt-posts/dt-posts.php
@@ -22,7 +22,7 @@ class DT_Posts extends Disciple_Tools_Posts {
     );
 
     public static function get_post_types(){
-        return apply_filters( 'dt_registered_post_types', [ 'contacts', 'groups' ] );
+        return array_unique( apply_filters( 'dt_registered_post_types', [ 'contacts', 'groups' ] ) );
     }
 
     /**

--- a/dt-posts/dt-posts.php
+++ b/dt-posts/dt-posts.php
@@ -22,7 +22,7 @@ class DT_Posts extends Disciple_Tools_Posts {
     );
 
     public static function get_post_types(){
-        return apply_filters( 'dt_registered_post_types', [] );
+        return apply_filters( 'dt_registered_post_types', [ 'contacts', 'groups' ] );
     }
 
     /**
@@ -1657,7 +1657,7 @@ class DT_Posts extends Disciple_Tools_Posts {
         if ( $load_from_cache && $cached ){
             return $cached;
         }
-        $post_types = apply_filters( 'dt_registered_post_types', [] );
+        $post_types = self::get_post_types();
         $fields = Disciple_Tools_Post_Type_Template::get_base_post_type_fields();
         $fields = apply_filters( 'dt_custom_fields_settings', $fields, $post_type );
 


### PR DESCRIPTION
Hey @corsacca 

Is this a bug that these places had an empty array instead of 'contacts' and 'groups' in them?

I was trying to use `DT_Posts::get_post( 'laps', $post_id )` to get a lap and all of it's fields, but the contacts field, which was linked to the contacts post type was getting filtered out, as the `$post_types` field in function `DT_Posts::get_post_field_settings` was returning an empty array.
I think this is because the `dt_registered_post_types` apply filter in function `log_activity` hadn't run yet and added the defaults 'contacts' and 'groups'.

What do you think?

Also I couldn't find any other references to this filter in core, so was wondering where it's being used for the other post types like peoplegroups etc.