### PR TITLE
#2292 - View to see scheduled jobs

### DIFF
--- a/dt-core/admin/js/dt-utilities-scripts.js
+++ b/dt-core/admin/js/dt-utilities-scripts.js
@@ -55,6 +55,15 @@ jQuery(document).ready(function ($) {
     })
   })
 
+  $('.process-jobs-button').on('click', function() {
+    make_admin_request("GET", 'process_jobs').then(status => {
+        $(`#process-jobs-loading-spinner .loading-spinner`).addClass( "active" )
+        if (status.success === true) {
+            $('.process-jobs-result-text').html('Done!')
+            $(`#process-jobs-loading-spinner .loading-spinner`).removeClass( "active" )
+        }
+    })
+})
   /**
    * FILE UPLOADS
    */

--- a/dt-core/admin/js/dt-utilities-scripts.js
+++ b/dt-core/admin/js/dt-utilities-scripts.js
@@ -56,8 +56,8 @@ jQuery(document).ready(function ($) {
   })
 
   $('.process-jobs-button').on('click', function() {
+    $(`#process-jobs-loading-spinner .loading-spinner`).addClass( "active" )
     make_admin_request("GET", 'process_jobs').then(status => {
-        $(`#process-jobs-loading-spinner .loading-spinner`).addClass( "active" )
         if (status.success === true) {
             $('.process-jobs-result-text').html('Done!')
             $(`#process-jobs-loading-spinner .loading-spinner`).removeClass( "active" )

--- a/dt-core/admin/menu/tabs/admin-endpoints.php
+++ b/dt-core/admin/menu/tabs/admin-endpoints.php
@@ -34,6 +34,16 @@ class DT_Admin_Endpoints {
                 },
             ]
         );
+
+        register_rest_route(
+            $this->namespace, '/scripts/process_jobs', [
+                'methods'  => 'GET',
+                'callback' => [ $this, 'process_jobs' ],
+                'permission_callback' => function(){
+                    return current_user_can( 'manage_dt' );
+                },
+            ]
+        );
     }
 
     public function reset_count_field( WP_REST_Request $request ){
@@ -145,6 +155,14 @@ class DT_Admin_Endpoints {
         } else {
             return new WP_Error( __FILE__, 'Missing required parameters.' );
         }
+    }
+
+    public function process_jobs( WP_REST_Request $request ){
+        //no apparent way for wp_queue to report an issue
+        wp_queue()->cron()->cron_worker();
+        return [
+            'success' => (bool) true
+        ];
     }
 
 }

--- a/dt-core/admin/menu/tabs/tab-background-jobs.php
+++ b/dt-core/admin/menu/tabs/tab-background-jobs.php
@@ -1,0 +1,182 @@
+<?php
+
+if ( !defined( 'ABSPATH' ) ){
+    exit; // Exit if accessed directly
+}
+
+/**
+ * Class Disciple_Tools_Tab_Logs
+ */
+class Disciple_Tools_Tab_Background_Jobs extends Disciple_Tools_Abstract_Menu_Base{
+    private static $_instance = null;
+
+    public static function instance(){
+        if ( is_null( self::$_instance ) ){
+            self::$_instance = new self();
+        }
+
+        return self::$_instance;
+    } // End instance()
+
+    /**
+     * Constructor function.
+     *
+     * @access  public
+     * @since   0.1.0
+     */
+    public function __construct(){
+        add_action( 'admin_menu', [ $this, 'add_submenu' ], 125 );
+        add_action( 'dt_utilities_tab_menu', [ $this, 'add_tab' ], 125, 1 );
+        add_action( 'dt_utilities_tab_content', [ $this, 'content' ], 125, 1 );
+
+        parent::__construct();
+    } // End __construct()
+
+    public function add_submenu(){
+        add_submenu_page( 'edit.php?post_type=background_jobs', __( 'Background Jobs', 'disciple_tools' ), __( 'Background Jobs', 'disciple_tools' ), 'manage_dt', 'dt_utilities&tab=background_jobs', [
+            'Disciple_Tools_Settings_Menu',
+            'content'
+        ] );
+        add_submenu_page( 'dt_utilities', __( 'Background Jobs', 'disciple_tools' ), __( 'Background Jobs', 'disciple_tools' ), 'manage_dt', 'dt_utilities&tab=background_jobs', [
+            'Disciple_Tools_Settings_Menu',
+            'content'
+        ] );
+    }
+
+    public function add_tab( $tab ){
+        echo '<a href="' . esc_url( admin_url() ) . 'admin.php?page=dt_utilities&tab=background_jobs" class="nav-tab ';
+        if ( $tab == 'background_jobs' ){
+            echo 'nav-tab-active';
+        }
+        echo '">' . esc_attr__( 'Background Jobs' ) . '</a>';
+    }
+
+    public function content( $tab ){
+        if ( 'background_jobs' == $tab ) :
+
+            $this->template( 'begin' );
+
+            $this->process_settings();
+            $this->display_job_total();
+            $this->display_settings();
+            $this->display_jobs();
+
+            $this->template( 'right_column' );
+
+            $this->template( 'end' );
+
+        endif;
+    }
+
+    private function process_settings(){
+        if ( isset( $_POST['background_jobs_nonce'] ) && wp_verify_nonce( sanitize_key( wp_unslash( $_POST['background_jobs_nonce'] ) ), 'background_jobs_nonce' ) ){
+            update_option( 'dt_background_jobs_enabled', isset( $_POST['background_jobs_enabled'] ) ? 1 : 0 );
+            update_option( 'dt_background_jobs_display_count', isset( $_POST['background_jobs_display_count'] ) ? intval( $_POST['background_jobs_display_count'] ) : 20 );
+        }
+    }
+
+    private function fetch_display_count(): int{
+        $display_count_option = get_option( 'dt_background_jobs_display_count' );
+        return ( $display_count_option > 0 ) ? intval( $display_count_option ) : 20;
+    }
+
+    private function display_settings(){
+
+        $this->box( 'top', 'Logging Settings', [ 'col_span' => 4 ] );
+
+        ?>
+        <form method="POST">
+            <input type="hidden" name="background_jobs_nonce" id="background_jobs_nonce"
+                   value="<?php echo esc_attr( wp_create_nonce( 'background_jobs_nonce' ) ) ?>"/>
+            <table class="widefat striped">
+                <tr>
+                    <td align="right">
+                        <input type="number" id="background_jobs_display_count"
+                               name="background_jobs_display_count"
+                               value="<?php echo esc_html( $this->fetch_display_count() ) ?>"/>
+                    </td>
+                    <td>Number Of Background Jobs To Be Displayed</td>
+                </tr>
+            </table>
+            <br>
+            <span style="float:right;"><button type="submit"
+                                               class="button float-right"><?php esc_html_e( 'Update', 'disciple_tools' ) ?></button></span>
+        </form>
+        <?php
+
+        $this->box( 'bottom' );
+    }
+
+
+    private function background_job_queue_counts() {
+        global $wpdb;
+
+        wp_queue_wpdb_init();
+
+        return [
+            'jobs' => $wpdb->get_var( "SELECT COUNT(id) FROM $wpdb->queue_jobs" ),
+            'failures' => $wpdb->get_var( "SELECT COUNT(id) FROM $wpdb->queue_failures" )
+        ];
+    }
+
+    private function display_job_total() {
+                $background_job_counts = $this->background_job_queue_counts();
+                echo esc_html( sprintf( 'Background Jobs Queue: Jobs: %1$s, Failures: %2$s', $background_job_counts['jobs'], $background_job_counts['failures'] ) );
+    }
+
+    private function display_jobs(){
+        global $wpdb;
+
+        // Obtain list of recent error logs
+        $jobs = $wpdb->get_results( $wpdb->prepare( "
+SELECT que.job AS job_details, que.category, que.attempts, que.priority, que.available_at
+FROM $wpdb->queue_jobs que
+ORDER BY que.available_at
+DESC LIMIT %d", $this->fetch_display_count() ) );
+
+        $this->box( 'top', 'Background Jobs', [ 'col_span' => 4 ] );
+
+        ?>
+        <table class="widefat striped">
+            <tr>
+                <th>Name</th>
+                <th>Category</th>
+                <th>Subject</th>
+                <th>Attempts</th>
+                <th>Available At</th>
+            </tr>
+        <?php
+        if ( !empty( $jobs ) ){
+            foreach ( $jobs as $job ){
+                //Find the job name
+                preg_match( ':"(.*?)":', $job->job_details, $job_name );
+
+                echo '<tr>';
+                echo '<td>' . esc_attr( $job_name[1] ) . '</td>';
+                echo '<td>' . esc_attr( $job->category ) . '</td>';
+                echo '<td>' . esc_attr( $job->attempts ) . '</td>';
+                echo '<td>' . esc_attr( $job->priority ) . '</td>';
+                echo '<td>' . esc_attr( gmdate( 'Y-m-d h:i:sa', strtotime( esc_attr( $job->available_at ) ) ) ) . '</td>';
+                echo '</tr>';
+            }
+        }
+        echo '</table>';
+        $this->box( 'bottom' );
+    }
+
+    private function format_object_name( $obj_name ): string{
+        if ( is_array( $obj_name ) ){
+            $key_value = array();
+
+            foreach ( array_keys( $obj_name ) as $key ){
+                $key_value[] = $this->format_object_name( $obj_name[$key] );
+            }
+
+            return implode( ', ', $key_value );
+        }
+
+        return $obj_name ?? '';
+    }
+}
+
+Disciple_Tools_Tab_Background_Jobs::instance();

--- a/dt-core/admin/menu/tabs/tab-background-jobs.php
+++ b/dt-core/admin/menu/tabs/tab-background-jobs.php
@@ -124,7 +124,7 @@ class Disciple_Tools_Tab_Background_Jobs extends Disciple_Tools_Abstract_Menu_Ba
     private function display_job_queue_cron_schedule() {
         $wp_queue_cron_schedule = wp_get_schedules();
         if ( array_key_exists( 'wp_queue_connections_databaseconnection', $wp_queue_cron_schedule ) ) {
-            echo esc_html( $wp_queue_cron_schedule['wp_queue_connections_databaseconnection']['display'] . ' the queue is processed' );
+            echo esc_html( 'The queue is scheduled to be processed: ' . $wp_queue_cron_schedule['wp_queue_connections_databaseconnection']['display'] );
         } else {
             echo esc_html( 'wp_queue has not setup a CRON.' );
         }

--- a/dt-core/admin/menu/tabs/tab-background-jobs.php
+++ b/dt-core/admin/menu/tabs/tab-background-jobs.php
@@ -106,6 +106,7 @@ class Disciple_Tools_Tab_Background_Jobs extends Disciple_Tools_Abstract_Menu_Ba
         <span style="display: inline-block" class="process-jobs-result-text"></span>
         <?php
 
+        $this->display_job_queue_cron_schedule();
         $this->box( 'bottom' );
     }
 
@@ -116,14 +117,22 @@ class Disciple_Tools_Tab_Background_Jobs extends Disciple_Tools_Abstract_Menu_Ba
         wp_queue_wpdb_init();
 
         return [
-            'jobs' => $wpdb->get_var( "SELECT COUNT(id) FROM $wpdb->queue_jobs" ),
-            'failures' => $wpdb->get_var( "SELECT COUNT(id) FROM $wpdb->queue_failures" )
+            'jobs' => $wpdb->get_var( "SELECT COUNT(id) FROM $wpdb->queue_jobs" )
         ];
+    }
+
+    private function display_job_queue_cron_schedule() {
+        $wp_queue_cron_schedule = wp_get_schedules();
+        if ( array_key_exists( 'wp_queue_connections_databaseconnection', $wp_queue_cron_schedule ) ) {
+            echo esc_html( $wp_queue_cron_schedule['wp_queue_connections_databaseconnection']['display'] . ' the queue is processed' );
+        } else {
+            echo esc_html( 'wp_queue has not setup a CRON.' );
+        }
     }
 
     private function display_job_total() {
         $background_job_counts = $this->background_job_queue_counts();
-        echo esc_html( sprintf( 'Background Jobs Queue: Jobs: %1$s, Failures: %2$s', $background_job_counts['jobs'], $background_job_counts['failures'] ) );
+        echo esc_html( sprintf( 'Background Jobs Queued: %1$s', $background_job_counts['jobs'] ) );
     }
 
     private function display_jobs() {

--- a/dt-core/admin/menu/tabs/tab-background-jobs.php
+++ b/dt-core/admin/menu/tabs/tab-background-jobs.php
@@ -1,17 +1,18 @@
 <?php
 
-if ( !defined( 'ABSPATH' ) ){
+if ( !defined( 'ABSPATH' ) ) {
     exit; // Exit if accessed directly
 }
 
 /**
  * Class Disciple_Tools_Tab_Logs
  */
-class Disciple_Tools_Tab_Background_Jobs extends Disciple_Tools_Abstract_Menu_Base{
+class Disciple_Tools_Tab_Background_Jobs extends Disciple_Tools_Abstract_Menu_Base
+{
     private static $_instance = null;
 
-    public static function instance(){
-        if ( is_null( self::$_instance ) ){
+    public static function instance() {
+        if ( is_null( self::$_instance ) ) {
             self::$_instance = new self();
         }
 
@@ -24,34 +25,35 @@ class Disciple_Tools_Tab_Background_Jobs extends Disciple_Tools_Abstract_Menu_Ba
      * @access  public
      * @since   0.1.0
      */
-    public function __construct(){
+    public function __construct() {
         add_action( 'admin_menu', [ $this, 'add_submenu' ], 125 );
         add_action( 'dt_utilities_tab_menu', [ $this, 'add_tab' ], 125, 1 );
         add_action( 'dt_utilities_tab_content', [ $this, 'content' ], 125, 1 );
+        add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
 
         parent::__construct();
     } // End __construct()
 
-    public function add_submenu(){
-        add_submenu_page( 'edit.php?post_type=background_jobs', __( 'Background Jobs', 'disciple_tools' ), __( 'Background Jobs', 'disciple_tools' ), 'manage_dt', 'dt_utilities&tab=background_jobs', [
+    public function add_submenu() {
+        add_submenu_page('edit.php?post_type=background_jobs', __( 'Background Jobs', 'disciple_tools' ), __( 'Background Jobs', 'disciple_tools' ), 'manage_dt', 'dt_utilities&tab=background_jobs', [
             'Disciple_Tools_Settings_Menu',
             'content'
-        ] );
-        add_submenu_page( 'dt_utilities', __( 'Background Jobs', 'disciple_tools' ), __( 'Background Jobs', 'disciple_tools' ), 'manage_dt', 'dt_utilities&tab=background_jobs', [
+        ]);
+        add_submenu_page('dt_utilities', __( 'Background Jobs', 'disciple_tools' ), __( 'Background Jobs', 'disciple_tools' ), 'manage_dt', 'dt_utilities&tab=background_jobs', [
             'Disciple_Tools_Settings_Menu',
             'content'
-        ] );
+        ]);
     }
 
-    public function add_tab( $tab ){
+    public function add_tab( $tab ) {
         echo '<a href="' . esc_url( admin_url() ) . 'admin.php?page=dt_utilities&tab=background_jobs" class="nav-tab ';
-        if ( $tab == 'background_jobs' ){
+        if ( $tab == 'background_jobs' ) {
             echo 'nav-tab-active';
         }
         echo '">' . esc_attr__( 'Background Jobs' ) . '</a>';
     }
 
-    public function content( $tab ){
+    public function content( $tab ) {
         if ( 'background_jobs' == $tab ) :
 
             $this->template( 'begin' );
@@ -68,40 +70,40 @@ class Disciple_Tools_Tab_Background_Jobs extends Disciple_Tools_Abstract_Menu_Ba
         endif;
     }
 
-    private function process_settings(){
-        if ( isset( $_POST['background_jobs_nonce'] ) && wp_verify_nonce( sanitize_key( wp_unslash( $_POST['background_jobs_nonce'] ) ), 'background_jobs_nonce' ) ){
+    private function process_settings() {
+        if ( isset( $_POST['background_jobs_nonce'] ) && wp_verify_nonce( sanitize_key( wp_unslash( $_POST['background_jobs_nonce'] ) ), 'background_jobs_nonce' ) ) {
             update_option( 'dt_background_jobs_enabled', isset( $_POST['background_jobs_enabled'] ) ? 1 : 0 );
             update_option( 'dt_background_jobs_display_count', isset( $_POST['background_jobs_display_count'] ) ? intval( $_POST['background_jobs_display_count'] ) : 20 );
         }
     }
 
-    private function fetch_display_count(): int{
+    private function fetch_display_count(): int
+    {
         $display_count_option = get_option( 'dt_background_jobs_display_count' );
         return ( $display_count_option > 0 ) ? intval( $display_count_option ) : 20;
     }
 
-    private function display_settings(){
+    private function display_settings() {
 
         $this->box( 'top', 'Logging Settings', [ 'col_span' => 4 ] );
 
         ?>
         <form method="POST">
-            <input type="hidden" name="background_jobs_nonce" id="background_jobs_nonce"
-                   value="<?php echo esc_attr( wp_create_nonce( 'background_jobs_nonce' ) ) ?>"/>
+            <input type="hidden" name="background_jobs_nonce" id="background_jobs_nonce" value="<?php echo esc_attr( wp_create_nonce( 'background_jobs_nonce' ) ) ?>" />
             <table class="widefat striped">
                 <tr>
                     <td align="right">
-                        <input type="number" id="background_jobs_display_count"
-                               name="background_jobs_display_count"
-                               value="<?php echo esc_html( $this->fetch_display_count() ) ?>"/>
+                        <input type="number" id="background_jobs_display_count" name="background_jobs_display_count" value="<?php echo esc_html( $this->fetch_display_count() ) ?>" />
                     </td>
                     <td>Number Of Background Jobs To Be Displayed</td>
                 </tr>
             </table>
             <br>
-            <span style="float:right;"><button type="submit"
-                                               class="button float-right"><?php esc_html_e( 'Update', 'disciple_tools' ) ?></button></span>
+            <span style="float:right;"><button type="submit" class="button float-right"><?php esc_html_e( 'Update', 'disciple_tools' ) ?></button></span>
         </form>
+        <button type="button" class="process-jobs-button" id="process-jobs-button">Process Jobs</button>
+        <span id="process-jobs-loading-spinner" style="display: inline-block" class="loading-spinner"></span>
+        <span style="display: inline-block" class="process-jobs-result-text"></span>
         <?php
 
         $this->box( 'bottom' );
@@ -120,19 +122,19 @@ class Disciple_Tools_Tab_Background_Jobs extends Disciple_Tools_Abstract_Menu_Ba
     }
 
     private function display_job_total() {
-                $background_job_counts = $this->background_job_queue_counts();
-                echo esc_html( sprintf( 'Background Jobs Queue: Jobs: %1$s, Failures: %2$s', $background_job_counts['jobs'], $background_job_counts['failures'] ) );
+        $background_job_counts = $this->background_job_queue_counts();
+        echo esc_html( sprintf( 'Background Jobs Queue: Jobs: %1$s, Failures: %2$s', $background_job_counts['jobs'], $background_job_counts['failures'] ) );
     }
 
-    private function display_jobs(){
+    private function display_jobs() {
         global $wpdb;
 
         // Obtain list of recent error logs
-        $jobs = $wpdb->get_results( $wpdb->prepare( "
-SELECT que.job AS job_details, que.category, que.attempts, que.priority, que.available_at
+        $jobs = $wpdb->get_results($wpdb->prepare("
+SELECT que.job AS job_details, que.category, que.attempts, que.priority, que.available_at, que.created_at
 FROM $wpdb->queue_jobs que
-ORDER BY que.available_at
-DESC LIMIT %d", $this->fetch_display_count() ) );
+ORDER BY que.created_at
+DESC LIMIT %d", $this->fetch_display_count()));
 
         $this->box( 'top', 'Background Jobs', [ 'col_span' => 4 ] );
 
@@ -141,14 +143,15 @@ DESC LIMIT %d", $this->fetch_display_count() ) );
             <tr>
                 <th>Name</th>
                 <th>Category</th>
-                <th>Subject</th>
                 <th>Attempts</th>
-                <th>Available At</th>
+                <th>Priority</th>
+                <th>Processing Time</th>
+                <th>Created Time</th>
             </tr>
         <?php
-        if ( !empty( $jobs ) ){
-            foreach ( $jobs as $job ){
-                //Find the job name
+        if ( !empty( $jobs ) ) {
+            foreach ( $jobs as $job ) {
+                //Find the job name from the serialized job
                 preg_match( ':"(.*?)":', $job->job_details, $job_name );
 
                 echo '<tr>';
@@ -157,6 +160,7 @@ DESC LIMIT %d", $this->fetch_display_count() ) );
                 echo '<td>' . esc_attr( $job->attempts ) . '</td>';
                 echo '<td>' . esc_attr( $job->priority ) . '</td>';
                 echo '<td>' . esc_attr( gmdate( 'Y-m-d h:i:sa', strtotime( esc_attr( $job->available_at ) ) ) ) . '</td>';
+                echo '<td>' . esc_attr( gmdate( 'Y-m-d h:i:sa', strtotime( esc_attr( $job->created_at ) ) ) ) . '</td>';
                 echo '</tr>';
             }
         }
@@ -164,18 +168,14 @@ DESC LIMIT %d", $this->fetch_display_count() ) );
         $this->box( 'bottom' );
     }
 
-    private function format_object_name( $obj_name ): string{
-        if ( is_array( $obj_name ) ){
-            $key_value = array();
 
-            foreach ( array_keys( $obj_name ) as $key ){
-                $key_value[] = $this->format_object_name( $obj_name[$key] );
-            }
+    public function admin_enqueue_scripts() {
 
-            return implode( ', ', $key_value );
-        }
+        wp_enqueue_script( 'dt_utilities_scripts_script', disciple_tools()->admin_js_url . 'dt-utilities-scripts.js', [
+            'jquery',
+            'wp-color-picker'
+        ], filemtime( disciple_tools()->admin_js_path . 'dt-utilities-scripts.js' ), true );
 
-        return $obj_name ?? '';
     }
 }
 

--- a/functions.php
+++ b/functions.php
@@ -453,6 +453,7 @@ if ( version_compare( phpversion(), '7.4', '<' ) ) {
                 require_once( 'dt-core/admin/menu/tabs/tab-scripts.php' );
 
                 require_once( 'dt-core/admin/menu/tabs/tab-gdpr.php' );
+                require_once( 'dt-core/admin/menu/tabs/tab-background-jobs.php' );
                 require_once( 'dt-core/admin/menu/tabs/tab-email-logs.php' );
                 require_once( 'dt-core/admin/menu/tabs/tab-error-logs.php' );
                 require_once( 'dt-core/admin/menu/tabs/tab-workflows.php' );


### PR DESCRIPTION
@corsacca Here is my first pass at #2292 for seeing scheduled jobs.

- [x] Show the overall count
- [x] Show job names
- [x] Show job attempts 
- [x] Don't show the job contents
- [x] Button to trigger processing the jobs

Extra
- [x] Show cron schedule to user
Next to the button that triggers processing jobs I added some text to indicate the wp_queue cron schedule timing. You can test this by adjusting the interval default here:  
https://github.com/DiscipleTools/disciple-tools-theme/blob/f397541a1871d7d7d5c3864eed00d45d913126c6/dt-core/libraries/wp-queue/WP_Queue/class-queue.php#L62
I tried to add a "countdown" for when the cron schedule would trigger the next processing but [wp_next_scheduled](https://developer.wordpress.org/reference/functions/wp_next_scheduled/) didn't appear to give me accurate info and I didn't know where else to turn.

I wasn't positive where to place the JS to trigger the make_admin_request so I guessed. Feel free to let me know it needs to be located somewhere else.