### PR TITLE
Feat/option to hide login page nav

### DIFF
--- a/dt-assets/js/shared-functions.js
+++ b/dt-assets/js/shared-functions.js
@@ -575,11 +575,17 @@ window.SHAREDFUNCTIONS = {
     }
     return "";
   },
-  setCookie(cname, cvalue, exdays = 30 ) {
-    var d = new Date();
-    d.setTime(d.getTime() + (exdays * 24 * 60 * 60 * 1000));
-    var expires = "expires="+d.toUTCString();
-    document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+  setCookie(cname, cvalue, path, exdays ) {
+    let cookie = `${cname}=${cvalue};`
+    if ( Number.isInteger( exdays ) && exdays > 0 ) {
+      var d = new Date();
+      d.setTime(d.getTime() + (exdays * 24 * 60 * 60 * 1000));
+      cookie += "expires="+d.toUTCString()+";";
+    }
+    if (path) {
+      cookie += "path=" + path + ";"
+    }
+    document.cookie = cookie
   },
   get_json_cookie(cname, default_val = []) {
     let cookie = this.getCookie(cname);
@@ -588,12 +594,12 @@ window.SHAREDFUNCTIONS = {
     } catch (e) {}
     return default_val;
   },
-  save_json_cookie(cname, json, path = "") {
+  save_json_cookie(cname, json, path = "", exdays) {
     if (path) {
       path = window.location.pathname.split(path)[0] + path;
       path = path.replace(/^\/?([^\/]+(?:\/[^\/]+)*)\/?$/, "/$1"); // add leading and remove trailing slashes
     }
-    document.cookie = `${cname}=${JSON.stringify(json)};path=${path}`;
+    this.setCookie(cname, JSON.stringify(json), path, exdays)
   },
   get_json_from_local_storage(key, default_val = {}, path) {
     if ( path ){

--- a/dt-assets/js/shared-functions.js
+++ b/dt-assets/js/shared-functions.js
@@ -575,6 +575,12 @@ window.SHAREDFUNCTIONS = {
     }
     return "";
   },
+  setCookie(cname, cvalue, exdays = 30 ) {
+    var d = new Date();
+    d.setTime(d.getTime() + (exdays * 24 * 60 * 60 * 1000));
+    var expires = "expires="+d.toUTCString();
+    document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+  },
   get_json_cookie(cname, default_val = []) {
     let cookie = this.getCookie(cname);
     try {

--- a/dt-assets/js/shared-functions.js
+++ b/dt-assets/js/shared-functions.js
@@ -583,7 +583,9 @@ window.SHAREDFUNCTIONS = {
       cookie += "expires="+d.toUTCString()+";";
     }
     if (path) {
-      cookie += "path=" + path + ";"
+      let newPath = window.location.pathname.split(path)[0] + path;
+      newPath = newPath.replace(/^\/?([^\/]+(?:\/[^\/]+)*)\/?$/, "/$1"); // add leading and remove trailing slashes
+      cookie += "path=" + newPath + ";"
     }
     document.cookie = cookie
   },
@@ -595,10 +597,6 @@ window.SHAREDFUNCTIONS = {
     return default_val;
   },
   save_json_cookie(cname, json, path = "", exdays) {
-    if (path) {
-      path = window.location.pathname.split(path)[0] + path;
-      path = path.replace(/^\/?([^\/]+(?:\/[^\/]+)*)\/?$/, "/$1"); // add leading and remove trailing slashes
-    }
     this.setCookie(cname, JSON.stringify(json), path, exdays)
   },
   get_json_from_local_storage(key, default_val = {}, path) {

--- a/dt-assets/js/shared-functions.js
+++ b/dt-assets/js/shared-functions.js
@@ -575,7 +575,7 @@ window.SHAREDFUNCTIONS = {
     }
     return "";
   },
-  setCookie(cname, cvalue, path, exdays ) {
+  setCookie(cname, cvalue, path = '', exdays = 0 ) {
     let cookie = `${cname}=${cvalue};`
     if ( Number.isInteger( exdays ) && exdays > 0 ) {
       var d = new Date();
@@ -596,7 +596,7 @@ window.SHAREDFUNCTIONS = {
     } catch (e) {}
     return default_val;
   },
-  save_json_cookie(cname, json, path = "", exdays) {
+  save_json_cookie(cname, json, path = '', exdays = 0) {
     this.setCookie(cname, JSON.stringify(json), path, exdays)
   },
   get_json_from_local_storage(key, default_val = {}, path) {

--- a/dt-core/utilities/dt-query-params.php
+++ b/dt-core/utilities/dt-query-params.php
@@ -61,7 +61,7 @@ class DT_Query_Params {
      *
      * @return array
      */
-    public function toArray() {
+    public function to_array() {
         return $this->query_params ? $this->query_params : [];
     }
 }

--- a/dt-core/utilities/dt-query-params.php
+++ b/dt-core/utilities/dt-query-params.php
@@ -7,6 +7,22 @@ class DT_Query_Params {
         parse_str( $query_params, $this->query_params );
     }
 
+    /**
+     * Add a query param to the list of params clobbering any previous instance of
+     *
+     * @param string $name
+     * @param string $value
+     */
+    public function append( $name, $value ) : void {
+        $this->query_params[$name] = $value;
+    }
+
+    /**
+     * Get a query param by name
+     *
+     * @param string $name
+     * @return string|null
+     */
     public function get( string $name ) {
 
         foreach ( $this->query_params as $key => $value ) {
@@ -16,5 +32,36 @@ class DT_Query_Params {
         }
 
         return null;
+    }
+
+    /**
+     * Check if a query param exists
+     *
+     * @param string $name
+     * @return bool
+     */
+    public function has( string $name ) {
+        return key_exists( $name, $this->query_params );
+    }
+
+    /**
+     * Removes a query param from the array
+     *
+     * @param string $name
+     */
+    public function delete( string $name ) {
+
+        if ( $this->has( $name ) ) {
+            unset( $this->query_params[ $name ] );
+        }
+    }
+
+    /**
+     * Get the query params as an array
+     *
+     * @return array
+     */
+    public function toArray() {
+        return $this->query_params ? $this->query_params : [];
     }
 }

--- a/dt-login/login-functions.php
+++ b/dt-login/login-functions.php
@@ -107,7 +107,7 @@ function dt_login_url( string $name, string $url = '' ): string {
         $query_params->append( 'redirect_to', rawurlencode( $redirect_url ) );
     }
 
-    $params = $query_params->toArray();
+    $params = $query_params->to_array();
 
     $login_page_enabled = $dt_login['login_enabled'] === 'on';
 

--- a/dt-login/login-functions.php
+++ b/dt-login/login-functions.php
@@ -70,16 +70,30 @@ function dt_login_redirect_login_page() {
 }
 // END LOGIN PAGE REDIRECT
 
+/**
+ * This function is used to create urls for the different wp login actions
+ * In order for the current query params for the current page to propogate to any login action links in the page
+ * the query params are extracted from the current url
+ */
 function dt_login_url( string $name, string $url = '' ): string {
     $dt_login = DT_Login_Fields::all_values();
+
     if ( empty( $url ) ){
         $url = dt_get_url_path();
     }
 
     $dt_url = new DT_URL( $url );
-    $query_redirect_url = $dt_url->query_params->get( 'redirect_to' );
+    $query_params = $dt_url->query_params;
 
-    $login_url = $dt_login['login_url'] ?? '';
+    if ( $query_params->has( 'action' ) ) {
+        $query_params->delete( 'action' );
+    }
+
+    if ( $query_params->has( 'redirect_to' ) ) {
+        $query_redirect_url = $query_params->get( 'redirect_to' );
+        $query_params->delete( 'redirect_to' );
+    }
+
     $redirect_url = empty( $query_redirect_url ) ? site_url( $dt_login['redirect_url'] ) ?? '' : $query_redirect_url;
 
     /**
@@ -89,7 +103,15 @@ function dt_login_url( string $name, string $url = '' ): string {
      */
     $redirect_url = apply_filters( 'dt_login_redirect_url', $redirect_url );
 
+    if ( !empty( $redirect_url ) ) {
+        $query_params->append( 'redirect_to', rawurlencode( $redirect_url ) );
+    }
+
+    $params = $query_params->toArray();
+
     $login_page_enabled = $dt_login['login_enabled'] === 'on';
+
+    $login_url = $dt_login['login_url'] ?? '';
 
     if ( !$login_page_enabled ) {
         $login_url = 'wp-login.php';
@@ -102,14 +124,12 @@ function dt_login_url( string $name, string $url = '' ): string {
      */
     $login_url = apply_filters( 'dt_login_url', $login_url );
 
-    $redirect_params = empty( $redirect_url ) ? [] : [ 'redirect_to' => rawurlencode( $redirect_url ) ];
-
     switch ( $name ) {
         case 'home':
             $home_url = apply_filters( 'dt_login_url', '' );
             return dt_create_site_url( $home_url );
         case 'login':
-            return dt_create_site_url( $login_url, $redirect_params );
+            return dt_create_site_url( $login_url, $params );
         case 'redirect':
         case 'success':
             return $redirect_url;
@@ -119,9 +139,9 @@ function dt_login_url( string $name, string $url = '' ): string {
             if ( !dt_can_users_register() ) {
                 return dt_login_url( 'login', $url );
             }
-            return dt_create_site_url( $login_url, [ 'action' => 'register' ] );
+            return dt_create_site_url( $login_url, [ 'action' => 'register', ...$params ] );
         case 'lostpassword':
-            return dt_create_site_url( $login_url, [ 'action' => 'lostpassword' ] );
+            return dt_create_site_url( $login_url, [ 'action' => 'lostpassword', ...$params ] );
         case 'resetpass':
             return dt_create_site_url( $login_url, [ 'action' => 'resetpass' ] );
         case 'expiredkey':

--- a/dt-login/login-page.php
+++ b/dt-login/login-page.php
@@ -45,7 +45,13 @@ class Disciple_Tools_Login_Base extends DT_Login_Page_Base
 
     public function body(){
 
-        do_action( 'dt_login_login_page_header' );
+        $url = new DT_URL( dt_get_url_path() );
+        $hide_nav = $url->query_params->has( 'hide-nav' );
+        $show_nav = !$hide_nav;
+
+        if ( $show_nav === true ) {
+            do_action( 'dt_login_login_page_header' );
+        }
 
         require_once( get_template_directory() . '/dt-login/login-template.php' );
     }

--- a/dt-login/login-template.php
+++ b/dt-login/login-template.php
@@ -574,65 +574,48 @@ function dt_login_form_links() {
         <div class="cell medium-3 large-4"></div>
         <div class="cell medium-6 large-4">
             <p>
-            <?php if ( ! isset( $_GET['checkemail'] ) || ! in_array( wp_unslash( $_GET['checkemail'] ), array( 'confirm', 'newpass' ) ) ) : ?>
+            <?php if ( ! isset( $_GET['checkemail'] ) || ! in_array( wp_unslash( $_GET['checkemail'] ), array( 'confirm', 'newpass' ) ) ) :
 
+                $dt_url = dt_get_url_path();
+                $query_params = ( new DT_URL( $dt_url ) )->query_params;
+                $action = $query_params->get( 'action' );
+                $to_display = [];
+                if ( !$query_params->has( 'hide-nav' ) ) {
+                    $to_display[] = [
+                        'url' => dt_login_url( 'home' ),
+                        'text' => __( 'Home', 'disciple_tools' ),
+                    ];
+                }
 
-                <?php
-                    $dt_url = dt_get_url_path();
-                    $query_params = ( new DT_URL( $dt_url ) )->query_params;
-                    $action = $query_params->get( 'action' );
-                ?>
-
-                <?php $show_break = false; ?>
-                <?php if ( !$query_params->has( 'hide-nav' ) ) : ?>
-
-                    <?php $show_break = true; ?>
-
-                    <a href="<?php echo esc_url( dt_login_url( 'home' ) ) ?>"><?php esc_html_e( 'Home', 'disciple_tools' ) ?></a>
-
-                <?php endif; ?>
-
-                <?php
                 // login link
                 if ( in_array( $action, [ 'register', 'lostpassword' ] ) ) {
-                    ?>
-
-                    <?php if ( $show_break ): ?>
-
-                        &nbsp;|&nbsp;
-
-                    <?php endif; ?>
-
-                    <a href="<?php echo esc_url( dt_login_url( 'login' ) ) ?>"><?php esc_html_e( 'Login', 'disciple_tools' ) ?></a>
-
-                    <?php
+                    $to_display[] = [
+                        'url' => dt_login_url( 'login' ),
+                        'text' => __( 'Login', 'disciple_tools' ),
+                    ];
                 }
 
                 // registration link
                 if ( dt_can_users_register() && empty( $action ) ) {
-                    ?>
-
-                    <?php if ( $show_break ): ?>
-
-                        &nbsp;|&nbsp;
-
-                    <?php endif; ?>
-
-                    <a href="<?php echo esc_url( dt_login_url( 'register' ) ) ?>"><?php esc_html_e( 'Register', 'disciple_tools' ) ?></a>
-
-                    <?php
+                    $to_display[] = [
+                        'url' => dt_login_url( 'register' ),
+                        'text' => __( 'Register', 'disciple_tools' ),
+                    ];
                 }
 
-                if ( $action !== 'lostpassword' ) {
-                    ?>
-
-                  |&nbsp;
-
-                    <a href="<?php echo esc_url( dt_login_url( 'lostpassword' ) ); ?>"><?php esc_html_e( 'Lost your password?', 'disciple_tools' ); ?></a>
-                    <?php
+                if ( $action !== 'lostpassword' ){
+                    $to_display[] = [
+                        'url' => dt_login_url( 'lostpassword' ),
+                        'text' => __( 'Lost Password', 'disciple_tools' ),
+                    ];
                 }
-                ?>
-            <?php endif; ?>
+                foreach ( $to_display as $link ) {
+                    echo '<a href="' . esc_url( $link['url'] ) . '">' . esc_html( $link['text'] ) . '</a>';
+                    if ( $link !== end( $to_display ) ) {
+                        echo ' | ';
+                    }
+                }
+            endif; ?>
             </p>
         </div>
         <div class="cell medium-3 large-4"></div>

--- a/dt-login/login-template.php
+++ b/dt-login/login-template.php
@@ -576,33 +576,62 @@ function dt_login_form_links() {
             <p>
             <?php if ( ! isset( $_GET['checkemail'] ) || ! in_array( wp_unslash( $_GET['checkemail'] ), array( 'confirm', 'newpass' ) ) ) : ?>
 
-                 <a href="<?php echo esc_url( dt_login_url( 'home' ) ) ?>"><?php esc_html_e( 'Home', 'disciple_tools' ) ?></a>
+
+                <?php
+                    $dt_url = dt_get_url_path();
+                    $query_params = ( new DT_URL( $dt_url ) )->query_params;
+                    $action = $query_params->get( 'action' );
+                ?>
+
+                <?php $show_break = false; ?>
+                <?php if ( !$query_params->has( 'hide-nav' ) ) : ?>
+
+                    <?php $show_break = true; ?>
+
+                    <a href="<?php echo esc_url( dt_login_url( 'home' ) ) ?>"><?php esc_html_e( 'Home', 'disciple_tools' ) ?></a>
+
+                <?php endif; ?>
+
+                <?php
+                // login link
+                if ( in_array( $action, [ 'register', 'lostpassword' ] ) ) {
+                    ?>
+
+                    <?php if ( $show_break ): ?>
+
+                        &nbsp;|&nbsp;
+
+                    <?php endif; ?>
+
+                    <a href="<?php echo esc_url( dt_login_url( 'login' ) ) ?>"><?php esc_html_e( 'Login', 'disciple_tools' ) ?></a>
 
                     <?php
-                    // login link
-                    $dt_url = dt_get_url_path();
-                    if ( $dt_login['login_url'] !== $dt_url ) {
-                        ?>
-                       &nbsp;|&nbsp;
-                       <a href="<?php echo esc_url( dt_login_url( 'login' ) ) ?>"><?php esc_html_e( 'Login', 'disciple_tools' ) ?></a>
-                        <?php
-                    }
+                }
 
-                    // registration link
-                    if ( dt_can_users_register() && strpos( $dt_url, '?action=register' ) === false ) {
-                        ?>
-                       &nbsp;|&nbsp;
-                       <a href="<?php echo esc_url( dt_login_url( 'register' ) ) ?>"><?php esc_html_e( 'Register', 'disciple_tools' ) ?></a>
-                        <?php
-                    }
-
-                    if ( strpos( $dt_url, '?action=lostpassword' ) === false ) {
-                        ?>
-                      |&nbsp;
-                    <a href="<?php echo esc_url( dt_login_url( 'lostpassword' ) ); ?>"><?php esc_html_e( 'Lost your password?', 'disciple_tools' ); ?></a>
-                        <?php
-                    }
+                // registration link
+                if ( dt_can_users_register() && empty( $action ) ) {
                     ?>
+
+                    <?php if ( $show_break ): ?>
+
+                        &nbsp;|&nbsp;
+
+                    <?php endif; ?>
+
+                    <a href="<?php echo esc_url( dt_login_url( 'register' ) ) ?>"><?php esc_html_e( 'Register', 'disciple_tools' ) ?></a>
+
+                    <?php
+                }
+
+                if ( $action !== 'lostpassword' ) {
+                    ?>
+
+                  |&nbsp;
+
+                    <a href="<?php echo esc_url( dt_login_url( 'lostpassword' ) ); ?>"><?php esc_html_e( 'Lost your password?', 'disciple_tools' ); ?></a>
+                    <?php
+                }
+                ?>
             <?php endif; ?>
             </p>
         </div>


### PR DESCRIPTION
@corsacca 

The missing piece for me not understanding Chris's desire for the login page to be within the login magic link, was the ability to control the login page so that there are no other links anywhere else but to do the login/registration and then be redirected back to the magic link.

ergo restricting the user's flow so that they don't get distracted by any navbar/footer links etc.

I've added the necessary code to hide the nav bar when the hide-nav query param is in the url on the custom login page.

setCookie shared js function was a piece I needed for the language switching in zume, but forgot to create a PR for so I've just rolled it into here.