### PR TITLE
fix: broken query to remove corresponds_to_user

### DIFF
--- a/dt-users/user-hooks-and-config.php
+++ b/dt-users/user-hooks-and-config.php
@@ -440,9 +440,9 @@ class DT_User_Hooks_And_Configuration {
         global $wpdb;
         $wpdb->get_results(
             $wpdb->prepare( "
-                DELETE FROM $wpdb->postmeta pm
+                DELETE FROM $wpdb->postmeta
                 WHERE meta_key = 'corresponds_to_user'
-                AND pm.meta_value = %d
+                AND meta_value = %d
             ", $user_id )
         );
     }
@@ -452,9 +452,9 @@ class DT_User_Hooks_And_Configuration {
         global $wpdb;
         $wpdb->get_results(
             $wpdb->prepare( "
-                DELETE FROM $wpdb->postmeta pm
+                DELETE FROM $wpdb->postmeta
                 WHERE meta_key = 'corresponds_to_user'
-                AND pm.meta_value = %d
+                AND meta_value = %d
             ", $user_id )
         );
 


### PR DESCRIPTION
I was looking into why the contact record wasn't being downgraded and saw this error in the debug.log

```
[05-Aug-2023 08:25:13 UTC] WordPress database error You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'pm
                WHERE meta_key = 'corresponds_to_user'
                AND pm' at line 1 for query 
                DELETE FROM wp_postmeta pm
                WHERE meta_key = 'corresponds_to_user'
                AND pm.meta_value = 32161
             made by wpmu_delete_user, do_action('wpmu_delete_user'), WP_Hook->do_action, WP_Hook->apply_filters, DT_User_Hooks_And_Configuration::dt_multisite_delete_user_contact_meta, DT_User_Hooks_And_Configuration::dt_delete_user_from_blog
```
This doesn't stop the contact record being of the type user, but did mean that the corresponds_to_user meta wasn't being deleted.