### PR TITLE
Bug fix: No tile field options in 'no_tile' submenu

### DIFF
--- a/dt-core/admin/js/dt-settings.js
+++ b/dt-core/admin/js/dt-settings.js
@@ -278,6 +278,9 @@ jQuery(document).ready(function($) {
     });
 
     function show_preview_tile(tile_key) {
+        if(tile_key == 'no_tile') {
+            return;
+        }
         var tile_html = `
             <div class="dt-tile-preview">
                 <div class="section-header">

--- a/dt-core/admin/menu/tabs/tab-customizations.php
+++ b/dt-core/admin/menu/tabs/tab-customizations.php
@@ -364,7 +364,9 @@ class Disciple_Tools_Customizations_Tab extends Disciple_Tools_Abstract_Menu_Bas
                         <span id="tile-key-<?php echo esc_attr( $tile_key ); ?>" style="vertical-align: sub;">
                             <?php echo esc_html( isset( $tile_value['label'] ) ? $tile_value['label'] : $tile_key ); ?>
                         </span>
+                        <?php if ( $tile_key !== 'no_tile' ) : ?>
                         <span class="edit-icon"></span>
+                        <?php endif; ?>
                     </div>
                     <!-- END TILE -->
                     <div class="tile-rundown-elements" data-parent-tile-key="<?php echo esc_attr( $tile_key ); ?>" style="display: none;">

--- a/dt-core/admin/menu/tabs/tab-customizations.php
+++ b/dt-core/admin/menu/tabs/tab-customizations.php
@@ -348,11 +348,14 @@ class Disciple_Tools_Customizations_Tab extends Disciple_Tools_Abstract_Menu_Bas
     private function display_field_rundown() {
         $post_type = self::get_parameter( 'post_type' );
         $post_tiles = DT_Posts::get_post_settings( $post_type, false );
+        $post_tiles['tiles']['no_tile'] = [
+            'label' => 'No Tile / Hidden',
+            'tile_priority' => 9999,
+        ];
         ?>
         <!-- START TABLE -->
         <div class="field-settings-table">
             <?php foreach ( $post_tiles['tiles'] as $tile_key => $tile_value ) : ?>
-                <?php if ( $tile_key !== 'no_tile' ) : ?>
                 <!-- START TILE -->
                 <div class="<?php echo esc_attr( self::get_sortable_class( $tile_key ) ); ?>" id="<?php echo esc_attr( $tile_key ); ?>">
                     <div class="field-settings-table-tile-name expandable" data-modal="edit-tile" data-key="<?php echo esc_attr( $tile_key ); ?>">
@@ -428,32 +431,7 @@ class Disciple_Tools_Customizations_Tab extends Disciple_Tools_Abstract_Menu_Bas
                         </div>
                     </div>
                 </div>
-                <?php endif; ?>
             <?php endforeach; ?>
-            <!-- START UNTILED FIELDS -->
-            <div class="sortable-tile">
-                <div class="field-settings-table-tile-name expandable" data-modal="edit-tile" data-key="no-tile-hidden">
-                   <span class="sortable ui-icon ui-icon-arrow-4"></span>
-                    <span class="expand-icon">+</span>
-                    <span id="tile-key-untiled" style="vertical-align: sub;">
-                        <?php echo esc_html_e( 'No Tile / Hidden', 'disciple-tools' ); ?>
-                    </span>
-                </div>
-                <div class="tile-rundown-elements" data-parent-tile-key="no-tile-hidden" style="display: none;">
-                    <?php foreach ( $post_tiles['fields'] as $field_key => $field_settings ) : ?>
-                        <?php if ( ( !array_key_exists( 'tile', $field_settings ) || $field_settings['tile'] === 'no_tile' ) && ( !isset( $field_settings['customizable'] ) || $field_settings['customizable'] !== false ) && empty( $field_settings['hidden'] ) ) : ?>
-                        <div class="field-settings-table-field-name" data-modal="edit-field" data-key="<?php echo esc_attr( $field_key ); ?>" data-parent-tile-key="no-tile-hidden">
-                           <span class="sortable ui-icon ui-icon-arrow-4"></span>
-                            <span class="field-name-content" data-parent-tile-key="no-tile-hidden" data-key="<?php echo esc_attr( $field_key ); ?>">
-                                <?php echo esc_html( $field_settings['name'] ); ?>
-                            </span>
-                            <span class="edit-icon"></span>
-                        </div>
-                        <?php endif; ?>
-                    <?php endforeach; ?>
-                </div>
-            </div>
-                <!-- END UNTILED FIELDS -->
             <div class="add-new-link">
                 <a href="#" id="add-new-tile-link"><?php echo esc_html( 'add new tile', 'disciple_tools' ); ?></a>
             </div>
@@ -470,11 +448,12 @@ class Disciple_Tools_Customizations_Tab extends Disciple_Tools_Abstract_Menu_Bas
         return $sortable_class;
     }
 
-    public static function field_option_in_tile( $field_option_name, $tile_name ) {
+    public static function field_option_in_tile( $field_option_name, $tile_key ) {
         $post_type = self::get_parameter( 'post_type' );
         $post_tiles = DT_Posts::get_post_settings( $post_type, true );
+
         if ( isset( $post_tiles['fields'][$field_option_name]['tile'] ) ) {
-            if ( $post_tiles['fields'][$field_option_name]['tile'] === $tile_name ) {
+            if ( $post_tiles['fields'][$field_option_name]['tile'] === $tile_key ) {
                 return true;
             }
         }


### PR DESCRIPTION
Refactored the `display_field_rundown()` function so that the `no_tile` menu element works properly. 

Before, it didn't display field options, just fields. Also, collapsable fields weren't displayed as collapsable. This is now fixed.

Before there were two loops: One for tiles and one for the `no_tile` element. Now, there is only one loop. A big chunk of code was cleaned up thanks to this, resulting in cleaner code.

In order to clean up the code, the `no_tile` element was added to the `$post_tiles` as a tile so it appears in the loop. No "no_tile-specific code" is now needed.
