### PR TITLE
fix: add firebase Displayname to user manager if not exists

### DIFF
--- a/dt-login/login-endpoints.php
+++ b/dt-login/login-endpoints.php
@@ -67,6 +67,10 @@ class DT_Login_Endpoints {
             return new WP_Error( 'bad_token', $th->getMessage(), [ 'status' => 401 ] );
         }
 
+        if ( !isset( $payload['name'] ) ) {
+            $payload['name'] = $body->user->displayName;
+        }
+
         $user_manager = new DT_Login_User_Manager( $payload );
 
         try {


### PR DESCRIPTION
fixes: user having UID as displayname when logging in with email through SSO login UI on Prayer.Global