### PR TITLE
feat: add filter to override dt_custom_dir_attr

### DIFF
--- a/dt-core/configuration/dt-configuration.php
+++ b/dt-core/configuration/dt-configuration.php
@@ -73,6 +73,17 @@ function dt_is_locale_rtl( $locale = null ){
 }
 
 function dt_custom_dir_attr( $lang ){
+    /**
+     * If true overrides this filter and returns $lang
+     *
+     * @since 1.57
+     *
+     * @param bool       $override Whether to override dt_custom_dir_attr or not
+     */
+    if ( apply_filters( 'dt_custom_dir_attr_override', false ) ) {
+        return $lang;
+    }
+
     if ( is_admin() ) {
         return $lang;
     }


### PR DESCRIPTION
Where a porch is using it's own language switching method, this allows that porch to prevent the html attrs from being switched to match the WP user locale