### PR TITLE
Added non tiled fields to typeahead

### DIFF
--- a/dt-core/admin/admin-settings-endpoints.php
+++ b/dt-core/admin/admin-settings-endpoints.php
@@ -181,6 +181,7 @@ class Disciple_Tools_Admin_Settings_Endpoints {
                 'post_tile' => null,
                 'post_setting' => null,
             ];
+            $no_tile_elements = [];
 
             $post_tiles = DT_Posts::get_post_tiles( $post_type );
             foreach ( $post_tiles as $tile_key => $tile_value ) {
@@ -192,6 +193,7 @@ class Disciple_Tools_Admin_Settings_Endpoints {
                 ];
 
                 $post_settings = DT_Posts::get_post_settings( $post_type, false );
+
                 foreach ( $post_settings['fields'] as $setting_key => $setting_value ) {
                     if ( isset( $setting_value['tile'] ) && $setting_value['tile'] === $tile_key ) {
                         $output[] = [
@@ -201,6 +203,19 @@ class Disciple_Tools_Admin_Settings_Endpoints {
                             'post_setting' => $setting_key,
                         ];
                     }
+                    if ( !isset( $setting_value['tile'] ) || $setting_value['tile'] === 'no_tile' ) {
+                        if ( in_array( $post_label . ' > ' . $setting_value['name'], $no_tile_elements ) ) {
+                            continue;
+                        }
+                        $setting_value['label'] = '(No Tile)';
+                            $output[] = [
+                                'label' => $post_label . ' > ' . $setting_value['label'] . ' > ' . $setting_value['name'],
+                                'post_type' => $post_type,
+                                'post_tile' => 'no-tile-hidden',
+                                'post_setting' => $setting_key,
+                            ];
+                            $no_tile_elements[] = $post_label . ' > ' . $setting_value['name'];
+                     }
                 }
             }
         }

--- a/dt-core/admin/admin-settings-endpoints.php
+++ b/dt-core/admin/admin-settings-endpoints.php
@@ -215,7 +215,7 @@ class Disciple_Tools_Admin_Settings_Endpoints {
                                 'post_setting' => $setting_key,
                             ];
                             $no_tile_elements[] = $post_label . ' > ' . $setting_value['name'];
-                     }
+                    }
                 }
             }
         }

--- a/dt-core/admin/js/dt-settings.js
+++ b/dt-core/admin/js/dt-settings.js
@@ -1610,7 +1610,7 @@ jQuery(document).ready(function($) {
         cancelButton: false,
         dynamic: false,
         emptyTemplate: '<em style="padding-left:12px;">No results for "{{query}}"</em>',
-        template: '<a href="' + window.location.origin + window.location.pathname + '?page=dt_customizations&post_type={{post_type}}&tab=tiles&post_tile_key={{post_tile}}#{{post_setting}}">{{label}}</a>',
+        template: '<a href="' + window.location.origin + window.location.pathname + '?page=dt_customizations&post_type={{post_type}}&tab=tiles&tile={{post_tile}}#{{post_setting}}">{{label}}</a>',
         correlativeTemplate: true,
         source: {
             ajax: {


### PR DESCRIPTION
The typeahead now includes fields that don't have a tile associated to them.

![Screenshot 2023-05-18 at 12 18 27](https://github.com/DiscipleTools/disciple-tools-theme/assets/36511666/fc389949-d0c4-4c64-a11e-0fc2a89e9ff1)