### PR TITLE
#1538 - Activity During Date Range Metric

### DIFF
--- a/dt-metrics/combined/date-range-activity.js
+++ b/dt-metrics/combined/date-range-activity.js
@@ -177,11 +177,18 @@ function project_activity_during_date_range() {
           posts.forEach(function (post) {
             if (post['id'] && post['name'] && post['timestamp']) {
               let post_url = dtMetricsProject.site_url + '/' + post['post_type'] + '/' + post['id'];
+              let new_value = window.lodash.escape(post['new_value']);
+
+              // Apply custom styling.
+              if ((post['field_type'] && post['field_type'] === 'connection') && (post['deleted'] && post['deleted'] === true)) {
+                new_value = `<s>${window.lodash.escape(post['new_value'])}</s>`;
+              }
+
               tbody.append(`
                 <tr>
                     <td><a href="${post_url}" target="_blank">${window.lodash.escape(post['name'])}</a></td>
                     <td>${window.lodash.escape(moment.unix(post['timestamp']).format('dddd, MMMM Do YYYY, h:mm:ss A'))}</td>
-                    <td>${window.lodash.escape(post['new_value'])}</td>
+                    <td>${new_value}</td>
                 </tr>
               `);
             }

--- a/dt-metrics/combined/date-range-activity.js
+++ b/dt-metrics/combined/date-range-activity.js
@@ -26,7 +26,8 @@ function project_activity_during_date_range() {
     submit_button_label,
     total_label,
     results_table_head_title_label,
-    results_table_head_date_label
+    results_table_head_date_label,
+    results_table_head_new_value_label
   } = escapeObject(dtMetricsProject.translations);
 
   const postTypeOptions = escapeObject(dtMetricsProject.select_options.post_type_select_options);
@@ -70,6 +71,7 @@ function project_activity_during_date_range() {
                 <tr>
                     <th>${results_table_head_title_label}</th>
                     <th>${results_table_head_date_label}</th>
+                    <th>${results_table_head_new_value_label}</th>
                 </tr>
             </thead>
             <tbody></tbody>
@@ -179,6 +181,7 @@ function project_activity_during_date_range() {
                 <tr>
                     <td><a href="${post_url}" target="_blank">${window.lodash.escape(post['name'])}</a></td>
                     <td>${window.lodash.escape(moment.unix(post['timestamp']).format('dddd, MMMM Do YYYY, h:mm:ss A'))}</td>
+                    <td>${window.lodash.escape(post['new_value'])}</td>
                 </tr>
               `);
             }

--- a/dt-metrics/combined/date-range-activity.js
+++ b/dt-metrics/combined/date-range-activity.js
@@ -80,9 +80,8 @@ function project_activity_during_date_range() {
   `;
 
   // Activate date range picker element.
-  window.METRICS.setupDatePicker(
-    `${dtMetricsProject.root}dt/v1/metrics/dummy_endpoint`,
-    function (data, label) {
+  window.METRICS.setupDatePickerWithoutEndpoint(
+    function (start, end, label) {
       $('.date_range_picker span').html(label);
       $('#post-field-submit-button').click();
     },

--- a/dt-metrics/combined/date-range-activity.js
+++ b/dt-metrics/combined/date-range-activity.js
@@ -45,9 +45,6 @@ function project_activity_during_date_range() {
         <select class="select-field" id="post-field-select">
             ${buildFieldSelectOptions()}
         </select>
-        <select class="select-field" id="post-field-condition-select">
-            ${buildFieldConditionSelectOptions()}
-        </select>
         <div id="post-field-value-entry-div"></div>
 
         <label class="section-subheader" for="date-select">${date_select_label}</label>
@@ -123,7 +120,6 @@ function project_activity_during_date_range() {
     getDateRangeActivity({
       'post_type': $('#post-type-select').val(),
       'field': $('#post-field-select').val(),
-      'condition': $('#post-field-condition-select').val(),
       'value': $('#post-field-value').val(),
       'ts_start': (date_range_picker.startDate.unix() > 0) ? date_range_picker.startDate.unix() : 0,
       'ts_end': date_range_picker.endDate.unix()
@@ -149,12 +145,12 @@ function project_activity_during_date_range() {
           tbody.empty();
 
           posts.forEach(function (post) {
-            if (post['ID'] && post['post_title'] && post['post_date']) {
-              let post_url = dtMetricsProject.site_url + '/' + post['post_type'] + '/' + post['ID'];
+            if (post['id'] && post['name'] && post['timestamp']) {
+              let post_url = dtMetricsProject.site_url + '/' + post['post_type'] + '/' + post['id'];
               tbody.append(`
                 <tr>
-                    <td><a href="${post_url}" target="_blank">${window.lodash.escape(post['post_title'])}</a></td>
-                    <td>${window.lodash.escape(post['post_date']['formatted'])}</td>
+                    <td><a href="${post_url}" target="_blank">${window.lodash.escape(post['name'])}</a></td>
+                    <td>${window.lodash.escape(moment.unix(post['timestamp']).format('dddd, MMMM Do YYYY, h:mm:ss A'))}</td>
                 </tr>
               `);
             }
@@ -194,21 +190,6 @@ function buildFieldSelectOptions() {
     `)
 }
 
-function buildFieldConditionSelectOptions() {
-  let conditions = Object.entries(dtMetricsProject.field_conditions)
-  .reduce((options, [key, label]) => {
-    options[key] = label
-    return options
-  }, {});
-
-  let html = ``;
-  Object.entries(conditions).forEach(([key, label]) => {
-    html += `<option value="${key}">${label}</option>`;
-  });
-
-  return html;
-}
-
 function refreshFieldValueEntryElement() {
 
   // Empty any previous entries.
@@ -220,15 +201,15 @@ function refreshFieldValueEntryElement() {
   let field_id = jQuery('#post-field-select').val();
   if (field_id && field_settings[field_id]) {
 
-    // Based on field type, determine html element style to be adopted.
-    if (window.lodash.includes(['key_select', 'multi_select', 'link'], field_settings[field_id]['type'])) {
-      let options_html = ``;
+    // Based on field type & associated defaults, determine html element style to be adopted.
+    if (field_settings[field_id]['default'] && Object.keys(field_settings[field_id]['default']).length > 0) {
+      let options_html = `<option value="">[ ${window.lodash.escape(dtMetricsProject.translations['post_field_select_any_activity_label'])} ]</option>`;
       Object.entries(field_settings[field_id]['default']).forEach(([key, option]) => {
         options_html += `<option value="${key}">${option['label']}</option>`;
       });
       entry_div.html(`<select class="select-field" id="post-field-value">${options_html}</select>`);
     } else {
-      entry_div.html('<input type="text" id="post-field-value" />');
+      entry_div.html('<input type="hidden" id="post-field-value" value="" />');
     }
   }
 }

--- a/dt-metrics/combined/date-range-activity.js
+++ b/dt-metrics/combined/date-range-activity.js
@@ -1,0 +1,234 @@
+jQuery(function () {
+  if (window.wpApiShare.url_path.startsWith('metrics/combined/date_range_activity')) {
+    project_activity_during_date_range();
+  }
+});
+
+const getFieldSettings = (postType) =>
+  makeRequest('GET', `metrics/field_settings/${postType}`)
+
+const getDateRangeActivity = (data) =>
+  makeRequest('GET', `metrics/date_range_activity`, data)
+
+const escapeObject = window.SHAREDFUNCTIONS.escapeObject
+
+function project_activity_during_date_range() {
+  const chartDiv = document.querySelector('#chart');
+
+  const {
+    title_date_range_activity,
+    post_type_select_label,
+    post_field_select_label,
+    date_select_label,
+    submit_button_label,
+    total_label,
+    results_table_head_title_label,
+    results_table_head_date_label
+  } = escapeObject(dtMetricsProject.translations);
+
+  const postTypeOptions = escapeObject(dtMetricsProject.select_options.post_type_select_options);
+
+  jQuery('#metrics-sidemenu').foundation('down', jQuery('#combined-menu'));
+
+  // Display initial controls.
+  chartDiv.innerHTML = `
+    <div class="section-header">${title_date_range_activity}</div>
+    <section class="chart-controls">
+        <label class="section-subheader" for="post-type-select">${post_type_select_label}</label>
+        <select class="select-field" id="post-type-select">
+            ${Object.entries(postTypeOptions).map(([value, label]) => `
+                <option value="${value}"> ${label} </option>
+            `)}
+        </select>
+
+        <label class="section-subheader" for="post-field-select">${post_field_select_label}</label>
+        <select class="select-field" id="post-field-select">
+            ${buildFieldSelectOptions()}
+        </select>
+        <select class="select-field" id="post-field-condition-select">
+            ${buildFieldConditionSelectOptions()}
+        </select>
+        <div id="post-field-value-entry-div"></div>
+
+        <label class="section-subheader" for="date-select">${date_select_label}</label>
+        <div class="date_range_picker">
+            <i class="fi-calendar"></i>&nbsp;
+            <span>${moment().format("YYYY")}</span>
+            <i class="dt_caret down"></i>
+        </div>
+
+        <br><br>
+        <button class="button" id="post-field-submit-button">${submit_button_label}</button>
+        <div id="chart-loading-spinner" class="loading-spinner"></div>
+    </section>
+    <hr>
+    <div id="activity_results_div" style="display: none;">
+        <h2>${total_label}: <span id="activity_results_total">0</span></h2>
+        <br>
+        <table>
+            <thead>
+                <tr>
+                    <th>${results_table_head_title_label}</th>
+                    <th>${results_table_head_date_label}</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+  `;
+
+  // Activate date range picker element.
+  window.METRICS.setupDatePicker(
+    `${dtMetricsProject.root}dt/v1/metrics/dummy_endpoint`,
+    function (data, label) {
+      $('.date_range_picker span').html(label);
+      $('#post-field-submit-button').click();
+    },
+    moment().startOf('year')
+  );
+
+  // Display field value entry accordingly based on selected field.
+  refreshFieldValueEntryElement();
+
+  // Add post type event listener.
+  const fieldSelectElement = document.querySelector('#post-field-select')
+  document.querySelector('#post-type-select').addEventListener('change', (e) => {
+    const postType = e.target.value
+    dtMetricsProject.state.post_type = postType;
+    getFieldSettings(postType)
+    .promise()
+    .then((data) => {
+      console.log(data);
+      dtMetricsProject.field_settings = data;
+      fieldSelectElement.innerHTML = buildFieldSelectOptions();
+      fieldSelectElement.dispatchEvent(new Event('change'));
+    })
+    .catch((error) => {
+      console.log(error)
+    });
+  });
+
+  // Add field event listener.
+  fieldSelectElement.addEventListener('change', (e) => {
+    refreshFieldValueEntryElement();
+  });
+
+  // Add submit button event listener.
+  document.querySelector('#post-field-submit-button').addEventListener('click', (e) => {
+    let date_range_picker = $('.date_range_picker').data('daterangepicker');
+    let loadingSpinner = document.querySelector('#chart-loading-spinner');
+    loadingSpinner.classList.add('active');
+
+    // Fetch records matching activity within specified date range.
+    getDateRangeActivity({
+      'post_type': $('#post-type-select').val(),
+      'field': $('#post-field-select').val(),
+      'condition': $('#post-field-condition-select').val(),
+      'value': $('#post-field-value').val(),
+      'ts_start': (date_range_picker.startDate.unix() > 0) ? date_range_picker.startDate.unix() : 0,
+      'ts_end': date_range_picker.endDate.unix()
+    })
+    .promise()
+    .then((response) => {
+
+      let total = response['total'];
+      let posts = response['posts'];
+
+      let activity_results_div = $('#activity_results_div');
+
+      // Refresh activity during date range results display.
+      activity_results_div.fadeOut('fast', function () {
+        $('#activity_results_total').html(total);
+
+        // Refresh and re-populate results table.
+        let table = activity_results_div.find('table');
+        table.fadeOut('fast');
+        if(total && (total > 0)) {
+
+          let tbody = table.find('tbody');
+          tbody.empty();
+
+          posts.forEach(function (post) {
+            if (post['ID'] && post['post_title'] && post['post_date']) {
+              let post_url = dtMetricsProject.site_url + '/' + post['post_type'] + '/' + post['ID'];
+              tbody.append(`
+                <tr>
+                    <td><a href="${post_url}" target="_blank">${window.lodash.escape(post['post_title'])}</a></td>
+                    <td>${window.lodash.escape(post['post_date']['formatted'])}</td>
+                </tr>
+              `);
+            }
+          });
+
+          table.fadeIn('fast');
+        }
+
+        // Display result findings.
+        activity_results_div.fadeIn('fast');
+        loadingSpinner.classList.remove('active');
+
+      });
+
+    })
+    .catch((error) => {
+      console.log(error);
+    });
+
+  });
+}
+
+function buildFieldSelectOptions() {
+    const unescapedOptions = Object.entries(dtMetricsProject.field_settings)
+        .reduce((options, [ key, setting ]) => {
+            options[key] = setting.name
+            return options
+        }, {})
+    const postFieldOptions = escapeObject(unescapedOptions)
+    const sortedOptions = Object.entries(postFieldOptions).sort(([key1, value1], [key2, value2]) => {
+        if (value1 < value2) return -1
+        if (value1 === value2) return 0
+        if (value1 > value2) return 1
+    })
+    return sortedOptions.map(([value, label]) => `
+        <option value="${value}"> ${label} </option>
+    `)
+}
+
+function buildFieldConditionSelectOptions() {
+  let conditions = Object.entries(dtMetricsProject.field_conditions)
+  .reduce((options, [key, label]) => {
+    options[key] = label
+    return options
+  }, {});
+
+  let html = ``;
+  Object.entries(conditions).forEach(([key, label]) => {
+    html += `<option value="${key}">${label}</option>`;
+  });
+
+  return html;
+}
+
+function refreshFieldValueEntryElement() {
+
+  // Empty any previous entries.
+  let entry_div = jQuery('#post-field-value-entry-div');
+  entry_div.empty();
+
+  // Determine field id to be refreshed.
+  let field_settings = dtMetricsProject.field_settings;
+  let field_id = jQuery('#post-field-select').val();
+  if (field_id && field_settings[field_id]) {
+
+    // Based on field type, determine html element style to be adopted.
+    if (window.lodash.includes(['key_select', 'multi_select', 'link'], field_settings[field_id]['type'])) {
+      let options_html = ``;
+      Object.entries(field_settings[field_id]['default']).forEach(([key, option]) => {
+        options_html += `<option value="${key}">${option['label']}</option>`;
+      });
+      entry_div.html(`<select class="select-field" id="post-field-value">${options_html}</select>`);
+    } else {
+      entry_div.html('<input type="text" id="post-field-value" />');
+    }
+  }
+}

--- a/dt-metrics/combined/date-range-activity.php
+++ b/dt-metrics/combined/date-range-activity.php
@@ -223,7 +223,7 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
                             $field_types[] = 'connection ' . $p2p_direction;
                         }
                     }
-                    $field_type_sql = "AND field_type IN (" . dt_array_to_sql( $field_types ) . ")";
+                    $field_type_sql = 'AND field_type IN (' . dt_array_to_sql( $field_types ) . ')';
                 }
                 $meta_key_sql = ( $field_type == 'connection' ) ? "AND meta_key LIKE '". esc_sql( !empty( $settings['p2p_key'] ) ? $settings['p2p_key'] : '%' ) ."'" : "AND meta_key LIKE '" . esc_sql( $params['field'] ) . "'";
 

--- a/dt-metrics/combined/date-range-activity.php
+++ b/dt-metrics/combined/date-range-activity.php
@@ -149,18 +149,6 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
         );
 
         register_rest_route(
-            $namespace, '/metrics/dummy_endpoint', [
-                [
-                    'methods'  => WP_REST_Server::READABLE,
-                    'callback' => [ $this, 'dummy_endpoint' ],
-                    'permission_callback' => function(){
-                        return $this->has_permission();
-                    },
-                ],
-            ]
-        );
-
-        register_rest_route(
             $namespace, '/metrics/date_range_activity', [
                 [
                     'methods'  => WP_REST_Server::CREATABLE,
@@ -199,10 +187,6 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
         }
 
         return [];
-    }
-
-    public function dummy_endpoint( WP_REST_Request $request ){
-        return new WP_REST_Response( [] );
     }
 
     public function date_range_activity( WP_REST_Request $request ){

--- a/dt-metrics/combined/date-range-activity.php
+++ b/dt-metrics/combined/date-range-activity.php
@@ -197,6 +197,7 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
             ] );
 
             global $wpdb;
+            // phpcs:disable
             $results = $wpdb->get_results( $wpdb->prepare( "
             SELECT *
             FROM $wpdb->dt_activity_log
@@ -208,6 +209,7 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
             $meta_value_sql
             ORDER BY hist_time DESC;
             ", $params['post_type'], $params['ts_start'], $params['ts_end'] ), ARRAY_A );
+            // phpcs:enable
 
             // Package result findings and return.
             $posts = [];

--- a/dt-metrics/combined/date-range-activity.php
+++ b/dt-metrics/combined/date-range-activity.php
@@ -129,7 +129,9 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
                 [
                     'methods'  => WP_REST_Server::READABLE,
                     'callback' => [ $this, 'field_settings' ],
-                    'permission_callback' => '__return_true',
+                    'permission_callback' => function(){
+                        return $this->has_permission();
+                    },
                 ],
             ]
         );
@@ -139,7 +141,9 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
                 [
                     'methods'  => WP_REST_Server::READABLE,
                     'callback' => [ $this, 'render_field_html' ],
-                    'permission_callback' => '__return_true'
+                    'permission_callback' => function(){
+                        return $this->has_permission();
+                    },
                 ]
             ]
         );
@@ -149,7 +153,9 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
                 [
                     'methods'  => WP_REST_Server::READABLE,
                     'callback' => [ $this, 'dummy_endpoint' ],
-                    'permission_callback' => '__return_true',
+                    'permission_callback' => function(){
+                        return $this->has_permission();
+                    },
                 ],
             ]
         );
@@ -159,24 +165,20 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
                 [
                     'methods'  => WP_REST_Server::CREATABLE,
                     'callback' => [ $this, 'date_range_activity' ],
-                    'permission_callback' => '__return_true',
+                    'permission_callback' => function(){
+                        return $this->has_permission();
+                    },
                 ],
             ]
         );
     }
 
     public function field_settings( WP_REST_Request $request ) {
-        if ( !$this->has_permission() ) {
-            wp_send_json_error( new WP_Error( 'get_field_settings', 'Missing Permissions', [ 'status' => 400 ] ) );
-        }
         $url_params = $request->get_url_params();
         return $this->get_field_settings( $url_params['post_type'] );
     }
 
     public function render_field_html( WP_REST_Request $request ){
-        if ( !$this->has_permission() ){
-            wp_send_json_error( new WP_Error( 'render_field_html', 'Missing Permissions', [ 'status' => 400 ] ) );
-        }
         $params = $request->get_params();
         if ( isset( $params['post_type'], $params['field_id'] ) ){
 
@@ -204,9 +206,6 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
     }
 
     public function date_range_activity( WP_REST_Request $request ){
-        if ( !$this->has_permission() ){
-            wp_send_json_error( new WP_Error( 'date_range_activity', 'Missing Permissions', [ 'status' => 400 ] ) );
-        }
 
         $params = $request->get_params();
         if ( isset( $params['post_type'], $params['field'], $params['ts_start'], $params['ts_end'] ) ){

--- a/dt-metrics/combined/date-range-activity.php
+++ b/dt-metrics/combined/date-range-activity.php
@@ -211,7 +211,19 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
 
             } elseif ( ( $field_type == 'connection' ) || ( $field_type == 'location' ) ){
                 if ( $field_type == 'connection' ){
-                    $field_type_sql = "AND field_type IN ('" . esc_sql( $field_type ) . "', 'connection to', 'connection from')";
+
+                    // Determine field types to be expected, based on p2p_direction.
+                    $field_types = [ $field_type ];
+                    if ( !empty( $settings['p2p_direction'] ) ){
+                        $p2p_direction = $settings['p2p_direction'];
+                        if ( $p2p_direction == 'any' ){
+                            $field_types[] = 'connection to';
+                            $field_types[] = 'connection from';
+                        } else {
+                            $field_types[] = 'connection ' . $p2p_direction;
+                        }
+                    }
+                    $field_type_sql = "AND field_type IN (" . dt_array_to_sql( $field_types ) . ")";
                 }
                 $meta_key_sql = ( $field_type == 'connection' ) ? "AND meta_key LIKE '". esc_sql( !empty( $settings['p2p_key'] ) ? $settings['p2p_key'] : '%' ) ."'" : "AND meta_key LIKE '" . esc_sql( $params['field'] ) . "'";
 

--- a/dt-metrics/combined/date-range-activity.php
+++ b/dt-metrics/combined/date-range-activity.php
@@ -275,12 +275,16 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
 
                 // Determine new value label to be returned.
                 $new_value = $activity['meta_value'] ?? '';
+                $deleted = false;
                 if ( $field_type == 'connection' ){
                     if ( isset( $settings['post_type'], $new_value ) ){
                         $post = DT_Posts::get_post( $settings['post_type'], $new_value, true, false );
                         if ( !is_wp_error( $post ) ){
                             $new_value = $post['name'] ?? $new_value;
                         }
+                    }
+                    if ( $activity['action'] == 'disconnected from' ){
+                        $deleted = true;
                     }
                 } elseif ( $field_type == 'location' ){
                     $geocoder = new Location_Grid_Geocoder();
@@ -301,6 +305,7 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
                         $new_value = ( $new_value != 'value_deleted' ) ? gmdate( 'F j, Y, g:i A', $new_value ) : '';
                     } elseif ( $new_value == 'value_deleted' ){
                         $new_value = '';
+                        $deleted = true;
                     }
                 } elseif ( $field_type == 'boolean' ){
                     $new_value = ( $new_value == 1 ) ? __( 'True', 'disciple_tools' ) : __( 'False', 'disciple_tools' );
@@ -310,6 +315,7 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
 
                 } elseif ( $new_value == 'value_deleted' ){
                     $new_value = '';
+                    $deleted = true;
                 }
 
                 $posts[] = [
@@ -317,7 +323,9 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
                     'post_type' => $activity['object_type'],
                     'name' => $activity['object_name'],
                     'timestamp' => $activity['hist_time'],
-                    'new_value' => $new_value
+                    'new_value' => $new_value,
+                    'deleted' => $deleted,
+                    'field_type' => $field_type
                 ];
             }
 

--- a/dt-metrics/combined/date-range-activity.php
+++ b/dt-metrics/combined/date-range-activity.php
@@ -1,0 +1,210 @@
+<?php
+if ( !defined( 'ABSPATH' ) ) {
+    exit;
+} // Exit if accessed directly.
+
+class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
+{
+
+    //slug and title of the top menu folder
+    public $base_slug = 'combined'; // lowercase
+    public $base_title;
+    public $title;
+    public $slug = 'date_range_activity'; // lowercase
+    public $js_object_name = 'wp_js_object'; // This object will be loaded into the metrics.js file by the wp_localize_script.
+    public $js_file_name = '/dt-metrics/combined/date-range-activity.js'; // should be full file name plus extension
+    public $permissions = [ 'view_project_metrics', 'dt_all_access_contacts' ];
+    public $post_types = [];
+    public $field_settings = [];
+    public $post_type_select_options = [];
+    public $post_field_select_options = [];
+    public $post_field_types_filter = [
+        'tags',
+        'multi_select',
+        'key_select'
+    ];
+
+    public function __construct() {
+        parent::__construct();
+        if ( !$this->has_permission() ){
+            return;
+        }
+
+        $this->title = __( 'Activity During Date Range', 'disciple_tools' );
+        $this->base_title = __( 'Project', 'disciple_tools' );
+
+        $url_path = dt_get_url_path( true );
+        if ( "metrics/$this->base_slug/$this->slug" === $url_path ) {
+
+            add_action( 'wp_enqueue_scripts', [ $this, 'scripts' ], 99 );
+
+        }
+
+        $post_types = DT_Posts::get_post_types();
+        $post_types = array_values( array_diff( $post_types, [ 'peoplegroups' ] ) ); //skip people groups for now.
+        $this->post_types = $post_types;
+        $post_type_options = [];
+        foreach ( $post_types as $post_type ) {
+            $post_type_options[$post_type] = DT_Posts::get_label_for_post_type( $post_type );
+        }
+
+        $this->field_settings = $this->get_field_settings( $post_types[0] );
+        $this->post_field_select_options = $this->create_select_options_from_field_settings( $this->field_settings );
+
+        $this->post_type_select_options = apply_filters( 'dt_time_chart_select_options', $post_type_options );
+
+        add_action( 'rest_api_init', [ $this, 'add_api_routes' ] );
+    }
+
+    public function scripts() {
+        wp_register_script( 'datepicker', 'https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.min.js', array(), false, true );
+        wp_enqueue_style( 'datepicker-css', 'https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css', array() );
+
+        wp_register_script( 'amcharts-core', 'https://www.amcharts.com/lib/4/core.js', false, false, true );
+        wp_register_script( 'amcharts-charts', 'https://www.amcharts.com/lib/4/charts.js', false, false, true );
+        wp_register_script( 'amcharts-animated', 'https://www.amcharts.com/lib/4/themes/animated.js', [ 'amcharts-core' ], '4', true );
+
+        wp_enqueue_script( 'dt_metrics_project_script', get_template_directory_uri() . $this->js_file_name, [
+            'moment',
+            'jquery',
+            'jquery-ui-core',
+            'amcharts-core',
+            'amcharts-charts',
+            'amcharts-animated',
+            'datepicker',
+            'wp-i18n'
+        ], filemtime( get_theme_file_path() . $this->js_file_name ), true );
+
+
+        $post_type = $this->post_types[0];
+        $field = array_keys( $this->post_field_select_options )[0];
+        wp_localize_script(
+            'dt_metrics_project_script', 'dtMetricsProject', [
+                'root'               => esc_url_raw( rest_url() ),
+                'site_url' => site_url(),
+                'state'              => [
+                    'post_type' => $post_type,
+                    'field' => $field
+                ],
+                'translations'       => [
+                    'title_date_range_activity' => $this->title,
+                    'post_type_select_label' => __( 'Post Type', 'disciple_tools' ),
+                    'post_field_select_label' => __( 'Field', 'disciple_tools' ),
+                    'total_label' => __( 'Total', 'disciple_tools' ),
+                    'date_select_label' => __( 'Date', 'disciple_tools' ),
+                    'submit_button_label' => __( 'Reload', 'disciple_tools' ),
+                    'results_table_head_title_label' => __( 'Title', 'disciple_tools' ),
+                    'results_table_head_date_label' => __( 'Date', 'disciple_tools' )
+                ],
+                'select_options' => [
+                    'post_type_select_options' => $this->post_type_select_options,
+                    'post_field_select_options' => $this->post_field_select_options,
+                ],
+                'field_settings' => $this->field_settings,
+                'field_conditions' => [
+                    'equal' => __( 'Equal To', 'disciple_tools' ),
+                    'not_equal' => __( 'Not Equal To', 'disciple_tools' )
+                ]
+            ]
+        );
+    }
+
+    public function add_api_routes() {
+        $version   = '1';
+        $namespace = 'dt/v' . $version;
+
+        register_rest_route(
+            $namespace, '/metrics/field_settings/(?P<post_type>\w+)', [
+                [
+                    'methods'  => WP_REST_Server::READABLE,
+                    'callback' => [ $this, 'field_settings' ],
+                    'permission_callback' => '__return_true',
+                ],
+            ]
+        );
+
+        register_rest_route(
+            $namespace, '/metrics/dummy_endpoint', [
+                [
+                    'methods'  => WP_REST_Server::READABLE,
+                    'callback' => [ $this, 'dummy_endpoint' ],
+                    'permission_callback' => '__return_true',
+                ],
+            ]
+        );
+
+        register_rest_route(
+            $namespace, '/metrics/date_range_activity', [
+                [
+                    'methods'  => WP_REST_Server::READABLE,
+                    'callback' => [ $this, 'date_range_activity' ],
+                    'permission_callback' => '__return_true',
+                ],
+            ]
+        );
+    }
+
+    public function field_settings( WP_REST_Request $request ) {
+        if ( !$this->has_permission() ) {
+            wp_send_json_error( new WP_Error( 'get_field_settings', 'Missing Permissions', [ 'status' => 400 ] ) );
+        }
+        $url_params = $request->get_url_params();
+        return $this->get_field_settings( $url_params['post_type'] );
+    }
+
+    public function dummy_endpoint( WP_REST_Request $request ){
+        return new WP_REST_Response( [] );
+    }
+
+    public function date_range_activity( WP_REST_Request $request ){
+        if ( !$this->has_permission() ){
+            wp_send_json_error( new WP_Error( 'date_range_activity', 'Missing Permissions', [ 'status' => 400 ] ) );
+        }
+
+        $params = $request->get_params();
+
+        if ( !empty( $params['value'] ) ){
+            $value = ( ( $params['condition'] == 'not_equal' ) ? '-' : '' ) . trim( $params['value'] );
+
+            return DT_Posts::list_posts( $params['post_type'], [
+                'assigned_to' => [ 'me' ],
+                'post_date' => [
+                    'start' => $params['ts_start'],
+                    'end' => $params['ts_end']
+                ],
+                'sort' => '-post_date',
+                $params['field'] => [ $value ]
+            ], false );
+
+        }
+
+        return [];
+    }
+
+    public function get_field_settings( $post_type ) {
+        $post_field_settings = DT_Posts::get_post_field_settings( $post_type );
+
+        $field_settings = [];
+
+        foreach ( $post_field_settings as $key => $setting ) {
+            if ( array_key_exists( 'hidden', $setting ) && $setting['hidden'] === true ) {
+                continue;
+            }
+            if ( in_array( $setting['type'], $this->post_field_types_filter ) ) {
+                $field_settings[$key] = $setting;
+            }
+        }
+        return $field_settings;
+    }
+
+    public function create_select_options_from_field_settings( $field_settings ) {
+        $select_options = [];
+        foreach ( $field_settings as $key => $setting ) {
+            $select_options[$key] = $setting['name'];
+        }
+        asort( $select_options );
+        return $select_options;
+    }
+
+}
+new DT_Metrics_Date_Range_Activity();

--- a/dt-metrics/combined/date-range-activity.php
+++ b/dt-metrics/combined/date-range-activity.php
@@ -234,7 +234,7 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
                         $values[] = $value['ID'];
                     }
                 }
-                $meta_value_sql = ( !empty( $values ) ? "AND meta_value IN (" . dt_array_to_sql( $values ) . ")" : "AND meta_value LIKE '%'" );
+                $meta_value_sql = ( !empty( $values ) ? 'AND meta_value IN (' . dt_array_to_sql( $values ) . ')' : "AND meta_value LIKE '%'" );
 
             } elseif ( $field_type == 'user_select' ){
                 $value = $params['value'];
@@ -279,7 +279,6 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
                             $new_value = $post['name'] ?? $new_value;
                         }
                     }
-
                 } elseif ( $field_type == 'location' ){
                     $geocoder = new Location_Grid_Geocoder();
                     $new_value = $geocoder->_format_full_name( [ 'grid_id' => $new_value ] );
@@ -291,7 +290,6 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
                             $new_value = $post['name'] ?? $new_value;
                         }
                     }
-
                 } elseif ( $field_type == 'date' ){
                     $new_value = ( $new_value != 'value_deleted' ) ? gmdate( 'F j, Y, g:i A', $new_value ) : '';
 

--- a/dt-metrics/combined/date-range-activity.php
+++ b/dt-metrics/combined/date-range-activity.php
@@ -226,6 +226,9 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
                 $meta_value_sql = "AND meta_value LIKE '" . ( empty( $params['value'] ) ? '%' : esc_sql( $params['value'] ) ) . "'";
 
             } elseif ( ( $field_type == 'connection' ) || ( $field_type == 'location' ) ){
+                if ( $field_type == 'connection' ){
+                    $field_type_sql = "AND field_type IN ('" . esc_sql( $field_type ) . "', 'connection to', 'connection from')";
+                }
                 $meta_key_sql = ( $field_type == 'connection' ) ? "AND meta_key LIKE '%'" : "AND meta_key LIKE '" . esc_sql( $params['field'] ) . "'";
 
                 $values = [];
@@ -235,7 +238,7 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
                     }
                 }
                 $meta_value_sql = ( !empty( $values ) ? 'AND meta_value IN (' . dt_array_to_sql( $values ) . ')' : "AND meta_value LIKE '%'" );
-                $obj_subtype_sql = ( $field_type == 'connection' ) ? "AND object_subtype = '" . esc_sql( $params['field'] ) . "'" : '';
+                $obj_subtype_sql = ( $field_type == 'connection' ) ? "AND object_subtype IN ('" . esc_sql( $params['field'] ) . "','p2p')" : '';
 
             } elseif ( $field_type == 'user_select' ){
                 $value = $params['value'];

--- a/dt-metrics/combined/date-range-activity.php
+++ b/dt-metrics/combined/date-range-activity.php
@@ -23,12 +23,15 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
         'key_select',
         'tags',
         'communication_channel',
+        'connection',
+        'user_select',
         'text',
         'textarea',
         'link',
         'date',
         'number',
-        'boolean'
+        'boolean',
+        'location'
     ];
 
     public function __construct() {
@@ -182,13 +185,22 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
                 $field_type_sql = "AND (field_type = '' OR field_type = '" . esc_sql( $field_type ) . "')";
                 $meta_key_sql = "AND meta_key LIKE '" . esc_sql( $params['field'] ) . "%'";
             }
+            if ( $field_type == 'connection' ){
+                $meta_key_sql = "AND meta_key LIKE '%'";
+            }
 
             // Execute sql query.
+            $supported_actions_sql = dt_array_to_sql( [
+                'field_update',
+                'connected to',
+                'disconnected from'
+            ] );
+
             global $wpdb;
             $results = $wpdb->get_results( $wpdb->prepare( "
             SELECT *
             FROM $wpdb->dt_activity_log
-            WHERE action = 'field_update'
+            WHERE action IN ( $supported_actions_sql )
             AND object_type = %s
             AND hist_time BETWEEN %d AND %d
             $field_type_sql

--- a/dt-metrics/combined/date-range-activity.php
+++ b/dt-metrics/combined/date-range-activity.php
@@ -213,7 +213,7 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
                 if ( $field_type == 'connection' ){
                     $field_type_sql = "AND field_type IN ('" . esc_sql( $field_type ) . "', 'connection to', 'connection from')";
                 }
-                $meta_key_sql = ( $field_type == 'connection' ) ? "AND meta_key LIKE '%'" : "AND meta_key LIKE '" . esc_sql( $params['field'] ) . "'";
+                $meta_key_sql = ( $field_type == 'connection' ) ? "AND meta_key LIKE '". esc_sql( !empty( $settings['p2p_key'] ) ? $settings['p2p_key'] : '%' ) ."'" : "AND meta_key LIKE '" . esc_sql( $params['field'] ) . "'";
 
                 $values = [];
                 foreach ( $params['value'] ?? [] as $value ){

--- a/dt-metrics/metrics.php
+++ b/dt-metrics/metrics.php
@@ -77,6 +77,7 @@ class Disciple_Tools_Metrics{
                     require_once( get_template_directory() . '/dt-metrics/combined/critical-path.php' );
                 }
                 require_once( get_template_directory() . '/dt-metrics/combined/time-charts.php' );
+                require_once( get_template_directory() . '/dt-metrics/combined/date-range-activity.php' );
             }, 1000);
 
             // default menu order


### PR DESCRIPTION
- fixes: #1538 
- fixes: #2080 
---

- New Activity During Date Range project metric introduced.
- Metric provides the ability to query post records by field and within a given date range.
- Ability to click-through to listed results post records for more detail.
- Added 2nd level filter support for typeahead based field types: `connection`, `location` & `user_select`.
- Display new value field was updated with.

![Screenshot 2023-05-30 at 16 45 31](https://github.com/DiscipleTools/disciple-tools-theme/assets/19330800/93c6fd0d-6736-4e34-9dcf-907fba8b60b7)

![Screenshot 2023-05-30 at 16 46 19](https://github.com/DiscipleTools/disciple-tools-theme/assets/19330800/7bad0c78-0c2a-405b-ba69-59f5f51bbf3f)

![Screenshot 2023-05-30 at 16 47 06](https://github.com/DiscipleTools/disciple-tools-theme/assets/19330800/0f877e14-f36b-4ca2-bf2c-55289bb6f597)
