### PR TITLE
fix: clear any WP login cookies before JWT login

### DIFF
--- a/dt-login/login-endpoints.php
+++ b/dt-login/login-endpoints.php
@@ -106,6 +106,9 @@ class DT_Login_Endpoints {
         }
 
         if ( DT_Login_Methods::MOBILE === $login_method ) {
+            /* Make sure that any WP login tokens are cleared before logging in with JWT */
+            wp_logout();
+
             require_once( get_template_directory() . '/dt-core/libraries/wp-api-jwt-auth/public/class-jwt-auth-public.php' );
             $response = Jwt_Auth_Public::validate_token( $request );
 

--- a/dt-login/login-user-manager.php
+++ b/dt-login/login-user-manager.php
@@ -132,7 +132,9 @@ class DT_Login_User_Manager {
      */
     private function mobile_login() {
         /* Force logout of any logged in admin user with WP cookies set */
-        wp_logout();
+        if ( is_user_logged_in() ) {
+            wp_logout();
+        }
 
         add_filter( 'authenticate', [ $this, 'allow_programmatic_login' ], 10, 3 );    // hook in earlier than other callbacks to short-circuit them
 


### PR DESCRIPTION
@corsacca 

In PG, there is an issue, where if a user logs in with the admin side which uses PHP, and then comes back to their logged in PG (with JWT token) then it has an issue and can't check the auth properly.

This might be a sledgehammer solution, and not sure if it will have any other repercussions (but I don't think it would)

But would essentially make sure, that if someone is logging in with JWT, that the WP side is logged out first.

This makes sure that the JWT check_auth function continues to work and doesn't lead to any unexpected behaviour where the check_auth doesn't return the user correctly.