### PR TITLE
Allow emails to have html links in notifications

### DIFF
--- a/dt-notifications/notifications-email.php
+++ b/dt-notifications/notifications-email.php
@@ -57,7 +57,7 @@ function dt_send_email( $email, $subject, $message_plain_text, bool $subject_pre
     $email = sanitize_email( $email );
     $subject = sanitize_text_field( $subject );
 
-    $message_plain_text = sanitize_textarea_field( $message_plain_text );
+    $message_plain_text = wp_kses_post( $message_plain_text );
 
     if ( $subject_prefix ) {
         $subject = dt_get_option( 'dt_email_base_subject' ) . ': ' . $subject;

--- a/dt-notifications/notifications.php
+++ b/dt-notifications/notifications.php
@@ -905,7 +905,7 @@ class Disciple_Tools_Notifications
         if ( $html ){
             $link = '<a href="' . home_url( '/' ) . get_post_type( $object_id ) . '/' . $object_id . '">' . $post_title . '</a>';
         } else {
-            $link = $post_title;
+            $link = home_url( '/' ) . get_post_type( $object_id );
         }
         if ( $notification['notification_name'] === 'created' ) {
             $notification_note = sprintf( esc_html_x( '%s was created and assigned to you.', '%s was created and assigned to you.', 'disciple_tools' ), $link );
@@ -960,7 +960,7 @@ class Disciple_Tools_Notifications
             $user_who_declined = get_userdata( $notification['source_user_id'] );
             $notification_note = sprintf( esc_html_x( '%1$s declined assignment on: %2$s.', 'User1 declined assignment on: contact1', 'disciple_tools' ), $user_who_declined->display_name, $link );
         } else {
-            $notification_note = apply_filters( 'dt_custom_notification_note', '', $notification );
+            $notification_note = apply_filters( 'dt_custom_notification_note', '', $notification, $html, $condensed );
         }
         return $notification_note;
     }


### PR DESCRIPTION
Displays 
![image](https://github.com/DiscipleTools/disciple-tools-theme/assets/24901539/1f92ffbb-0315-49fa-a7b5-4d5f2fc85760)

Instead of
![image](https://github.com/DiscipleTools/disciple-tools-theme/assets/24901539/1f6e39c6-565f-4ba8-9905-4d4952b24eb4)
