### PR TITLE
Added field key check functionality before adding field

### DIFF
--- a/dt-core/admin/admin-settings-endpoints.php
+++ b/dt-core/admin/admin-settings-endpoints.php
@@ -167,6 +167,14 @@ class Disciple_Tools_Admin_Settings_Endpoints {
                 'permission_callback' => [ $this, 'default_permission_check' ],
             ]
         );
+
+        register_rest_route(
+            $this->namespace, '/check-field-key-is-available', [
+                'methods' => 'POST',
+                'callback' => [ $this, 'check_field_key_is_available' ],
+                'permission_callback' => [ $this, 'default_permission_check' ],
+            ]
+        );
     }
 
     public static function get_post_fields() {
@@ -839,6 +847,24 @@ class Disciple_Tools_Admin_Settings_Endpoints {
             return $default_label;
         }
         return false;
+    }
+
+    public static function check_field_key_is_available( WP_REST_Request $request ) {
+        $params = $request->get_params();
+        if ( isset( $params['post_type'] ) && !empty( $params['post_type'] ) ) {
+            if ( isset( $params['field_name'] ) && !empty( $params['field_name'] )  ) {
+                $post_type = sanitize_text_Field( wp_unslash( $params['post_type'] ) );
+                $field_name = sanitize_text_field( wp_unslash( $params['field_name'] ) );
+                $field_key = dt_create_field_key( $field_name );
+                $post_fields = DT_Posts::get_post_field_settings( $post_type, false, true );
+                if ( isset( $post_fields[$field_key] ) ) {
+                    return false;
+                }
+                return true;
+            }
+        }
+        return new WP_Error( __FUNCTION__, 'Parameters missing', [ 'status' => 422 ] );
+
     }
 
     public static function edit_field( WP_REST_Request $request ) {

--- a/dt-core/admin/admin-settings-endpoints.php
+++ b/dt-core/admin/admin-settings-endpoints.php
@@ -852,7 +852,7 @@ class Disciple_Tools_Admin_Settings_Endpoints {
     public static function check_field_key_is_available( WP_REST_Request $request ) {
         $params = $request->get_params();
         if ( isset( $params['post_type'] ) && !empty( $params['post_type'] ) ) {
-            if ( isset( $params['field_name'] ) && !empty( $params['field_name'] )  ) {
+            if ( isset( $params['field_name'] ) && !empty( $params['field_name'] ) ) {
                 $post_type = sanitize_text_Field( wp_unslash( $params['post_type'] ) );
                 $field_name = sanitize_text_field( wp_unslash( $params['field_name'] ) );
                 $field_key = dt_create_field_key( $field_name );

--- a/dt-core/admin/admin-settings-endpoints.php
+++ b/dt-core/admin/admin-settings-endpoints.php
@@ -167,14 +167,6 @@ class Disciple_Tools_Admin_Settings_Endpoints {
                 'permission_callback' => [ $this, 'default_permission_check' ],
             ]
         );
-
-        register_rest_route(
-            $this->namespace, '/check-field-key-is-available', [
-                'methods' => 'POST',
-                'callback' => [ $this, 'check_field_key_is_available' ],
-                'permission_callback' => [ $this, 'default_permission_check' ],
-            ]
-        );
     }
 
     public static function get_post_fields() {
@@ -847,24 +839,6 @@ class Disciple_Tools_Admin_Settings_Endpoints {
             return $default_label;
         }
         return false;
-    }
-
-    public static function check_field_key_is_available( WP_REST_Request $request ) {
-        $params = $request->get_params();
-        if ( isset( $params['post_type'] ) && !empty( $params['post_type'] ) ) {
-            if ( isset( $params['field_name'] ) && !empty( $params['field_name'] ) ) {
-                $post_type = sanitize_text_Field( wp_unslash( $params['post_type'] ) );
-                $field_name = sanitize_text_field( wp_unslash( $params['field_name'] ) );
-                $field_key = dt_create_field_key( $field_name );
-                $post_fields = DT_Posts::get_post_field_settings( $post_type, false, true );
-                if ( isset( $post_fields[$field_key] ) ) {
-                    return false;
-                }
-                return true;
-            }
-        }
-        return new WP_Error( __FUNCTION__, 'Parameters missing', [ 'status' => 422 ] );
-
     }
 
     public static function edit_field( WP_REST_Request $request ) {

--- a/dt-core/admin/css/dt-settings.css
+++ b/dt-core/admin/css/dt-settings.css
@@ -411,6 +411,14 @@ select {
     display: flex;
     justify-content: space-between;
 }
+.error-message {
+    color: red;
+    font-style: italic;
+}
+.spinner-box {
+    display: inline-block;
+    vertical-align: super;
+}
 .typeahead-div {
     min-width: 40%;
     padding: 18px 18px 0 0;

--- a/dt-core/admin/js/dt-settings.js
+++ b/dt-core/admin/js/dt-settings.js
@@ -321,117 +321,120 @@ jQuery(document).ready(function($) {
 
         $.each(fields, function(field_index, field_key) {
             var field = window['field_settings']['post_type_settings']['fields'][field_key];
+            if( !field?.type ){
+              return;
+            }
 
-                var icon_html = '';
-                if ( field['icon'] ) {
-                    icon_html = `<img src="${field['icon']}" class="dt-icon lightgray"></img>`
-                }
+            var icon_html = '';
+            if ( field['icon'] ) {
+                icon_html = `<img src="${field['icon']}" class="dt-icon lightgray"></img>`
+            }
 
+            tile_html += `
+                    <div class="section-subheader">
+                        ${icon_html}
+                        ${field['name']}
+                    </div>
+            `;
+
+
+            /*** TEXT - START ***/
+            if ( [ 'text', 'communication_channel', 'location', 'location_meta' ].indexOf(field['type']) > -1 ) {
                 tile_html += `
-                        <div class="section-subheader">
-                            ${icon_html}
-                            ${field['name']}
-                        </div>
+                    <input type="text" class="text-input">
                 `;
-
-
-                /*** TEXT - START ***/
-                if ( [ 'text', 'communication_channel', 'location', 'location_meta' ].indexOf(field['type']) > -1 ) {
-                    tile_html += `
-                        <input type="text" class="text-input">
-                    `;
-                }
-                /*** TEXT - END ***/
+            }
+            /*** TEXT - END ***/
 
 
 
-                /*** NUMBER - START ***/
-                if ( field['type'] === 'number' ) {
-                    tile_html += `
-                        <input type="number" class="text-input" value="1" min="" max=""></input>
-                    `;
-                }
-                /*** NUMBER - END ***/
-
-
-                /*** DATE - START ***/
-                if ( field['type'] === 'date' ) {
-                    tile_html += `
-                        <div class="typeahead-container">
-                            <input class="typeahead-input">
-                            <button class="typeahead-delete-button">x</button>
-                        </div>
-                    `;
-                }
-                /*** DATE - END ***/
-
-
-
-               /*** USER_SELECT - START ***/
-               if ( field['type'] === 'user_select' ) {
-                    tile_html += `
-                        <div class="typeahead-container">
-                            <span class="typeahead-cancel-button">×</span>
-                            <input class="typeahead-input" placeholder="Search Users">
-                            <button class="typeahead-button">
-                                <img src="${window.field_settings.template_dir}/dt-assets/images/search.svg">
-                            </button>
-                        </div>
+            /*** NUMBER - START ***/
+            if ( field['type'] === 'number' ) {
+                tile_html += `
+                    <input type="number" class="text-input" value="1" min="" max=""></input>
                 `;
-               }
-               /*** USER_SELECT - END ***/
+            }
+            /*** NUMBER - END ***/
+
+
+            /*** DATE - START ***/
+            if ( field['type'] === 'date' ) {
+                tile_html += `
+                    <div class="typeahead-container">
+                        <input class="typeahead-input">
+                        <button class="typeahead-delete-button">x</button>
+                    </div>
+                `;
+            }
+            /*** DATE - END ***/
 
 
 
-               /*** CONNECTION - START ***/
-                if ( ['connection', 'tags'].indexOf(field['type'] ) > -1 ) {
-                    tile_html += `
-                        <div class="typeahead-container">
-                            <input class="typeahead-input" placeholder="Search ${field['name']}">
-                            <button class="typeahead-button">
-                                <img src="${window.field_settings.template_dir}/dt-assets/images/add-contact.svg">
-                            </button>
-                        </div>
-                    `;
-                }
-                /*** CONNECTION - END ***/
+           /*** USER_SELECT - START ***/
+           if ( field['type'] === 'user_select' ) {
+                tile_html += `
+                    <div class="typeahead-container">
+                        <span class="typeahead-cancel-button">×</span>
+                        <input class="typeahead-input" placeholder="Search Users">
+                        <button class="typeahead-button">
+                            <img src="${window.field_settings.template_dir}/dt-assets/images/search.svg">
+                        </button>
+                    </div>
+            `;
+           }
+           /*** USER_SELECT - END ***/
 
 
 
-                /*** MULTISELECT - START ***/
-                if ( field['type'] === 'multi_select' ) {
-                    tile_html += `<div class="button-group" style="display: inline-flex;">`;
-                        var multi_select_icon_html = '';
-                        $.each( field['default'], function(k,f) {
-                            if ( f['icon'] ) {
-                                multi_select_icon_html = `<img src="${f['icon']}" class="dt-icon">`;
-                            }
-                            tile_html += `
-                            <button>
-                                ${multi_select_icon_html}
-                                ${f['label']}
-                            </button>
-                            `;
-                        });
-                    tile_html += `</div>`;
-                }
-                /*** MULTISELECT - START ***/
+           /*** CONNECTION - START ***/
+            if ( ['connection', 'tags'].indexOf(field['type'] ) > -1 ) {
+                tile_html += `
+                    <div class="typeahead-container">
+                        <input class="typeahead-input" placeholder="Search ${field['name']}">
+                        <button class="typeahead-button">
+                            <img src="${window.field_settings.template_dir}/dt-assets/images/add-contact.svg">
+                        </button>
+                    </div>
+                `;
+            }
+            /*** CONNECTION - END ***/
 
 
 
-                /*** KEY_SELECT - START ***/
-                if ( field['type'] === 'key_select' ) {
-                    var color_select = '';
-                    if ( field['custom_display'] ) {
-                        color_select = 'color-select';
-                    }
-                    tile_html += `<select class="select-field ${color_select}" style="width: 100%;">`;
+            /*** MULTISELECT - START ***/
+            if ( field['type'] === 'multi_select' ) {
+                tile_html += `<div class="button-group" style="display: inline-flex;">`;
+                    var multi_select_icon_html = '';
                     $.each( field['default'], function(k,f) {
-                        tile_html += `<option>${f['label']}</option>`;
+                        if ( f['icon'] ) {
+                            multi_select_icon_html = `<img src="${f['icon']}" class="dt-icon">`;
+                        }
+                        tile_html += `
+                        <button>
+                            ${multi_select_icon_html}
+                            ${f['label']}
+                        </button>
+                        `;
                     });
-                    tile_html += `</select>`;
+                tile_html += `</div>`;
+            }
+            /*** MULTISELECT - START ***/
+
+
+
+            /*** KEY_SELECT - START ***/
+            if ( field['type'] === 'key_select' ) {
+                var color_select = '';
+                if ( field['custom_display'] ) {
+                    color_select = 'color-select';
                 }
-                /*** KEY_SELECT - END ***/
+                tile_html += `<select class="select-field ${color_select}" style="width: 100%;">`;
+                $.each( field['default'], function(k,f) {
+                    tile_html += `<option>${f['label']}</option>`;
+                });
+                tile_html += `</select>`;
+            }
+            /*** KEY_SELECT - END ***/
         });
         tile_html += `
                 </div>

--- a/dt-core/admin/js/dt-settings.js
+++ b/dt-core/admin/js/dt-settings.js
@@ -179,9 +179,9 @@ jQuery(document).ready(function($) {
                     sortable_field_options_ordering.push(option_element.dataset['fieldOptionKey']);
                 });
                 API.update_field_options_order(post_type, field_key, sortable_field_options_ordering).promise().then(function(new_order){
-                    var old_order = window.field_settings.post_type_settings.fields[field_key].default;
+                    var old_order = window['field_settings']['post_type_settings']['fields'][field_key]['default'];
                     field_options_in_new_order = order_field_option_keys_by_array(old_order, new_order);
-                    window.field_settings.post_type_settings.fields[field_key].default = field_options_in_new_order;
+                    window['field_settings']['post_type_settings']['fields'][field_key]['default'] = field_options_in_new_order;
 
                     tile_key = window.field_settings.post_type_settings.fields[field_key].tile;
                     show_preview_tile(tile_key);
@@ -1201,7 +1201,7 @@ jQuery(document).ready(function($) {
                 <div class="field-settings-table-child-toggle">
                     <div class="field-settings-table-field-option">
                        <span class="sortable ui-icon ui-icon-arrow-4"></span>
-                        <span class="field-name-content"><i>default blank</i></span>
+                        <span class="field-name-content">default blank</span>
                     </div>
                     <div class="field-settings-table-field-option new-field-option" data-parent-tile-key="${tile_key}" data-field-key="${field_key}">
                         <span class="sortable ui-icon ui-icon-arrow-4"></span>
@@ -1291,11 +1291,11 @@ jQuery(document).ready(function($) {
         var field_option_icon = $('#edit-field-icon').val();
 
         API.new_field_option(post_type, tile_key, field_key, field_option_name, field_option_description, field_option_icon).promise().then(function(new_field_option_key) {
-            window['field_settings']['post_type_settings']['fields'][field_key]['default'].push( new_field_option_key = {
+            window['field_settings']['post_type_settings']['fields'][field_key]['default'][new_field_option_key] = {
                 label:field_option_name,
                 description:field_option_description,
                 icon:field_option_icon,
-            });
+            };
 
             var new_field_option_html = `
             <div class="field-settings-table-field-option">

--- a/dt-core/admin/js/dt-settings.js
+++ b/dt-core/admin/js/dt-settings.js
@@ -119,11 +119,6 @@ jQuery(document).ready(function($) {
         field_option_key: field_option_key,
     }, `dt-admin-settings/`);
 
-    window.API.check_field_key_is_available = (post_type, field_name) => makeRequest("POST", `check-field-key-is-available`, {
-        post_type: post_type,
-        field_name: field_name,
-    }, `dt-admin-settings/`);
-
     function autonavigate_to_menu() {
         var tile_key = get_tile_from_uri();
         var field_key = get_field_from_uri();
@@ -701,7 +696,7 @@ jQuery(document).ready(function($) {
                     <input name="new-field-name" id="new-field-name" type="text" value="" required>
                 </td>
                 <td class="spinner-box">
-                    <span style="" class="loading-spinner"></span>
+                    <span class="loading-spinner"></span>
                 </td>
             </tr>
             <tr id="field-exists-message" style="display:none;">
@@ -1619,7 +1614,6 @@ jQuery(document).ready(function($) {
 
     $('.dt-admin-modal-box').on('input', '#new-field-name', function() {
         $('.loading-spinner').addClass('active');
-        var post_type = get_post_type();
         var field_name = $(this).val();
         if ( field_name.length == 0 ) {
             $('#field-exists-message').hide();
@@ -1627,16 +1621,16 @@ jQuery(document).ready(function($) {
             $('.loading-spinner').removeClass('active');
             return;
         }
-        API.check_field_key_is_available( post_type, field_name ).promise().then(function(available) {
-            if (!available) {
-                $('#field-exists-message').show();
-                $('#js-add-field').prop('disabled', true);
-            } else {
-                $('#field-exists-message').hide();
-                $('#js-add-field').prop('disabled', false);
-            }
-            $('.loading-spinner').removeClass('active');
-        });
+        var field_key = field_name.toLowerCase().replace(' ', '_');
+
+        if (window.field_settings.post_type_settings.fields[field_key]) {
+            $('#field-exists-message').show();
+            $('#js-add-field').prop('disabled', true);
+        } else {
+            $('#field-exists-message').hide();
+            $('#js-add-field').prop('disabled', false);
+        }
+        $('.loading-spinner').removeClass('active');
     });
 
     $.typeahead({

--- a/dt-core/admin/menu/tabs/tab-customizations.php
+++ b/dt-core/admin/menu/tabs/tab-customizations.php
@@ -410,13 +410,8 @@ class Disciple_Tools_Customizations_Tab extends Disciple_Tools_Abstract_Menu_Bas
                                             <?php if ( $key === 'default' && !empty( $field_settings['default'] ) && is_array( $field_settings['default'] ) ) : ?>
                                                 <?php foreach ( $value as $k => $v ) {
                                                     $label = 'default blank';
-                                                    if ( isset( $v['label'] ) || !empty( $v['label'] ) ) {
-                                                        // $option_key = $value;
+                                                    if ( isset( $v['label'] ) && !empty( $v['label'] ) ) {
                                                         $label = $v['label'];
-                                                    }
-
-                                                    if ( isset( $v['default'] ) || !empty( $v['default'] ) ) {
-                                                        $option_key = $v['default'];
                                                     }
                                                     ?>
                                                     <div class="field-settings-table-field-option" id="<?php echo esc_attr( $k ); ?>" data-field-option-key="<?php echo esc_attr( $k ); ?>" data-field-key="<?php echo esc_attr( $field_key ); ?>">


### PR DESCRIPTION
**Functionality example:**
https://user-images.githubusercontent.com/36511666/236450540-705aeed5-56dc-44fc-9b94-9c7b8cd1fd89.mov



**Refactored some code:**
- Fixed input field's name `edit-tile-label -> new-field-name`
- The `new_field_name`, `new_field_type`, and `new_field_private` elements didn't need to have the tile id in their id name because only one modal is displayed at a time so no ambiguity conflicts should arise.
- Other input fields might have the tile id in their id name but only this one was fixed in order to not broaden the PRs scope