### PR TITLE
Disable edit field private

### DIFF
--- a/dt-core/admin/admin-settings-endpoints.php
+++ b/dt-core/admin/admin-settings-endpoints.php
@@ -1126,12 +1126,6 @@ class Disciple_Tools_Admin_Settings_Endpoints {
                 $custom_field['default_name'] = self::get_default_field_name( $post_type, $field_key );
             }
 
-            // Field privacy
-            $custom_field['private'] = false;
-            if ( isset( $post_submission['field_private'] ) && $post_submission['field_private'] ) {
-                $custom_field['private'] = true;
-            }
-
             // Field tile
             if ( isset( $post_submission['tile_select'] ) ) {
                 $custom_field['tile'] = $post_submission['tile_select'];

--- a/dt-core/admin/js/dt-settings.js
+++ b/dt-core/admin/js/dt-settings.js
@@ -90,12 +90,11 @@ jQuery(document).ready(function($) {
         other_field_name: other_field_name,
     }, `dt-admin-settings/`);
 
-    window.API.edit_field = (post_type, tile_key, field_key, custom_name, field_private, tile_select, field_description, field_icon) => makeRequest("POST", `edit-field`, {
+    window.API.edit_field = (post_type, tile_key, field_key, custom_name, tile_select, field_description, field_icon) => makeRequest("POST", `edit-field`, {
         post_type: post_type,
         tile_key: tile_key,
         field_key: field_key,
         custom_name: custom_name,
-        field_private: field_private,
         tile_select: tile_select,
         field_description: field_description,
         field_icon: field_icon,
@@ -1061,7 +1060,7 @@ jQuery(document).ready(function($) {
                     <label for="edit-field-private"><b>Private Field</b></label>
                 </td>
                 <td>
-                    <input name="edit-field-private" id="edit-field-private" type="checkbox" ${private_field}>
+                    <input name="edit-field-private" id="edit-field-private" type="checkbox" ${private_field} disabled>
                 </td>
             </tr>
             <tr>
@@ -1655,7 +1654,6 @@ jQuery(document).ready(function($) {
         var tile_key = $(this).data('tile-key');
         var field_key = $(this).data('field-key');
         var custom_name = $('#edit-field-custom-name').val().trim();
-        var field_private = $('#edit-field-private').is(':checked');
         var tile_select = $('#tile_select').val().trim();
         var field_description = $('#edit-field-description').val().trim();
         var field_icon = $('#edit-field-icon').val().trim();
@@ -1665,7 +1663,7 @@ jQuery(document).ready(function($) {
             return false;
         }
 
-        API.edit_field(post_type, tile_key, field_key, custom_name, field_private, tile_select, field_description, field_icon).promise().then(function(result){
+        API.edit_field(post_type, tile_key, field_key, custom_name, tile_select, field_description, field_icon).promise().then(function(result){
             $.extend(window.field_settings.post_type_settings.fields[field_key], result);
 
             var edited_field_menu_element = $(`.sortable-field[data-key=${field_key}]`)

--- a/dt-core/admin/menu/tabs/tab-custom-fields.php
+++ b/dt-core/admin/menu/tabs/tab-custom-fields.php
@@ -634,10 +634,9 @@ class Disciple_Tools_Tab_Custom_Fields extends Disciple_Tools_Abstract_Menu_Base
                 <tr>
                     <th><?php esc_html_e( 'Private Field', 'disciple_tools' ) ?></th>
                     <td>
-                        <?php $private_field_disabled = isset( $defaults[$field_key] ) || $field['type'] === 'connection' ?>
                         <label>
-                            <input name="field_private" id="field_private" type="checkbox" <?php echo esc_html( ( isset( $field['private'] ) && $field['private'] ) ? 'checked' : '' );?> <?php echo esc_html( ( $private_field_disabled ) ? 'disabled' : '' ); ?>>
-                            Values for this field are only able to be seen by the user who entered them.
+                            <input name="field_private" id="field_private" type="checkbox" <?php echo esc_html( ( isset( $field['private'] ) && $field['private'] ) ? 'checked' : '' );?> disabled>
+                            Values for this field are only seen by the user who entered them.
                         </label>
                     </td>
                 </tr>
@@ -1160,12 +1159,6 @@ class Disciple_Tools_Tab_Custom_Fields extends Disciple_Tools_Abstract_Menu_Base
             }
             if ( isset( $post_submission['delete_custom_label'], $custom_field['name'] ) ){
                 unset( $custom_field['name'] );
-            }
-            //field privacy
-            if ( isset( $post_submission['field_private'] ) && $post_submission['field_private'] ) {
-                $custom_field['private'] = true;
-            } else if ( !isset( $post_submission['field_private'] ) || !$post_submission['field_private'] ) {
-                $custom_field['private'] = false;
             }
             //field hidden
             if ( isset( $post_submission['field_hidden'] ) && $post_submission['field_hidden'] ) {


### PR DESCRIPTION
Keeps admins from changing private fields to public and vice versa.
This causes issues because the data is stored diferrently.