### PR TITLE
Performance Optimization to `search_viewable_post` query

### DIFF
--- a/dt-posts/posts.php
+++ b/dt-posts/posts.php
@@ -1311,7 +1311,7 @@ class Disciple_Tools_Posts
             SELECT count(distinct p.ID)
             FROM $wpdb->posts p " . $fields_sql["joins_sql"] . " " . $joins . " WHERE " . $fields_sql["where_sql"] . " " . ( empty( $fields_sql["where_sql"] ) ? "" : " AND " ) . "
             (p.post_status = 'publish') AND p.post_type = '" . esc_sql ( $post_type ) . "' " .  $post_query . "
-        ", OBJECT );
+        " );
 
         if ( empty( $posts ) && !empty( $wpdb->last_error )){
             return new WP_Error( __FUNCTION__, "Sorry, we had a query issue.", [ 'status' => 500 ] );

--- a/dt-posts/posts.php
+++ b/dt-posts/posts.php
@@ -1312,14 +1312,11 @@ class Disciple_Tools_Posts
             FROM $wpdb->posts p " . $fields_sql["joins_sql"] . " " . $joins . " WHERE " . $fields_sql["where_sql"] . " " . ( empty( $fields_sql["where_sql"] ) ? "" : " AND " ) . "
             (p.post_status = 'publish') AND p.post_type = '" . esc_sql ( $post_type ) . "' " .  $post_query . "
         " );
+        // phpcs:enable
 
-        if ( empty( $posts ) && !empty( $wpdb->last_error )){
+        if ( empty( $posts ) && !empty( $wpdb->last_error ) ){
             return new WP_Error( __FUNCTION__, "Sorry, we had a query issue.", [ 'status' => 500 ] );
         }
-
-
-        // phpcs:enable
-        // $total_rows = $wpdb->get_var( 'SELECT found_rows();' );
 
         //search by post_id
         if ( is_numeric( $search ) ){

--- a/dt-posts/posts.php
+++ b/dt-posts/posts.php
@@ -1315,7 +1315,7 @@ class Disciple_Tools_Posts
         // phpcs:enable
 
         if ( empty( $posts ) && !empty( $wpdb->last_error ) ){
-            return new WP_Error( __FUNCTION__, "Sorry, we had a query issue.", [ 'status' => 500 ] );
+            return new WP_Error( __FUNCTION__, 'Sorry, we had a query issue.', [ 'status' => 500 ] );
         }
 
         //search by post_id


### PR DESCRIPTION
This will probably need some thorough testing from someone who understands the get list logic more than me.

In response to performance issues when looking at a very large data set, I found that the `SQL_CALC_FOUND_ROWS` is both more costly than a `count(distinct p.ID)` query and is also getting [deprecated as of MySQL 8.0.17](https://dev.mysql.com/doc/refman/8.0/en/information-functions.html#function_found-rows). The `GROUP BY` operation also is a bit expensive and doesn't seem to be necessary, at least if there are no joins happening (such as the default search without any filters).

Initial testing of this change in a very large dataset of about 1.2 million groups improves the response to about a quarter of its initial time.