### PR TITLE
Firebase Login: style background to match normal login

### DIFF
--- a/dt-login/login-page.php
+++ b/dt-login/login-page.php
@@ -48,7 +48,6 @@ class Disciple_Tools_Login_Base extends DT_Login_Page_Base
         ?>
         <style>
             body { background: #f0f0f1; }
-            #login > .grid-x > .callout h1 { display: none; }
             .login-remember { float: left; }
             .login-submit { float: right; }
             #firebaseui-auth-container { clear: both; }

--- a/dt-login/login-page.php
+++ b/dt-login/login-page.php
@@ -51,6 +51,7 @@ class Disciple_Tools_Login_Base extends DT_Login_Page_Base
             #login > .grid-x > .callout h1 { display: none; }
             .login-remember { float: left; }
             .login-submit { float: right; }
+            #firebaseui-auth-container { clear: both; }
         </style>
         <?php
     }

--- a/dt-login/login-page.php
+++ b/dt-login/login-page.php
@@ -43,6 +43,18 @@ class Disciple_Tools_Login_Base extends DT_Login_Page_Base
 
     }
 
+    public function header_style(){
+        // parent::header_style();
+        ?>
+        <style>
+            body { background: #f0f0f1; }
+            #login > .grid-x > .callout h1 { display: none; }
+            .login-remember { float: left; }
+            .login-submit { float: right; }
+        </style>
+        <?php
+    }
+
     public function body(){
 
         $url = new DT_URL( dt_get_url_path() );

--- a/dt-login/login-shortcodes.php
+++ b/dt-login/login-shortcodes.php
@@ -193,8 +193,8 @@ function dt_firebase_login_ui( $atts ) {
         // Will use popup for IDP Providers sign-in flow instead of the default, redirect.
         signInFlow: 'popup',
         signInOptions: signInOptions,
-        tosUrl: '/content_app/tos',
-        privacyPolicyUrl: '/content_app/privacy'
+        tosUrl: '/terms-of-service',
+        privacyPolicyUrl: '/privacy-policy'
       }
 
       if ( !config.api_key || !config.project_id || !config.app_id  ) {

--- a/dt-login/login-template.php
+++ b/dt-login/login-template.php
@@ -580,7 +580,7 @@ function dt_login_form_links() {
                 $query_params = ( new DT_URL( $dt_url ) )->query_params;
                 $action = $query_params->get( 'action' );
                 $to_display = [];
-                if ( !$query_params->has( 'hide-nav' ) ) {
+                if ( !$query_params->has( 'hide-nav' ) && !empty( $action ) ) {
                     $to_display[] = [
                         'url' => dt_login_url( 'home' ),
                         'text' => __( 'Home', 'disciple_tools' ),

--- a/dt-login/login-template.php
+++ b/dt-login/login-template.php
@@ -580,7 +580,7 @@ function dt_login_form_links() {
                 $query_params = ( new DT_URL( $dt_url ) )->query_params;
                 $action = $query_params->get( 'action' );
                 $to_display = [];
-                if ( !$query_params->has( 'hide-nav' ) && !empty( $action ) ) {
+                if ( !$query_params->has( 'hide-nav' ) ) {
                     $to_display[] = [
                         'url' => dt_login_url( 'home' ),
                         'text' => __( 'Home', 'disciple_tools' ),


### PR DESCRIPTION
- Change background to same gray as standard WP login
- Remove H1 heading that doesn't exist on standard WP login
- Remove "Home" link at bottom of login (login page is the home page if you're not logged in)
- Align "Remember Me" and "Login" button on same line, like standard WP login
- Update URLs sent to Firebase for TOS and Privacy Policy