### PR TITLE
workflows: handle not_equals/not_contain when field is not set

### DIFF
--- a/dt-workflows/workflows-execution-handler.php
+++ b/dt-workflows/workflows-execution-handler.php
@@ -137,6 +137,10 @@ class Disciple_Tools_Workflows_Execution_Handler {
                 switch ( $condition ) {
                     case 'not_set':
                         return self::condition_not_set( $field_type, null );
+                    case 'not_equals':
+                    case 'not_contain':
+                        // if $post[$field_id] is not set, not_contain and not_equals are true
+                        return true;
                 }
             }
         }


### PR DESCRIPTION
When setting a condition for a workflow with the `not_contain` comparison but the field is not set at all, the condition was not being matched. However, if the field is not set, we know that it doesn't contain the given value. This handles the case where the field is not set for `not_contain` and `not_equals`