### PR TITLE
Removed 'edit tile' feature for 'no tile/hidden' tile rundown element

### DIFF
--- a/dt-core/admin/menu/tabs/tab-customizations.php
+++ b/dt-core/admin/menu/tabs/tab-customizations.php
@@ -438,7 +438,6 @@ class Disciple_Tools_Customizations_Tab extends Disciple_Tools_Abstract_Menu_Bas
                     <span id="tile-key-untiled" style="vertical-align: sub;">
                         <?php echo esc_html_e( 'No Tile / Hidden', 'disciple-tools' ); ?>
                     </span>
-                    <span class="edit-icon"></span>
                 </div>
                 <div class="tile-rundown-elements" data-parent-tile-key="no-tile-hidden" style="display: none;">
                     <?php foreach ( $post_tiles['fields'] as $field_key => $field_settings ) : ?>


### PR DESCRIPTION
Clicking on the 'edit tile' icon for the 'No Tile/Hidden' element resulted in a bug because that element doesn't have tile settings.

**Bug Screenshot:**
![image](https://user-images.githubusercontent.com/36511666/231784119-a21459e3-d235-446a-8559-5dd309370381.png)

Bug was fixed by removing the edit feature in tile-less elements.
![Screenshot 2023-04-13 at 11 02 58](https://user-images.githubusercontent.com/36511666/231784274-6a0dcccf-aeed-41a1-9f98-6770241ba1e4.png)
