### PR TITLE
Add microsoft as sso option to login multisite

### DIFF
--- a/dt-login/login-fields.php
+++ b/dt-login/login-fields.php
@@ -484,6 +484,19 @@ class DT_Login_Fields {
                 ],
                 'multisite_level' => true,
             ],
+            'identity_providers_microsoft' => [
+                'tab' => 'identity_providers',
+                'key' => 'identity_providers_microsoft',
+                'label' => 'Microsoft',
+                'description' => '',
+                'value' => 'off',
+                'type' => 'select',
+                'default' => [
+                    'on' => 'on',
+                    'off' => 'off',
+                ],
+                'multisite_level' => true,
+            ],
 
             // captcha
             'google_captcha' => [

--- a/dt-login/login-shortcodes.php
+++ b/dt-login/login-shortcodes.php
@@ -46,6 +46,7 @@ function dt_firebase_login_ui( $atts ) {
     $sign_in_options['email'] = DT_Login_Fields::get( 'identity_providers_email' ) === 'on' ? true : false;
     $sign_in_options['github'] = DT_Login_Fields::get( 'identity_providers_github' ) === 'on' ? true : false;
     $sign_in_options['twitter'] = DT_Login_Fields::get( 'identity_providers_twitter' ) === 'on' ? true : false;
+    $sign_in_options['microsoft'] = DT_Login_Fields::get( 'identity_providers_microsoft' ) === 'on' ? true : false; // Add this line for Microsoft
 
     $config['sign_in_options'] = $sign_in_options;
 
@@ -59,8 +60,8 @@ function dt_firebase_login_ui( $atts ) {
 
         const signInOptions = []
 
-        const { google, facebook, email, github, twitter } = config.sign_in_options
-        const hasASignInProvider = google || facebook || email || github || twitter
+        const { google, facebook, email, github, twitter, microsoft} = config.sign_in_options
+        const hasASignInProvider = google || facebook || email || github || twitter || microsoft
 
         if (google) {
             signInOptions.push(firebase.auth.GoogleAuthProvider.PROVIDER_ID)
@@ -81,6 +82,9 @@ function dt_firebase_login_ui( $atts ) {
         }
         if (twitter) {
             signInOptions.push(firebase.auth.TwitterAuthProvider.PROVIDER_ID)
+        }
+        if (microsoft) {
+          signInOptions.push('microsoft.com');
         }
 
         const firebaseConfig = {


### PR DESCRIPTION
We have added a option to show Microsoft as a login option to WP-admin when the custom login option is enabled from the admin.