### PR TITLE
Set up prettier linting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[*.js]
+[{*.js,*.cjs}]
 indent_style = space
 indent_size = 2
 

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,7 +8,10 @@ module.exports = {
     "ecmaVersion": 2017, // enables parsing async functions correctly
     "requireConfigFile": false
   },
-  "extends": "eslint:recommended",
+  "extends": [
+      "eslint:recommended",
+      "prettier"
+  ],
   "globals": {
     "jQuery": false,
   },
@@ -28,5 +31,15 @@ module.exports = {
     ]
   },
   "parser": "@babel/eslint-parser",
-  ignorePatterns: [ 'dt-core/admin/multi-role/*' ]
+  ignorePatterns: [
+    'dt-assets/js/modernizr-custom.js',
+    'dt-core/admin/multi-role/js/min/',
+    'dt-core/admin/multi-role/*',
+    'dt-core/dependencies/',
+    'dt-core/libraries/',
+    'gulpfile.js',
+    'node_modules',
+    'vendor',
+    '*.min.js',
+  ]
 };

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,18 @@
+# Ignore artifacts:
+dt-assets/js/modernizr-custom.js
+dt-core/admin/multi-role/js/min/
+dt-core/dependencies/
+dt-core/libraries/
+gulpfile.js
+node_modules
+vendor
+*.min.js
+
+*.cjs
+*.css
+*.scss
+*.json
+*.md
+*.html
+*.yml
+*.webmanifest

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/dt-assets/js/activity-log.js
+++ b/dt-assets/js/activity-log.js
@@ -1,34 +1,42 @@
-jQuery(function() {
+jQuery(function () {
   function makeActivityList(userActivity, translations) {
-    const sortedActivities = groupActivityByDayAndRecord(userActivity)
+    const sortedActivities = groupActivityByDayAndRecord(userActivity);
 
     let activityHtml = ``;
     Object.entries(sortedActivities).forEach(([date, daysActivities]) => {
-      const dayTitle = `<h4 class="day-activities__title">${date}</h4>`
-      const daysActivitiesHtml = makeDaysActivitiesHtml(daysActivities, translations)
+      const dayTitle = `<h4 class="day-activities__title">${date}</h4>`;
+      const daysActivitiesHtml = makeDaysActivitiesHtml(
+        daysActivities,
+        translations,
+      );
       activityHtml += `
       <div class="day-activities">
         ${dayTitle}
         ${daysActivitiesHtml}
       </div>
-      `
-    })
+      `;
+    });
 
-    return activityHtml
+    return activityHtml;
   }
 
   function makeDaysActivitiesHtml(daysActivities, translations) {
-    let daysActivitiesHtml = ''
+    let daysActivitiesHtml = '';
 
-    const { template_dir } = window.wpApiShare
+    const { template_dir } = window.wpApiShare;
 
     Object.entries(daysActivities).forEach(([postTitle, postActivities]) => {
-      const firstPostActivity = postActivities[0]
-      const icon = window.SHAREDFUNCTIONS.escapeHTML(firstPostActivity.icon)
-      if (!firstPostActivity.post_type_label) return
-      const requiresTitle = ['field_update', 'created', 'comment'].includes(firstPostActivity.action)
-      const iconHtml = firstPostActivity.icon ? `<i class="${icon} medium post-activities__icon"></i> ` : window.SHAREDFUNCTIONS.escapeHTML(firstPostActivity.post_type_label) + ':'
-      const forID = `activity_${firstPostActivity.hist_time}_${firstPostActivity.object_name}`
+      const firstPostActivity = postActivities[0];
+      const icon = window.SHAREDFUNCTIONS.escapeHTML(firstPostActivity.icon);
+      if (!firstPostActivity.post_type_label) return;
+      const requiresTitle = ['field_update', 'created', 'comment'].includes(
+        firstPostActivity.action,
+      );
+      const iconHtml = firstPostActivity.icon
+        ? `<i class="${icon} medium post-activities__icon"></i> `
+        : window.SHAREDFUNCTIONS.escapeHTML(firstPostActivity.post_type_label) +
+          ':';
+      const forID = `activity_${firstPostActivity.hist_time}_${firstPostActivity.object_name}`;
       const activitiesTitle = requiresTitle
         ? `
         <input type="checkbox" class="activity__more-state" id="${forID}" />
@@ -41,135 +49,160 @@ jQuery(function() {
             <img src="${template_dir}/dt-assets/images/chevron_down.svg"/>
           </label>
         </h5>`
-        : ''
+        : '';
 
-      const groupedActivitiesHtml = makeGroupedActivitiesHtml(postActivities, translations, requiresTitle)
+      const groupedActivitiesHtml = makeGroupedActivitiesHtml(
+        postActivities,
+        translations,
+        requiresTitle,
+      );
 
       daysActivitiesHtml += `
       <div class="post-activities">
         ${activitiesTitle}
         ${groupedActivitiesHtml}
-      </div>`
-    })
+      </div>`;
+    });
 
-    return daysActivitiesHtml
+    return daysActivitiesHtml;
   }
 
-  function makeGroupedActivitiesHtml(postActivities, translations, requiresTitle) {
-    const moreLabel = window.SHAREDFUNCTIONS.escapeHTML(translations.more)
-    const lessLabel = window.SHAREDFUNCTIONS.escapeHTML(translations.less)
+  function makeGroupedActivitiesHtml(
+    postActivities,
+    translations,
+    requiresTitle,
+  ) {
+    const moreLabel = window.SHAREDFUNCTIONS.escapeHTML(translations.more);
+    const lessLabel = window.SHAREDFUNCTIONS.escapeHTML(translations.less);
 
-    let groupedActivitiesHtml = ''
+    let groupedActivitiesHtml = '';
 
-    const groupedActivities = groupActivityTypes(postActivities)
+    const groupedActivities = groupActivityTypes(postActivities);
 
     Object.entries(groupedActivities).forEach(([action, activities]) => {
-      const { fields, object_note_short, object_note, object_notes, count, hist_time } = activities
+      const {
+        fields,
+        object_note_short,
+        object_note,
+        object_notes,
+        count,
+        hist_time,
+      } = activities;
 
-      let note = ''
+      let note = '';
 
       if (action === 'field_update') {
-        const escapedFields = fields.map((field) => window.SHAREDFUNCTIONS.escapeHTML(field))
-        if (fields.length === 0) return
-        const hasMoreFields = fields.slice(2).length > 0
+        const escapedFields = fields.map((field) =>
+          window.SHAREDFUNCTIONS.escapeHTML(field),
+        );
+        if (fields.length === 0) return;
+        const hasMoreFields = fields.slice(2).length > 0;
 
         if (hasMoreFields) {
-          const forID = `fields_${hist_time}${activities.object_id}`
+          const forID = `fields_${hist_time}${activities.object_id}`;
           note = `
               <input type="checkbox" class="fields__more-state" id="${forID}" />
               ${window.SHAREDFUNCTIONS.escapeHTML(object_note_short)}: ${escapedFields.slice(0, 2).join(', ')}<span class="fields__more-details">, ${escapedFields.slice(2).join(', ')}</span>
               <label for="${forID}" class="fields__more-link">+&nbsp;${fields.slice(2).length}&nbsp;${moreLabel}</label>
               <label for="${forID}" class="fields__less-link">-&nbsp;${lessLabel}</label>
-            `
+            `;
         } else {
-          note = `${window.SHAREDFUNCTIONS.escapeHTML(object_note_short)}: ${escapedFields.join(', ')}`
+          note = `${window.SHAREDFUNCTIONS.escapeHTML(object_note_short)}: ${escapedFields.join(', ')}`;
         }
       } else {
         note = object_note_short
-          ? window.SHAREDFUNCTIONS.escapeHTML(object_note_short.replace('%n', count))
-          : window.SHAREDFUNCTIONS.escapeHTML(object_note)
+          ? window.SHAREDFUNCTIONS.escapeHTML(
+              object_note_short.replace('%n', count),
+            )
+          : window.SHAREDFUNCTIONS.escapeHTML(object_note);
       }
-      let activityDetails = ''
+      let activityDetails = '';
       let dateRegex = /\{(\d+)\}+/;
       object_notes.forEach((objectNote) => {
-        let newObjectNote = `${window.SHAREDFUNCTIONS.escapeHTML(objectNote)}`
+        let newObjectNote = `${window.SHAREDFUNCTIONS.escapeHTML(objectNote)}`;
         if (dateRegex.test(objectNote)) {
           newObjectNote = objectNote.replace(dateRegex, timestamptoDate);
         }
         if (action === 'comment') {
-          newObjectNote = window.SHAREDFUNCTIONS.formatComment(newObjectNote)
+          newObjectNote = window.SHAREDFUNCTIONS.formatComment(newObjectNote);
         }
-        activityDetails += `<li>${newObjectNote}</li>`
-      })
+        activityDetails += `<li>${newObjectNote}</li>`;
+      });
 
       groupedActivitiesHtml += `
       <div class="post-activities__item${requiresTitle ? '' : '--no-title'}">
         ${note}
-        ${(activityDetails !== '') ? `
+        ${
+          activityDetails !== ''
+            ? `
           <ul class="activity__more-details">
             ${activityDetails}
           </ul>
-        ` : ''}
-      </div>`
-
-    })
-    return groupedActivitiesHtml
+        `
+            : ''
+        }
+      </div>`;
+    });
+    return groupedActivitiesHtml;
   }
 
   function groupActivityByDayAndRecord(data) {
-    const sortedByDayAndRecord = []
-    let currentDay = ''
-    let daysActivity = {}
-    data.forEach(activity => {
+    const sortedByDayAndRecord = [];
+    let currentDay = '';
+    let daysActivity = {};
+    data.forEach((activity) => {
       // data is already in date order, so we can go day by day
-      const date = window.moment.unix(activity.hist_time).format('YYYY-MM-DD')
+      const date = window.moment.unix(activity.hist_time).format('YYYY-MM-DD');
       if (date !== currentDay) {
-        currentDay = date
-        daysActivity = {}
-        sortedByDayAndRecord[currentDay] = daysActivity
+        currentDay = date;
+        daysActivity = {};
+        sortedByDayAndRecord[currentDay] = daysActivity;
       }
       if (!daysActivity[activity.object_name]) {
-        daysActivity[activity.object_name] = []
+        daysActivity[activity.object_name] = [];
       }
-      daysActivity[activity.object_name].push(activity)
+      daysActivity[activity.object_name].push(activity);
     });
 
-    return sortedByDayAndRecord
+    return sortedByDayAndRecord;
   }
 
   function groupActivityTypes(postActivities) {
-    const groupedActivities = {}
+    const groupedActivities = {};
 
     postActivities.forEach((activity) => {
-      const action = activity.action
+      const action = activity.action;
       if (!groupedActivities[action]) {
         groupedActivities[action] = {
           count: 0,
           ...activity,
           fields: [],
           object_notes: [],
-        }
-        delete groupedActivities[action].field
+        };
+        delete groupedActivities[action].field;
       }
-      groupedActivities[action].count += 1
+      groupedActivities[action].count += 1;
       if (activity.field) {
-        groupedActivities[action].fields.push(activity.field)
+        groupedActivities[action].fields.push(activity.field);
       } else {
-        groupedActivities[action].fields.push(activity.meta_key)
+        groupedActivities[action].fields.push(activity.meta_key);
       }
       // e.g. If the name has been set the object_note = '0'
-      if (activity.object_note && !groupedActivities[action].object_notes.includes(activity.object_note)) {
-        groupedActivities[action].object_notes.push(activity.object_note)
+      if (
+        activity.object_note &&
+        !groupedActivities[action].object_notes.includes(activity.object_note)
+      ) {
+        groupedActivities[action].object_notes.push(activity.object_note);
       }
-    })
-    return groupedActivities
+    });
+    return groupedActivities;
   }
 
   function timestamptoDate(match, timestamp) {
-    return window.SHAREDFUNCTIONS.formatDate(timestamp)
+    return window.SHAREDFUNCTIONS.formatDate(timestamp);
   }
 
   window.dtActivityLogs = {
     makeActivityList,
-  }
-})
+  };
+});

--- a/dt-assets/js/advanced-search.js
+++ b/dt-assets/js/advanced-search.js
@@ -1,123 +1,182 @@
 jQuery(document).ready(function ($) {
-
   let timer = null;
-  let rest_api = window.API
+  let rest_api = window.API;
   let template_dir_uri = window.advanced_search_settings.template_dir_uri;
   let fetch_more_text = window.advanced_search_settings.fetch_more_text;
 
   // Open the advanced search modal
-  $(document).on("click", '.advanced-search-nav-button', function () {
+  $(document).on('click', '.advanced-search-nav-button', function () {
     reset_widgets();
     $('#advanced-search-modal').foundation('open');
     $('#advanced-search-modal-form-query').focus();
-  })
+  });
 
   // Process search queries
-  $(document).on("keyup", '.advanced-search-modal-form-input', function (e) {
+  $(document).on('keyup', '.advanced-search-modal-form-input', function (e) {
     clearTimeout(timer);
-    if ( $(this).val().length >= 3 ){
+    if ($(this).val().length >= 3) {
       timer = setTimeout(execute_search_query, 500);
     }
-  })
-  $(document).on("keypress", '.advanced-search-modal-form-input', function (e) {
+  });
+  $(document).on('keypress', '.advanced-search-modal-form-input', function (e) {
     if (e.which === 13) {
       e.preventDefault();
       execute_search_query();
     }
-  })
-  $(document).on("click", '.advanced-search-modal-form-button', function () {
+  });
+  $(document).on('click', '.advanced-search-modal-form-button', function () {
     execute_search_query();
-  })
+  });
 
-  $(document).on("click", '.advanced-search-modal-results-table-row-clickable', function (e) {
-    let post_type = e.currentTarget.querySelector("#advanced-search-modal-results-table-row-hidden-post-type").getAttribute("value");
-    let post_id = e.currentTarget.querySelector("#advanced-search-modal-results-table-row-hidden-post-id").getAttribute("value");
-    display_record(post_type, post_id);
-  })
+  $(document).on(
+    'click',
+    '.advanced-search-modal-results-table-row-clickable',
+    function (e) {
+      let post_type = e.currentTarget
+        .querySelector(
+          '#advanced-search-modal-results-table-row-hidden-post-type',
+        )
+        .getAttribute('value');
+      let post_id = e.currentTarget
+        .querySelector(
+          '#advanced-search-modal-results-table-row-hidden-post-id',
+        )
+        .getAttribute('value');
+      display_record(post_type, post_id);
+    },
+  );
 
-  $(document).on("click", '.advanced-search-modal-post-types', function (e) {
+  $(document).on('click', '.advanced-search-modal-post-types', function (e) {
     execute_search_query();
-  })
+  });
 
-  $(document).on("click", '.advanced-search-modal-results-table-row-section-head-load-more', function (e) {
-    execute_search_query_by_offset(e, $(this));
-  })
+  $(document).on(
+    'click',
+    '.advanced-search-modal-results-table-row-section-head-load-more',
+    function (e) {
+      execute_search_query_by_offset(e, $(this));
+    },
+  );
 
   // Mobile view - Toggle searchable post types display
-  $(document).on("click", '.advanced-search-modal-results-post-types-view-at-top-collapsible-button', function () {
-    let collapsible_button = $('.advanced-search-modal-results-post-types-view-at-top-collapsible-button');
-    let collapsible_content = $('.advanced-search-modal-results-post-types-view-at-top-collapsible-content');
+  $(document).on(
+    'click',
+    '.advanced-search-modal-results-post-types-view-at-top-collapsible-button',
+    function () {
+      let collapsible_button = $(
+        '.advanced-search-modal-results-post-types-view-at-top-collapsible-button',
+      );
+      let collapsible_content = $(
+        '.advanced-search-modal-results-post-types-view-at-top-collapsible-content',
+      );
 
-    collapsible_content.slideToggle('fast', function () {
-      let img = window.SHAREDFUNCTIONS.escapeHTML(template_dir_uri) + '/dt-assets/images/';
-      img += collapsible_content.is(':visible') ? 'chevron_up.svg' : 'chevron_down.svg';
+      collapsible_content.slideToggle('fast', function () {
+        let img =
+          window.SHAREDFUNCTIONS.escapeHTML(template_dir_uri) +
+          '/dt-assets/images/';
+        img += collapsible_content.is(':visible')
+          ? 'chevron_up.svg'
+          : 'chevron_down.svg';
 
-      collapsible_button.find('img').attr('src', img);
-    });
-  })
+        collapsible_button.find('img').attr('src', img);
+      });
+    },
+  );
 
-  $(document).on("click", '.advanced-search-modal-filters', function (e) {
+  $(document).on('click', '.advanced-search-modal-filters', function (e) {
     execute_search_query();
-  })
+  });
 
   function determine_orientation() {
-    return $('.advanced-search-modal-results-post-types-view-at-top-collapsible-button').is(':visible') ? 'top' : 'side';
+    return $(
+      '.advanced-search-modal-results-post-types-view-at-top-collapsible-button',
+    ).is(':visible')
+      ? 'top'
+      : 'side';
   }
 
   function fetch_filters() {
     // Source filters based on current visibility orientation
     let location = determine_orientation();
     return {
-      post: $('#advanced-search-modal-filters-posts-' + location).prop('checked'),
-      comment: $('#advanced-search-modal-filters-comments-' + location).prop('checked'),
-      meta: $('#advanced-search-modal-filters-meta-' + location).prop('checked'),
-      status: 'all'
+      post: $('#advanced-search-modal-filters-posts-' + location).prop(
+        'checked',
+      ),
+      comment: $('#advanced-search-modal-filters-comments-' + location).prop(
+        'checked',
+      ),
+      meta: $('#advanced-search-modal-filters-meta-' + location).prop(
+        'checked',
+      ),
+      status: 'all',
     };
   }
 
   function execute_search_query_by_offset(evt, current_section_head) {
     let query = $('.advanced-search-modal-form-input').val();
-    let offset = evt.currentTarget.parentNode.parentNode.querySelector("#advanced-search-modal-results-table-row-section-head-hidden-offset").getAttribute("value");
-    let post_type = evt.currentTarget.parentNode.parentNode.querySelector("#advanced-search-modal-results-table-row-section-head-hidden-post-type").getAttribute("value");
+    let offset = evt.currentTarget.parentNode.parentNode
+      .querySelector(
+        '#advanced-search-modal-results-table-row-section-head-hidden-offset',
+      )
+      .getAttribute('value');
+    let post_type = evt.currentTarget.parentNode.parentNode
+      .querySelector(
+        '#advanced-search-modal-results-table-row-section-head-hidden-post-type',
+      )
+      .getAttribute('value');
 
-    rest_api.advanced_search(encodeURI(query), post_type, offset, fetch_filters()).then(api_data => {
+    rest_api
+      .advanced_search(encodeURI(query), post_type, offset, fetch_filters())
+      .then((api_data) => {
+        /*
+         * As by offset search is on a per post_type basis, there should
+         * only be a single result element returned.
+         */
 
-      /*
-       * As by offset search is on a per post_type basis, there should
-       * only be a single result element returned.
-       */
+        if (api_data && parseInt(api_data['total_hits']) > 0) {
+          // Reverse sort order so as to ensure names appear up top!
+          let results = sort_hits(remove_duplicate_hits(api_data['hits']), {
+            meta_hit: [],
+            comment_hit: [],
+            post_hit: [],
+            status_hit: [],
+          });
+          let total_hits = calculate_total_hits(results);
 
-      if (api_data && (parseInt(api_data['total_hits']) > 0)) {
+          // Update global hits count
+          let results_total = $('.advanced-search-modal-results-total');
+          let new_global_hits_count =
+            parseInt(results_total.html()) + total_hits;
+          results_total.html(
+            window.SHAREDFUNCTIONS.escapeHTML(new_global_hits_count),
+          );
 
-        // Reverse sort order so as to ensure names appear up top!
-        let results = sort_hits(remove_duplicate_hits(api_data['hits']), {
-          meta_hit: [],
-          comment_hit: [],
-          post_hit: [],
-          status_hit: []
-        });
-        let total_hits = calculate_total_hits(results);
+          // Update section offset value
+          evt.currentTarget.parentNode.parentNode
+            .querySelector(
+              '#advanced-search-modal-results-table-row-section-head-hidden-offset',
+            )
+            .setAttribute(
+              'value',
+              window.SHAREDFUNCTIONS.escapeHTML(results[0]['offset']),
+            );
 
-        // Update global hits count
-        let results_total = $('.advanced-search-modal-results-total');
-        let new_global_hits_count = parseInt(results_total.html()) + total_hits;
-        results_total.html(window.SHAREDFUNCTIONS.escapeHTML(new_global_hits_count));
-
-        // Update section offset value
-        evt.currentTarget.parentNode.parentNode.querySelector("#advanced-search-modal-results-table-row-section-head-hidden-offset").setAttribute("value", window.SHAREDFUNCTIONS.escapeHTML(results[0]['offset']));
-
-        // Insert latest finds...!
-        results[0]['posts'].forEach(function (post) {
-          current_section_head.closest('tr').after(build_result_table_row(post)).next('tr').slideDown('fast');
-        });
-      } else {
-        // Hide more search option when there are no further hits to be returned.
-        evt.currentTarget.style.display = 'none';
-      }
-
-    }).catch(error => {
-      console.log(error);
-    });
+          // Insert latest finds...!
+          results[0]['posts'].forEach(function (post) {
+            current_section_head
+              .closest('tr')
+              .after(build_result_table_row(post))
+              .next('tr')
+              .slideDown('fast');
+          });
+        } else {
+          // Hide more search option when there are no further hits to be returned.
+          evt.currentTarget.style.display = 'none';
+        }
+      })
+      .catch((error) => {
+        console.log(error);
+      });
   }
 
   function reset_widgets() {
@@ -125,56 +184,103 @@ jQuery(document).ready(function ($) {
     $('.advanced-search-modal-results-total').html('');
     $('.advanced-search-modal-results-div').slideUp('fast');
     $('.advanced-search-modal-results').html('').fadeOut('fast');
-    $('input[name=advanced-search-modal-post-types-at-side][value=all]').prop('checked', true);
+    $('input[name=advanced-search-modal-post-types-at-side][value=all]').prop(
+      'checked',
+      true,
+    );
 
     // Mobile view
-    $('.advanced-search-modal-results-post-types-view-at-top-collapsible-content').slideUp('fast');
-    $('.advanced-search-modal-results-post-types-view-at-top-collapsible-button').find('img').attr('src', window.SHAREDFUNCTIONS.escapeHTML(template_dir_uri) + '/dt-assets/images/chevron_down.svg');
-    $('input[name=advanced-search-modal-post-types-at-top][value=all]').prop('checked', true);
+    $(
+      '.advanced-search-modal-results-post-types-view-at-top-collapsible-content',
+    ).slideUp('fast');
+    $(
+      '.advanced-search-modal-results-post-types-view-at-top-collapsible-button',
+    )
+      .find('img')
+      .attr(
+        'src',
+        window.SHAREDFUNCTIONS.escapeHTML(template_dir_uri) +
+          '/dt-assets/images/chevron_down.svg',
+      );
+    $('input[name=advanced-search-modal-post-types-at-top][value=all]').prop(
+      'checked',
+      true,
+    );
   }
 
   function execute_search_query() {
     let query = $('.advanced-search-modal-form-input').val();
-    let collapsible_button = $('.advanced-search-modal-results-post-types-view-at-top-collapsible-button'); // Mobile view indicator
-    let selected_post_type = $(collapsible_button.is(':visible') ? "input[name=advanced-search-modal-post-types-at-top]:checked" : "input[name=advanced-search-modal-post-types-at-side]:checked").val();
+    let collapsible_button = $(
+      '.advanced-search-modal-results-post-types-view-at-top-collapsible-button',
+    ); // Mobile view indicator
+    let selected_post_type = $(
+      collapsible_button.is(':visible')
+        ? 'input[name=advanced-search-modal-post-types-at-top]:checked'
+        : 'input[name=advanced-search-modal-post-types-at-side]:checked',
+    ).val();
 
-    if (query.trim() === "") {
+    if (query.trim() === '') {
       return;
     }
 
     // Dispatch search query and display api response accordingly
     $('.advanced-search-modal-results-div').slideDown('fast', function (data) {
       let spinner = '<span class="loading-spinner active"></span>';
-      $('.advanced-search-modal-results').html(spinner).fadeIn('slow', function () {
-        rest_api.advanced_search(encodeURI(query), selected_post_type, 0, fetch_filters()).then(api_data => {
-          display_results(api_data, function () {
-            $('.advanced-search-modal-results').fadeIn('fast');
-          });
-        }).catch(error => {
-          console.log(error);
+      $('.advanced-search-modal-results')
+        .html(spinner)
+        .fadeIn('slow', function () {
+          rest_api
+            .advanced_search(
+              encodeURI(query),
+              selected_post_type,
+              0,
+              fetch_filters(),
+            )
+            .then((api_data) => {
+              display_results(api_data, function () {
+                $('.advanced-search-modal-results').fadeIn('fast');
+              });
+            })
+            .catch((error) => {
+              console.log(error);
+            });
         });
-      });
     });
   }
 
   function display_results(api_data, callback) {
     let results = sort_hits(remove_duplicate_hits(api_data['hits']));
     let total_hits = calculate_total_hits(results);
-    let results_html = "";
+    let results_html = '';
 
     // Update global hits count
-    $('.advanced-search-modal-results-total').html(window.SHAREDFUNCTIONS.escapeHTML(total_hits));
+    $('.advanced-search-modal-results-total').html(
+      window.SHAREDFUNCTIONS.escapeHTML(total_hits),
+    );
 
     // Iterate through results, displaying accordingly
-    results_html += '<table class="advanced-search-modal-results-table" style="border-spacing: 0px 5px !important; border-collapse: separate;"><tbody>';
+    results_html +=
+      '<table class="advanced-search-modal-results-table" style="border-spacing: 0px 5px !important; border-collapse: separate;"><tbody>';
     results.forEach(function (result) {
-
       results_html += '<tr>';
-      results_html += '<td class="advanced-search-modal-results-table-section-head-options"><a class="advanced-search-modal-results-table-row-section-head-load-more button hollow">' + window.SHAREDFUNCTIONS.escapeHTML(fetch_more_text) + '</a></td>';
-      results_html += '<td class="advanced-search-modal-results-table-section-head-post-type">';
-      results_html += '<b>' + window.SHAREDFUNCTIONS.escapeHTML(result['post_type']) + '</b></td>';
-      results_html += '<input type="hidden" id="advanced-search-modal-results-table-row-section-head-hidden-offset" value="' + window.SHAREDFUNCTIONS.escapeHTML(result['offset']) + '">';
-      results_html += '<input type="hidden" id="advanced-search-modal-results-table-row-section-head-hidden-post-type" value="' + window.SHAREDFUNCTIONS.escapeHTML(result['post_type']) + '">';
+      results_html +=
+        '<td class="advanced-search-modal-results-table-section-head-options"><a class="advanced-search-modal-results-table-row-section-head-load-more button hollow">' +
+        window.SHAREDFUNCTIONS.escapeHTML(fetch_more_text) +
+        '</a></td>';
+      results_html +=
+        '<td class="advanced-search-modal-results-table-section-head-post-type">';
+      results_html +=
+        '<b>' +
+        window.SHAREDFUNCTIONS.escapeHTML(result['post_type']) +
+        '</b></td>';
+      results_html +=
+        '<input type="hidden" id="advanced-search-modal-results-table-row-section-head-hidden-offset" value="' +
+        window.SHAREDFUNCTIONS.escapeHTML(result['offset']) +
+        '">';
+      results_html +=
+        '<input type="hidden" id="advanced-search-modal-results-table-row-section-head-hidden-post-type" value="' +
+        window.SHAREDFUNCTIONS.escapeHTML(result['post_type']) +
+        '">';
       results_html += '</td>';
       results_html += '</tr>';
 
@@ -207,33 +313,86 @@ jQuery(document).ready(function ($) {
     let _is_comment_hit = is_comment_hit(post['comment_hit']);
     let _is_meta_hit = is_meta_hit(post['meta_hit']);
     let _is_status_hit = is_meta_hit(post['status_hit']);
-    let _is_default_hit = (!_is_post_hit && !_is_comment_hit && !_is_meta_hit);
+    let _is_default_hit = !_is_post_hit && !_is_comment_hit && !_is_meta_hit;
 
-    let results_html = '<tr class="advanced-search-modal-results-table-row-clickable">';
+    let results_html =
+      '<tr class="advanced-search-modal-results-table-row-clickable">';
 
     // Convert post title to link, so as to provide support for browser link options, such as open in new tab!
-    let status_label = (_is_status_hit && post['status'] && post['status']['label']) ? ' [<i>' + window.SHAREDFUNCTIONS.escapeHTML(post['status']['label']).toLowerCase() + '</i>]' : '';
-    let status_color_css = (_is_status_hit && post['status'] && post['status']['color']) ? 'style="border-left-color: ' + post['status']['color'] + ' !important; border-left: 5px solid;"' : '';
-    let post_link = window.wpApiShare.site_url + '/' + window.SHAREDFUNCTIONS.escapeHTML(hidden_post_type) + "/" + window.SHAREDFUNCTIONS.escapeHTML(hidden_post_id);
-    results_html += '<td class="advanced-search-modal-results-table-col-hits" ' + status_color_css + '><a href="' + post_link + '"><b>' + window.SHAREDFUNCTIONS.escapeHTML(post['post_title']) + '</b> (#' + window.SHAREDFUNCTIONS.escapeHTML(hidden_post_id) + ')' + status_label + '</a><br><span>';
+    let status_label =
+      _is_status_hit && post['status'] && post['status']['label']
+        ? ' [<i>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            post['status']['label'],
+          ).toLowerCase() +
+          '</i>]'
+        : '';
+    let status_color_css =
+      _is_status_hit && post['status'] && post['status']['color']
+        ? 'style="border-left-color: ' +
+          post['status']['color'] +
+          ' !important; border-left: 5px solid;"'
+        : '';
+    let post_link =
+      window.wpApiShare.site_url +
+      '/' +
+      window.SHAREDFUNCTIONS.escapeHTML(hidden_post_type) +
+      '/' +
+      window.SHAREDFUNCTIONS.escapeHTML(hidden_post_id);
+    results_html +=
+      '<td class="advanced-search-modal-results-table-col-hits" ' +
+      status_color_css +
+      '><a href="' +
+      post_link +
+      '"><b>' +
+      window.SHAREDFUNCTIONS.escapeHTML(post['post_title']) +
+      '</b> (#' +
+      window.SHAREDFUNCTIONS.escapeHTML(hidden_post_id) +
+      ')' +
+      status_label +
+      '</a><br><span>';
 
     if (_is_comment_hit) {
-      results_html += window.SHAREDFUNCTIONS.escapeHTML((String(post['comment_hit_content']).length > 100) ? String(post['comment_hit_content']).substring(0, 100) + "..." : post['comment_hit_content']);
+      results_html += window.SHAREDFUNCTIONS.escapeHTML(
+        String(post['comment_hit_content']).length > 100
+          ? String(post['comment_hit_content']).substring(0, 100) + '...'
+          : post['comment_hit_content'],
+      );
     } else if (_is_meta_hit) {
       results_html += window.SHAREDFUNCTIONS.escapeHTML(post['meta_hit_value']);
     }
     results_html += '</span>';
 
-    results_html += '<input type="hidden" id="advanced-search-modal-results-table-row-hidden-post-id" value="' + window.SHAREDFUNCTIONS.escapeHTML(hidden_post_id) + '">';
-    results_html += '<input type="hidden" id="advanced-search-modal-results-table-row-hidden-post-type" value="' + window.SHAREDFUNCTIONS.escapeHTML(hidden_post_type) + '">';
+    results_html +=
+      '<input type="hidden" id="advanced-search-modal-results-table-row-hidden-post-id" value="' +
+      window.SHAREDFUNCTIONS.escapeHTML(hidden_post_id) +
+      '">';
+    results_html +=
+      '<input type="hidden" id="advanced-search-modal-results-table-row-hidden-post-type" value="' +
+      window.SHAREDFUNCTIONS.escapeHTML(hidden_post_type) +
+      '">';
 
     results_html += '</td>';
 
     // Determine hit type icon to be displayed
-    results_html += '<td class="advanced-search-modal-results-table-col-hits-type">';
-    results_html += (_is_post_hit || _is_default_hit) ? '<img class="dt-icon" src="' + window.SHAREDFUNCTIONS.escapeHTML(template_dir_uri) + '/dt-assets/images/contact-generation.svg" alt="Record Hit"/>&nbsp;' : '';
-    results_html += (_is_comment_hit) ? '<img class="dt-icon" src="' + window.SHAREDFUNCTIONS.escapeHTML(template_dir_uri) + '/dt-assets/images/comment.svg" alt="Comment Hit"/>&nbsp;' : '';
-    results_html += (_is_meta_hit) ? '<img class="dt-icon" src="' + window.SHAREDFUNCTIONS.escapeHTML(template_dir_uri) + '/dt-assets/images/socialmedia.svg" alt="Meta Hit"/>&nbsp;' : '';
+    results_html +=
+      '<td class="advanced-search-modal-results-table-col-hits-type">';
+    results_html +=
+      _is_post_hit || _is_default_hit
+        ? '<img class="dt-icon" src="' +
+          window.SHAREDFUNCTIONS.escapeHTML(template_dir_uri) +
+          '/dt-assets/images/contact-generation.svg" alt="Record Hit"/>&nbsp;'
+        : '';
+    results_html += _is_comment_hit
+      ? '<img class="dt-icon" src="' +
+        window.SHAREDFUNCTIONS.escapeHTML(template_dir_uri) +
+        '/dt-assets/images/comment.svg" alt="Comment Hit"/>&nbsp;'
+      : '';
+    results_html += _is_meta_hit
+      ? '<img class="dt-icon" src="' +
+        window.SHAREDFUNCTIONS.escapeHTML(template_dir_uri) +
+        '/dt-assets/images/socialmedia.svg" alt="Meta Hit"/>&nbsp;'
+      : '';
     results_html += '</td>';
 
     results_html += '</tr>';
@@ -242,29 +401,29 @@ jQuery(document).ready(function ($) {
   }
 
   function is_post_hit(post_hit) {
-    return (post_hit && (post_hit === 'Y'));
+    return post_hit && post_hit === 'Y';
   }
 
   function is_comment_hit(comment_hit) {
-    return (comment_hit && (comment_hit === 'Y'));
+    return comment_hit && comment_hit === 'Y';
   }
 
   function is_meta_hit(meta_hit) {
-    return (meta_hit && (meta_hit === 'Y'));
+    return meta_hit && meta_hit === 'Y';
   }
 
   function is_status_hit(status_hit) {
-    return (status_hit && (status_hit === 'Y'));
+    return status_hit && status_hit === 'Y';
   }
 
   function display_record(post_type, post_id) {
-    window.location = window.wpApiShare.site_url + '/' + post_type + "/" + post_id;
+    window.location =
+      window.wpApiShare.site_url + '/' + post_type + '/' + post_id;
   }
 
   function remove_duplicate_hits(hits) {
     if (hits) {
       hits.forEach(function (hit) {
-
         let already_found_ids = [];
         let filtered_posts = [];
 
@@ -280,7 +439,6 @@ jQuery(document).ready(function ($) {
         // Revise hit shape.
         hit['total'] = filtered_posts.length;
         hit['posts'] = filtered_posts;
-
       });
     }
 
@@ -298,10 +456,12 @@ jQuery(document).ready(function ($) {
     return total;
   }
 
-  function sort_hits(hits, order = {post_hit: [], comment_hit: [], meta_hit: [], status_hit: []}) {
+  function sort_hits(
+    hits,
+    order = { post_hit: [], comment_hit: [], meta_hit: [], status_hit: [] },
+  ) {
     if (hits) {
       hits.forEach(function (hit) {
-
         // Reset arrays...
         let reordered_posts = [];
         order.post_hit = [];
@@ -313,16 +473,12 @@ jQuery(document).ready(function ($) {
         hit['posts'].forEach(function (post) {
           if (is_post_hit(post['post_hit'])) {
             order.post_hit.push(post);
-
           } else if (is_comment_hit(post['comment_hit'])) {
             order.comment_hit.push(post);
-
           } else if (is_meta_hit(post['meta_hit'])) {
             order.meta_hit.push(post);
-
           } else if (is_status_hit(post['status_hit'])) {
             order.status_hit.push(post);
-
           } else {
             order.post_hit.push(post); // Default hit type!
           }
@@ -336,12 +492,9 @@ jQuery(document).ready(function ($) {
         });
 
         hit['posts'] = reordered_posts;
-
       });
     }
 
     return hits;
   }
-})
-
-
+});

--- a/dt-assets/js/check-browser-version.js
+++ b/dt-assets/js/check-browser-version.js
@@ -6,7 +6,7 @@
  * any fancy features, and don't depend on any libraries except Modernizr.
  */
 
-(function(Modernizr) {
+(function (Modernizr) {
   var requiredFeatures = [
     'arrow',
     'csscalc',
@@ -21,45 +21,49 @@
     'hidden',
     'promises',
     'strictmode',
-    'templatestrings'
+    'templatestrings',
     // remember not to use a trailing comma, as older browsers don't support it
   ];
 
   var supportsAllFeatures = true;
   for (var i = 0; i < requiredFeatures.length; i++) {
-    if (! Modernizr[requiredFeatures[i]]) {
+    if (!Modernizr[requiredFeatures[i]]) {
       if (window.console && window.console.log) {
-        console.log("Required feature is missing: " + requiredFeatures[i]);
+        console.log('Required feature is missing: ' + requiredFeatures[i]);
       }
       supportsAllFeatures = false;
     }
   }
 
-  if (! supportsAllFeatures) {
+  if (!supportsAllFeatures) {
     if (window.console && window.console.log) {
-      console.log("Not all required features are supported, please update your browser. Internet Explorer is not supported.");
+      console.log(
+        'Not all required features are supported, please update your browser. Internet Explorer is not supported.',
+      );
     }
 
-    ready(function() {
+    ready(function () {
       try {
-        document.querySelector("#js-missing-required-browser-features-notice").removeAttribute("hidden");
+        document
+          .querySelector('#js-missing-required-browser-features-notice')
+          .removeAttribute('hidden');
       } catch (e) {
-        alert("Please update your browser. Internet Explorer is not supported.");
+        alert(
+          'Please update your browser. Internet Explorer is not supported.',
+        );
       }
     });
   }
 
   function ready(fn) {
-    if (document.readyState != 'loading'){
+    if (document.readyState != 'loading') {
       fn();
     } else if (document.addEventListener) {
       document.addEventListener('DOMContentLoaded', fn);
     } else {
-      document.attachEvent('onreadystatechange', function() {
-        if (document.readyState != 'loading')
-          fn();
+      document.attachEvent('onreadystatechange', function () {
+        if (document.readyState != 'loading') fn();
       });
     }
   }
-
 })(window.Modernizr);

--- a/dt-assets/js/comments.js
+++ b/dt-assets/js/comments.js
@@ -1,101 +1,117 @@
 /* global moment:false, _:false, commentsSettings:false */
-jQuery(document).ready(function($) {
+jQuery(document).ready(function ($) {
   let commentPostedEvent = document.createEvent('Event');
   commentPostedEvent.initEvent('comment_posted', true, true);
 
-  let postId = window.detailsSettings.post_id
-  let postType = window.detailsSettings.post_type
-  let rest_api = window.API
-  let { formatComment } = window.SHAREDFUNCTIONS
+  let postId = window.detailsSettings.post_id;
+  let postType = window.detailsSettings.post_type;
+  let rest_api = window.API;
+  let { formatComment } = window.SHAREDFUNCTIONS;
 
-  let comments = []
-  let activity = [] // not guaranteed to be in any particular order
-  let langcode = document.querySelector('html').getAttribute('lang') ? document.querySelector('html').getAttribute('lang').replace('_', '-') : "en";// get the language attribute from the HTML or default to english if it doesn't exists.
+  let comments = [];
+  let activity = []; // not guaranteed to be in any particular order
+  let langcode = document.querySelector('html').getAttribute('lang')
+    ? document.querySelector('html').getAttribute('lang').replace('_', '-')
+    : 'en'; // get the language attribute from the HTML or default to english if it doesn't exists.
 
   function post_comment(postId) {
-    let commentInput = jQuery("#comment-input")
-    let commentButton = jQuery("#add-comment-button")
-    let commentType = $('#comment_type_selector').val()
-    getCommentWithMentions(comment_plain_text=>{
+    let commentInput = jQuery('#comment-input');
+    let commentButton = jQuery('#add-comment-button');
+    let commentType = $('#comment_type_selector').val();
+    getCommentWithMentions((comment_plain_text) => {
       if (comment_plain_text) {
-        commentButton.toggleClass('loading')
-        commentInput.attr("disabled", true)
-        commentButton.attr("disabled", true)
-        rest_api.post_comment(postType, postId, comment_plain_text, commentType ).then(data => {
-          let updated_comment = data.comment || data
-          commentInput.val("").trigger( "change" )
-          commentButton.toggleClass('loading')
-          updated_comment.date = window.moment(updated_comment.comment_date_gmt + "Z")
-          comments.push(updated_comment)
-          display_activity_comment()
-          // fire comment posted event
-          $('#content')[0].dispatchEvent(commentPostedEvent);
-          commentInput.attr("disabled", false)
-          commentButton.attr("disabled", false)
-          $('textarea.mention').mentionsInput('reset')
-        }).catch(err => {
-          console.log("error")
-          console.log(err)
-          jQuery("#errors").append(err.responseText)
-        })
+        commentButton.toggleClass('loading');
+        commentInput.attr('disabled', true);
+        commentButton.attr('disabled', true);
+        rest_api
+          .post_comment(postType, postId, comment_plain_text, commentType)
+          .then((data) => {
+            let updated_comment = data.comment || data;
+            commentInput.val('').trigger('change');
+            commentButton.toggleClass('loading');
+            updated_comment.date = window.moment(
+              updated_comment.comment_date_gmt + 'Z',
+            );
+            comments.push(updated_comment);
+            display_activity_comment();
+            // fire comment posted event
+            $('#content')[0].dispatchEvent(commentPostedEvent);
+            commentInput.attr('disabled', false);
+            commentButton.attr('disabled', false);
+            $('textarea.mention').mentionsInput('reset');
+          })
+          .catch((err) => {
+            console.log('error');
+            console.log(err);
+            jQuery('#errors').append(err.responseText);
+          });
       }
     });
   }
-
 
   function prepareActivityData(activityData) {
     /* Insert a "created contact" item in the activity, even though it is not
      * stored in the database. It is not stored as an activity in the database,
      * to avoid duplicating data with the post's metadata. */
-    let settings = commentsSettings
-    const currentContact = settings.post
-    let createdDate = window.moment.utc(currentContact.post_date_gmt, "YYYY-MM-DD HH:mm:ss", true)
+    let settings = commentsSettings;
+    const currentContact = settings.post;
+    let createdDate = window.moment.utc(
+      currentContact.post_date_gmt,
+      'YYYY-MM-DD HH:mm:ss',
+      true,
+    );
     const createdContactActivityItem = {
       hist_time: createdDate.unix(),
-      object_note: window.detailsSettings.translations.created_on.replace('%s', window.SHAREDFUNCTIONS.formatDate(createdDate.unix(), true)),
+      object_note: window.detailsSettings.translations.created_on.replace(
+        '%s',
+        window.SHAREDFUNCTIONS.formatDate(createdDate.unix(), true),
+      ),
       name: settings.contact_author_name,
       user_id: currentContact.post_author,
-    }
-    activityData.push(createdContactActivityItem)
-    if (window.lodash.get(settings, "post_with_fields.initial_comments")){
+    };
+    activityData.push(createdContactActivityItem);
+    if (window.lodash.get(settings, 'post_with_fields.initial_comments')) {
       const initialComments = {
-        hist_time: createdDate.unix()+1,
+        hist_time: createdDate.unix() + 1,
         object_note: settings.post_with_fields.initial_comments,
         name: settings.contact_author_name,
         user_id: currentContact.post_author,
-      }
-      activityData.push(initialComments)
+      };
+      activityData.push(initialComments);
     }
 
-    activityData.forEach(item => {
-      item.date = window.moment.unix(item.hist_time)
-      let field = item.meta_key
+    activityData.forEach((item) => {
+      item.date = window.moment.unix(item.hist_time);
+      let field = item.meta_key;
 
-      if (field && field.includes("quick_button_")){
-        if (window.detailsSettings){
-          field = window.lodash.get(window.detailsSettings,`post_settings.fields[${item.meta_key}].name`)
+      if (field && field.includes('quick_button_')) {
+        if (window.detailsSettings) {
+          field = window.lodash.get(
+            window.detailsSettings,
+            `post_settings.fields[${item.meta_key}].name`,
+          );
         }
-        item.action = `<a class="revert-activity dt_tooltip" data-id="${window.SHAREDFUNCTIONS.escapeHTML( item.histid )}">
+        item.action = `<a class="revert-activity dt_tooltip" data-id="${window.SHAREDFUNCTIONS.escapeHTML(item.histid)}">
           <img class="revert-arrow-img" src="${commentsSettings.template_dir}/dt-assets/images/undo.svg">
-          <span class="tooltiptext">${window.SHAREDFUNCTIONS.escapeHTML( field || item.meta_key )} </span>
-        </a>`
+          <span class="tooltiptext">${window.SHAREDFUNCTIONS.escapeHTML(field || item.meta_key)} </span>
+        </a>`;
       } else {
-        item.action = ''
+        item.action = '';
       }
-    })
+    });
 
-    let tab = $(`[data-id="activity"].tab-button-label`)
-    let text = tab.text()
-    text = text.substring(0, text.indexOf('(')) || text
-    text += ` (${formatNumber(activityData.length, langcode)})`
-    tab.text(text)
-    tab.parent().parent('.hide').removeClass('hide')
+    let tab = $(`[data-id="activity"].tab-button-label`);
+    let text = tab.text();
+    text = text.substring(0, text.indexOf('(')) || text;
+    text += ` (${formatNumber(activityData.length, langcode)})`;
+    tab.text(text);
+    tab.parent().parent('.hide').removeClass('hide');
   }
-  $(".show-tabs").on("click", function () {
-    let id = $(this).attr("id")
-    $('input.tabs-section').prop('checked', id === 'show-all-tabs')
-    saveTabs()
-  })
+  $('.show-tabs').on('click', function () {
+    let id = $(this).attr('id');
+    $('input.tabs-section').prop('checked', id === 'show-all-tabs');
+    saveTabs();
+  });
 
   /* We use the CSS 'white-space:pre-wrap' and '<div dir=auto>' HTML elements
    * to match the behaviour that the user sees when editing the comment in an
@@ -186,120 +202,137 @@ jQuery(document).ready(function($) {
         </div>
     <% } %>
     </div>
-  </div>`
-  )
+  </div>`);
 
-  $(document).on("click", '.translate-button.showTranslation', function() {
+  $(document).on('click', '.translate-button.showTranslation', function () {
     let combinedArray = [];
-    jQuery(this).siblings('.comment-bubble').each(function(index, comment) {
-      let sourceText = $(comment).text();
-      sourceText = sourceText.replace(/\s+/g, ' ').trim();
-      combinedArray[index] = sourceText;
-    })
+    jQuery(this)
+      .siblings('.comment-bubble')
+      .each(function (index, comment) {
+        let sourceText = $(comment).text();
+        sourceText = sourceText.replace(/\s+/g, ' ').trim();
+        combinedArray[index] = sourceText;
+      });
 
     let translation_bubble = $(this).siblings('.translation-bubble');
-    let translation_hide = $(this).siblings('.translate-button.hideTranslation');
+    let translation_hide = $(this).siblings(
+      '.translate-button.hideTranslation',
+    );
 
-    let url = `https://translation.googleapis.com/language/translate/v2?key=${window.SHAREDFUNCTIONS.escapeHTML(commentsSettings.google_translate_key)}`
+    let url = `https://translation.googleapis.com/language/translate/v2?key=${window.SHAREDFUNCTIONS.escapeHTML(commentsSettings.google_translate_key)}`;
     let targetLang;
 
-    if (langcode !== "zh-TW") {
-      targetLang = langcode.substr(0,2);
+    if (langcode !== 'zh-TW') {
+      targetLang = langcode.substr(0, 2);
     } else {
       targetLang = langcode;
     }
 
-    function google_translate_fetch(postData, translate_button, arrayStartPos = 0) {
+    function google_translate_fetch(
+      postData,
+      translate_button,
+      arrayStartPos = 0,
+    ) {
       fetch(url, {
-            method: 'POST',
-            body: JSON.stringify(postData),
-        })
-        .then(response => response.json())
+        method: 'POST',
+        body: JSON.stringify(postData),
+      })
+        .then((response) => response.json())
         .then((result) => {
-
-          $.each(result.data.translations, function( index, translation ) {
-            $(translation_bubble[index + arrayStartPos]).append(translation.translatedText);
+          $.each(result.data.translations, function (index, translation) {
+            $(translation_bubble[index + arrayStartPos]).append(
+              translation.translatedText,
+            );
           });
           translation_hide.removeClass('hide');
           $(translate_button).addClass('hide');
-        })
+        });
     }
 
-    if( combinedArray.length <= 128) {
+    if (combinedArray.length <= 128) {
       let postData = {
-        "q": combinedArray,
-        "target": targetLang
-      }
+        q: combinedArray,
+        target: targetLang,
+      };
       google_translate_fetch(postData, this);
     } else {
-      var i,j,temparray,chunk = 128;
-      for (i=0,j=combinedArray.length; i<j; i+=chunk) {
-          temparray = combinedArray.slice(i,i+chunk);
+      var i,
+        j,
+        temparray,
+        chunk = 128;
+      for (i = 0, j = combinedArray.length; i < j; i += chunk) {
+        temparray = combinedArray.slice(i, i + chunk);
 
-          let postData = {
-            "q": temparray,
-            "target": targetLang
-          }
-          google_translate_fetch(postData, this, i);
+        let postData = {
+          q: temparray,
+          target: targetLang,
+        };
+        google_translate_fetch(postData, this, i);
       }
     }
+  });
 
-  })
-
-  $(document).on("click", '.translate-button.hideTranslation', function() {
+  $(document).on('click', '.translate-button.hideTranslation', function () {
     let translation_bubble = $(this).siblings('.translation-bubble');
-    let translate_button = $(this).siblings('.translate-button.showTranslation')
+    let translate_button = $(this).siblings(
+      '.translate-button.showTranslation',
+    );
 
     translation_bubble.empty();
     $(this).addClass('hide');
     translate_button.removeClass('hide');
-  })
+  });
 
-  $(document).on("click", ".open-delete-comment", function () {
-    let id = $(this).data("id")
-    $('#comment-to-delete').html($(`.comment-bubble.${id}`).html())
-    $('.delete-comment.callout').hide()
-    $('#delete-comment-modal').foundation('open')
-    $('#confirm-comment-delete').data("id", id)
-  })
-  $('#confirm-comment-delete').on("click", function () {
-    let id = $(this).data("id")
-    $(this).toggleClass('loading')
-    rest_api.delete_comment( postType, postId, id ).then(response=>{
-      $(this).toggleClass('loading')
-      if (response){
-        $('#delete-comment-modal').foundation('close')
-      } else {
-        $('.delete-comment.callout').show()
-      }
-    }).catch(err=>{
-      $(this).toggleClass('loading')
-      if (window.lodash.get(err, "responseJSON.message")){
-        $('.delete-comment.callout').show()
-        $('#delete-comment-error').html(err.responseJSON.message)
-      }
-    })
-  })
+  $(document).on('click', '.open-delete-comment', function () {
+    let id = $(this).data('id');
+    $('#comment-to-delete').html($(`.comment-bubble.${id}`).html());
+    $('.delete-comment.callout').hide();
+    $('#delete-comment-modal').foundation('open');
+    $('#confirm-comment-delete').data('id', id);
+  });
+  $('#confirm-comment-delete').on('click', function () {
+    let id = $(this).data('id');
+    $(this).toggleClass('loading');
+    rest_api
+      .delete_comment(postType, postId, id)
+      .then((response) => {
+        $(this).toggleClass('loading');
+        if (response) {
+          $('#delete-comment-modal').foundation('close');
+        } else {
+          $('.delete-comment.callout').show();
+        }
+      })
+      .catch((err) => {
+        $(this).toggleClass('loading');
+        if (window.lodash.get(err, 'responseJSON.message')) {
+          $('.delete-comment.callout').show();
+          $('#delete-comment-error').html(err.responseJSON.message);
+        }
+      });
+  });
 
-  $(document).on("click", ".open-edit-comment", function () {
-    let id = $(this).data("id")
-    let comment_type = $(this).data("type");
-    let comment = window.lodash.find(comments, {comment_ID:id.toString()})
+  $(document).on('click', '.open-edit-comment', function () {
+    let id = $(this).data('id');
+    let comment_type = $(this).data('type');
+    let comment = window.lodash.find(comments, { comment_ID: id.toString() });
 
-    let comment_html = comment.comment_content // eg: "Tom &amp; Jerry"
-
+    let comment_html = comment.comment_content; // eg: "Tom &amp; Jerry"
 
     /**
      * .DT - while previewing submitted comments, enhance the presentation of special characters with a helper function below
      */
 
     function unescapeHtml(safe) {
-      return safe.replace(/&amp;/g, '&')
+      return (
+        safe
+          .replace(/&amp;/g, '&')
           //.replace(/&lt;/g, '<')
           //.replace(/&gt;/g, '>')
           .replace(/&quot;/g, '"')
           .replace(/&#39;/g, "'")
-          .replace(/&#039;/g, "'");
+          .replace(/&#039;/g, "'")
+      );
     }
 
     // textarea deos not render HTML, so using window.lodash.unescape is safe. Note that
@@ -309,30 +342,33 @@ jQuery(document).ready(function($) {
 
     $('#edit_comment_type_selector').val(comment_type);
 
-    $('.edit-comment.callout').hide()
-    $('#edit-comment-modal').foundation('open')
-    $('#confirm-comment-edit').data("id", id)
-  })
-  $('#confirm-comment-edit').on("click", function () {
-    $(this).toggleClass('loading')
-    let id = $(this).data("id")
-    let updated_comment = $('#comment-to-edit').val()
+    $('.edit-comment.callout').hide();
+    $('#edit-comment-modal').foundation('open');
+    $('#confirm-comment-edit').data('id', id);
+  });
+  $('#confirm-comment-edit').on('click', function () {
+    $(this).toggleClass('loading');
+    let id = $(this).data('id');
+    let updated_comment = $('#comment-to-edit').val();
     let commentType = $('#edit_comment_type_selector').val();
-    rest_api.update_comment( postType, postId, id, updated_comment, commentType).then((response)=>{
-      $(this).toggleClass('loading')
-      if (response === 1 || response === 0 || response.comment_ID){
-        $('#edit-comment-modal').foundation('close')
-      } else {
-        $('.edit-comment.callout').show()
-      }
-    }).catch(err=>{
-      $(this).toggleClass('loading')
-      if (window.lodash.get(err, "responseJSON.message")){
-        $('.edit-comment.callout').show()
-        $('#edit-comment-error').html(err.responseJSON.message)
-      }
-    })
-  })
+    rest_api
+      .update_comment(postType, postId, id, updated_comment, commentType)
+      .then((response) => {
+        $(this).toggleClass('loading');
+        if (response === 1 || response === 0 || response.comment_ID) {
+          $('#edit-comment-modal').foundation('close');
+        } else {
+          $('.edit-comment.callout').show();
+        }
+      })
+      .catch((err) => {
+        $(this).toggleClass('loading');
+        if (window.lodash.get(err, 'responseJSON.message')) {
+          $('.edit-comment.callout').show();
+          $('#edit-comment-error').html(err.responseJSON.message);
+        }
+      });
+  });
 
   function formatNumber(num, lang) {
     return num.toLocaleString(lang);
@@ -341,203 +377,226 @@ jQuery(document).ready(function($) {
   function display_activity_comment() {
     let hiddenTabs = [];
     try {
-      hiddenTabs = JSON.parse( window.SHAREDFUNCTIONS.getCookie("dt_activity_comments_hidden_tabs") )
+      hiddenTabs = JSON.parse(
+        window.SHAREDFUNCTIONS.getCookie('dt_activity_comments_hidden_tabs'),
+      );
     } catch (e) {}
-    hiddenTabs.forEach(tab=>{
-      $(`#tab-button-${tab}`).prop('checked', false)
-    })
-    let commentsWrapper = $("#comments-wrapper")
-    commentsWrapper.empty()
-    let displayed = []
-    if ( !hiddenTabs.includes("activity")){
-      displayed = window.lodash.union(displayed, activity)
+    hiddenTabs.forEach((tab) => {
+      $(`#tab-button-${tab}`).prop('checked', false);
+    });
+    let commentsWrapper = $('#comments-wrapper');
+    commentsWrapper.empty();
+    let displayed = [];
+    if (!hiddenTabs.includes('activity')) {
+      displayed = window.lodash.union(displayed, activity);
     }
-    comments.forEach(comment=>{
-      if (!hiddenTabs.includes(comment.comment_type)){
-        displayed.push(comment)
+    comments.forEach((comment) => {
+      if (!hiddenTabs.includes(comment.comment_type)) {
+        displayed.push(comment);
       }
-    })
-    displayed = displayed.sort((a,b)=>{
-      return (a.sort_date || a.date) < (b.sort_date || b.date) ? 1 : -1
-    })
-    let array = []
+    });
+    displayed = displayed.sort((a, b) => {
+      return (a.sort_date || a.date) < (b.sort_date || b.date) ? 1 : -1;
+    });
+    let array = [];
 
-    displayed.forEach(d=>{
+    displayed.forEach((d) => {
       let baptismDateRegex = /\{(\d+)\}+/;
       if (baptismDateRegex.test(d.object_note)) {
         if (d.field_type === 'datetime') {
-          d.object_note = d.object_note.replace(baptismDateRegex, formatTimestampToDateTime);
+          d.object_note = d.object_note.replace(
+            baptismDateRegex,
+            formatTimestampToDateTime,
+          );
         } else {
-          d.object_note = d.object_note.replace(baptismDateRegex, formatTimestampToDate);
+          d.object_note = d.object_note.replace(
+            baptismDateRegex,
+            formatTimestampToDate,
+          );
         }
       }
-      if ( d.object_note ){
-        d.object_note = formatComment(d.object_note)
+      if (d.object_note) {
+        d.object_note = formatComment(d.object_note);
       }
-      let first = window.lodash.first(array)
-      let name = d.comment_author || d.name
-      let gravatar = d.gravatar || ""
+      let first = window.lodash.first(array);
+      let name = d.comment_author || d.name;
+      let gravatar = d.gravatar || '';
       let obj = {
         name: name,
         date: d.date,
-        date_formatted: window.SHAREDFUNCTIONS.formatDate(moment(d.date).unix(), true),
+        date_formatted: window.SHAREDFUNCTIONS.formatDate(
+          moment(d.date).unix(),
+          true,
+        ),
         gravatar,
-        text:d.object_note || formatComment(d.comment_content),
+        text: d.object_note || formatComment(d.comment_content),
         comment: !!d.comment_content,
-        comment_ID : d.comment_ID,
+        comment_ID: d.comment_ID,
         is_own_comment: d.user_id === commentsSettings.current_user_id,
-        comment_type : d.comment_type,
+        comment_type: d.comment_type,
         action: d.action,
         reactions: d.comment_reactions || {},
         meta: d.comment_meta || {},
-      }
+      };
 
-      let diff = first ? first.date.diff(obj.date, "hours") : 0
-      if (!first || (first.name === name && diff < 1) ){
-        array.push(obj)
+      let diff = first ? first.date.diff(obj.date, 'hours') : 0;
+      if (!first || (first.name === name && diff < 1)) {
+        array.push(obj);
       } else {
-        commentsWrapper.append(commentTemplate({
-          name: array[0].name,
-          gravatar: array[0].gravatar,
-          date: array[0].date_formatted,
-          activity: array
-        }))
-        array = [obj]
+        commentsWrapper.append(
+          commentTemplate({
+            name: array[0].name,
+            gravatar: array[0].gravatar,
+            date: array[0].date_formatted,
+            activity: array,
+          }),
+        );
+        array = [obj];
       }
-    })
-    if (array.length > 0){
-      commentsWrapper.append(commentTemplate({
-        gravatar: array[0].gravatar,
-        name: array[0].name,
-        date: array[0].date_formatted,
-        activity: array
-      }))
+    });
+    if (array.length > 0) {
+      commentsWrapper.append(
+        commentTemplate({
+          gravatar: array[0].gravatar,
+          name: array[0].name,
+          date: array[0].date_formatted,
+          activity: array,
+        }),
+      );
     }
 
     document.querySelectorAll('.reactions__dropdown').forEach((element) => {
-      const commentId = element.dataset.commentId
-      const emojis = emojiButtons()
-      const reactionForm = document.createElement('form')
-      reactionForm.classList.add('pick-reaction-form')
+      const commentId = element.dataset.commentId;
+      const emojis = emojiButtons();
+      const reactionForm = document.createElement('form');
+      reactionForm.classList.add('pick-reaction-form');
       reactionForm.innerHTML = `
         ${emojis}
-      `
+      `;
       reactionForm.addEventListener('submit', (e) => {
         e.preventDefault();
         const formDataEntries = new FormData(e.target).entries();
         const entries = Array.from(formDataEntries);
         //event submitter data is not available in Safari/Webkit browsers only in Chrome/Blink browsers. This checks if that data exists and falls back to the formDataEntries data if it doesn't exists.
         const reaction = e.submitter ? e.submitter.value : entries[0][1];
-        rest_api.toggle_comment_reaction(postType, postId, commentId, reaction)
-      })
-      element.appendChild(reactionForm)
-    })
-    document.querySelectorAll('#comments-wrapper [data-toggle]').forEach((element) => {
-      const dropdownId = $(element).data('toggle')
-      const dropdownElement = document.querySelector(`#${dropdownId}`)
-      element.addEventListener('click', (e) => {
-        const style = getComputedStyle(dropdownElement)
-        element.toggleAttribute('open')
-        if (style.visibility === 'hidden') {
-          dropdownElement.style.visibility = 'visible'
-          dropdownElement.style.display = 'block'
-        } else {
-          dropdownElement.style.visibility = 'hidden'
-          dropdownElement.style.display = 'none'
-        }
-      })
-    })
+        rest_api.toggle_comment_reaction(postType, postId, commentId, reaction);
+      });
+      element.appendChild(reactionForm);
+    });
+    document
+      .querySelectorAll('#comments-wrapper [data-toggle]')
+      .forEach((element) => {
+        const dropdownId = $(element).data('toggle');
+        const dropdownElement = document.querySelector(`#${dropdownId}`);
+        element.addEventListener('click', (e) => {
+          const style = getComputedStyle(dropdownElement);
+          element.toggleAttribute('open');
+          if (style.visibility === 'hidden') {
+            dropdownElement.style.visibility = 'visible';
+            dropdownElement.style.display = 'block';
+          } else {
+            dropdownElement.style.visibility = 'hidden';
+            dropdownElement.style.display = 'none';
+          }
+        });
+      });
     document.querySelectorAll('.comment-reaction').forEach((element) => {
       element.addEventListener('click', (e) => {
-        const commentId = e.target.dataset.commentId
-        const reaction = e.target.dataset.reactionValue
-        rest_api.toggle_comment_reaction(postType, postId, commentId, reaction)
-      })
-    })
+        const commentId = e.target.dataset.commentId;
+        const reaction = e.target.dataset.reactionValue;
+        rest_api.toggle_comment_reaction(postType, postId, commentId, reaction);
+      });
+    });
   }
 
   function emojiButtons() {
-    const reactions = commentsSettings.reaction_options
-    const emojiContainer = document.createElement('div')
-    emojiContainer.classList.add('reactions-emoji-container')
-    let emojis = ''
+    const reactions = commentsSettings.reaction_options;
+    const emojiContainer = document.createElement('div');
+    emojiContainer.classList.add('reactions-emoji-container');
+    let emojis = '';
     Object.entries(reactions).forEach(([alias, reaction]) => {
-      const reactionValue = `reaction_${alias}`
+      const reactionValue = `reaction_${alias}`;
       emojis += `
       <button class="add-reaction" type="submit" name="reaction" title="${window.SHAREDFUNCTIONS.escapeHTML(reaction.name)}" value="${reactionValue}">
         <img class="emoji" alt="${window.SHAREDFUNCTIONS.escapeHTML(reaction.name)}" src="${window.SHAREDFUNCTIONS.escapeHTML(reaction.path)}">
       </button>
-      `
-    })
-    emojiContainer.innerHTML = emojis
-    return emojiContainer.outerHTML
+      `;
+    });
+    emojiContainer.innerHTML = emojis;
+    return emojiContainer.outerHTML;
   }
 
   function formatTimestampToDate(match, timestamp) {
-    return window.SHAREDFUNCTIONS.formatDate(timestamp)
+    return window.SHAREDFUNCTIONS.formatDate(timestamp);
   }
   function formatTimestampToDateTime(match, timestamp) {
-    return window.SHAREDFUNCTIONS.formatDate(timestamp, true)
+    return window.SHAREDFUNCTIONS.formatDate(timestamp, true);
   }
   /**
    * Comments and activity
    */
-  $( document ).ajaxComplete(function(event, xhr, settings) {
-    if (settings && settings.type && (settings.type === "POST" || settings.type === "DELETE")){
-      if (!settings.url.includes("notifications")){
-        refreshActivity()
+  $(document).ajaxComplete(function (event, xhr, settings) {
+    if (
+      settings &&
+      settings.type &&
+      (settings.type === 'POST' || settings.type === 'DELETE')
+    ) {
+      if (!settings.url.includes('notifications')) {
+        refreshActivity();
       }
     }
   });
-  $( document ).ajaxSend(function(event, xhr, settings) {
-    if (settings && settings.type && (settings.type === "POST" || settings.type === "DELETE")){
-      if (!settings.url.includes("notifications")){
-        $("#comments-activity-spinner.loading-spinner").addClass("active")
+  $(document).ajaxSend(function (event, xhr, settings) {
+    if (
+      settings &&
+      settings.type &&
+      (settings.type === 'POST' || settings.type === 'DELETE')
+    ) {
+      if (!settings.url.includes('notifications')) {
+        $('#comments-activity-spinner.loading-spinner').addClass('active');
       }
     }
   });
 
-  let refreshActivity = ()=>{
+  let refreshActivity = () => {
     get_all();
-  }
+  };
 
-
-
-  let getAllPromise = null
-  let getCommentsPromise = null
-  let getActivityPromise = null
+  let getAllPromise = null;
+  let getCommentsPromise = null;
+  let getActivityPromise = null;
   function get_all() {
     //abort previous promise if it is not finished.
-    if (getAllPromise && window.lodash.get(getAllPromise, "readyState") !== 4){
-      getActivityPromise.abort()
-      getCommentsPromise.abort()
+    if (getAllPromise && window.lodash.get(getAllPromise, 'readyState') !== 4) {
+      getActivityPromise.abort();
+      getCommentsPromise.abort();
     }
-    getCommentsPromise =  rest_api.get_comments(postType, postId)
-    getActivityPromise = rest_api.get_activity(postType, postId)
-    getAllPromise = $.when(
-      getCommentsPromise,
-      getActivityPromise
-    )
-    getAllPromise.then(function(commentDataStatusJQXHR, activityDataStatusJQXHR) {
-      $("#comments-activity-spinner.loading-spinner").removeClass("active")
-      const commentData = commentDataStatusJQXHR[0].comments;
-      const activityData = activityDataStatusJQXHR[0].activity;
+    getCommentsPromise = rest_api.get_comments(postType, postId);
+    getActivityPromise = rest_api.get_activity(postType, postId);
+    getAllPromise = $.when(getCommentsPromise, getActivityPromise);
+    getAllPromise
+      .then(function (commentDataStatusJQXHR, activityDataStatusJQXHR) {
+        $('#comments-activity-spinner.loading-spinner').removeClass('active');
+        const commentData = commentDataStatusJQXHR[0].comments;
+        const activityData = activityDataStatusJQXHR[0].activity;
 
-      prepareData(commentData, activityData)
-    }).catch(err => {
-      if ( !window.lodash.get( err, "statusText" ) === "abort" ) {
-        console.error(err);
-        jQuery("#errors").append(err.responseText)
-      }
-    })
+        prepareData(commentData, activityData);
+      })
+      .catch((err) => {
+        if (!window.lodash.get(err, 'statusText') === 'abort') {
+          console.error(err);
+          jQuery('#errors').append(err.responseText);
+        }
+      });
   }
 
-
-  let prepareData = function(commentData, activityData){
+  let prepareData = function (commentData, activityData) {
     let typesCount = {};
-    commentData.forEach(comment => {
-      comment.date = window.moment(comment.comment_date_gmt + "Z")
-      comment.sort_date = window.moment(comment.comment_date_gmt + "Z").add(5, 'seconds')
+    commentData.forEach((comment) => {
+      comment.date = window.moment(comment.comment_date_gmt + 'Z');
+      comment.sort_date = window
+        .moment(comment.comment_date_gmt + 'Z')
+        .add(5, 'seconds');
 
       /* comment_content should be HTML. However, we want to make sure that
        * HTML like "<div>Hello" gets transformed to "<div>Hello</div>", that
@@ -547,121 +606,146 @@ jQuery(document).ready(function($) {
        * can trust the contents of the database to have been sanitized
        * thanks to wp_new_comment . */
 
-        // .DT lets strip out the tags provided from the submited comment and treat it as pure text.
-       comment.comment_content = $("<div>").text(comment.comment_content).text()
+      // .DT lets strip out the tags provided from the submited comment and treat it as pure text.
+      comment.comment_content = $('<div>').text(comment.comment_content).text();
 
-      if (!typesCount[comment.comment_type]){
+      if (!typesCount[comment.comment_type]) {
         typesCount[comment.comment_type] = 0;
       }
       typesCount[comment.comment_type]++;
-    })
-    $('#comment-activity-tabs .tabs-title[data-always-show!="true"]').addClass('hide')
-    window.lodash.forOwn(typesCount, (val, key)=>{
-      let tab = $(`[data-id="${key}"].tab-button-label`)
-      let text = tab.text()
-      text = text.substring(0, text.indexOf('(')) || text
-      text += ` (${formatNumber(val, langcode)})`
-      tab.text(text)
-      tab.parent().parent('.hide').removeClass('hide')
-    })
-    comments = commentData
-    activity = activityData
-    prepareActivityData(activity)
-    display_activity_comment("all")
-  }
-  prepareData( commentsSettings.comments.comments, commentsSettings.activity.activity )
-
+    });
+    $('#comment-activity-tabs .tabs-title[data-always-show!="true"]').addClass(
+      'hide',
+    );
+    window.lodash.forOwn(typesCount, (val, key) => {
+      let tab = $(`[data-id="${key}"].tab-button-label`);
+      let text = tab.text();
+      text = text.substring(0, text.indexOf('(')) || text;
+      text += ` (${formatNumber(val, langcode)})`;
+      tab.text(text);
+      tab.parent().parent('.hide').removeClass('hide');
+    });
+    comments = commentData;
+    activity = activityData;
+    prepareActivityData(activity);
+    display_activity_comment('all');
+  };
+  prepareData(
+    commentsSettings.comments.comments,
+    commentsSettings.activity.activity,
+  );
 
   jQuery('#add-comment-button').on('click', function () {
-    post_comment(postId)
-  })
-
-  $('#comment-activity-tabs .tabs-section').on("change", function () {
-    saveTabs()
-  })
-  let saveTabs = ()=>{
-    let hiddenTabs = $('#comment-activity-tabs .tabs-section:not(:checked)')
-    let hiddenTabIds = [];
-    hiddenTabs.each((i, e)=>{
-      hiddenTabIds.push($(e).data("id"))
-    })
-    document.cookie = `dt_activity_comments_hidden_tabs=${JSON.stringify(hiddenTabIds)};path=/;expires=Fri, 31 Dec 9999 23:59:59 GMT"`
-    display_activity_comment()
-  }
-
-
-  let searchUsersPromise = null
-
-  $('textarea.mention').mentionsInput({
-    onDataRequest:function (mode, query, callback) {
-      $('#comment-input').addClass('loading-gif')
-      if ( searchUsersPromise && window.lodash.get(searchUsersPromise, 'readyState') !== 4 ){
-        searchUsersPromise.abort("abortPromise")
-      }
-      searchUsersPromise = window.API.search_users(query)
-      searchUsersPromise.then(responseData=>{
-        $('#comment-input').removeClass('loading-gif')
-        let data = []
-        responseData.forEach(user=>{
-          data.push({id:user.ID, name:user.name, type:postType, avatar:user.avatar})
-          callback.call(this, data);
-        })
-      }).catch(err => { console.error(err) })
-    },
-    templates : {
-      mentionItemSyntax : function (data) {
-        return `[${data.value}](${data.id})`
-      }
-    },
-    showAvatars: true,
-    minChars: 0
+    post_comment(postId);
   });
 
-  let getMentionedUsers = (callback)=>{
-    $('textarea.mention').mentionsInput('getMentions', function(data) {
+  $('#comment-activity-tabs .tabs-section').on('change', function () {
+    saveTabs();
+  });
+  let saveTabs = () => {
+    let hiddenTabs = $('#comment-activity-tabs .tabs-section:not(:checked)');
+    let hiddenTabIds = [];
+    hiddenTabs.each((i, e) => {
+      hiddenTabIds.push($(e).data('id'));
+    });
+    document.cookie = `dt_activity_comments_hidden_tabs=${JSON.stringify(hiddenTabIds)};path=/;expires=Fri, 31 Dec 9999 23:59:59 GMT"`;
+    display_activity_comment();
+  };
+
+  let searchUsersPromise = null;
+
+  $('textarea.mention').mentionsInput({
+    onDataRequest: function (mode, query, callback) {
+      $('#comment-input').addClass('loading-gif');
+      if (
+        searchUsersPromise &&
+        window.lodash.get(searchUsersPromise, 'readyState') !== 4
+      ) {
+        searchUsersPromise.abort('abortPromise');
+      }
+      searchUsersPromise = window.API.search_users(query);
+      searchUsersPromise
+        .then((responseData) => {
+          $('#comment-input').removeClass('loading-gif');
+          let data = [];
+          responseData.forEach((user) => {
+            data.push({
+              id: user.ID,
+              name: user.name,
+              type: postType,
+              avatar: user.avatar,
+            });
+            callback.call(this, data);
+          });
+        })
+        .catch((err) => {
+          console.error(err);
+        });
+    },
+    templates: {
+      mentionItemSyntax: function (data) {
+        return `[${data.value}](${data.id})`;
+      },
+    },
+    showAvatars: true,
+    minChars: 0,
+  });
+
+  let getMentionedUsers = (callback) => {
+    $('textarea.mention').mentionsInput('getMentions', function (data) {
       callback(data);
     });
-  }
+  };
 
-  let getCommentWithMentions = (callback)=>{
-    $('textarea.mention').mentionsInput('val', function(text) {
+  let getCommentWithMentions = (callback) => {
+    $('textarea.mention').mentionsInput('val', function (text) {
       callback(text);
     });
-  }
+  };
 
   //
   $(document).on('click', '.revert-activity', function () {
-    let id = $(this).data('id')
-    $("#revert-modal").foundation('open')
-    $("#confirm-revert").data("id", id)
-    window.API.get_single_activity(postType, postId, id).then(a => {
-      let field = a.meta_key
-      if (window.detailsSettings.post_settings){
-        field = window.lodash.get(window.detailsSettings, `post_settings.fields[${a.meta_key}].name`)
-      }
+    let id = $(this).data('id');
+    $('#revert-modal').foundation('open');
+    $('#confirm-revert').data('id', id);
+    window.API.get_single_activity(postType, postId, id)
+      .then((a) => {
+        let field = a.meta_key;
+        if (window.detailsSettings.post_settings) {
+          field = window.lodash.get(
+            window.detailsSettings,
+            `post_settings.fields[${a.meta_key}].name`,
+          );
+        }
 
-      $(".revert-field").html(field || a.meta_key)
-      $(".revert-current-value").html(a.meta_value)
-      $(".revert-old-value").html(a.old_value || 0)
-    }).catch(err => { console.error(err) })
-  })
+        $('.revert-field').html(field || a.meta_key);
+        $('.revert-current-value').html(a.meta_value);
+        $('.revert-old-value').html(a.old_value || 0);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  });
 
   // confirm going back to the old version on the activity
-  $('#confirm-revert').on("click", function () {
-    let id = $(this).data('id')
-    window.API.revert_activity(postType, postId, id).then(contactResponse => {
-      refreshActivity()
-      $("#revert-modal").foundation('close')
-      if (typeof refresh_quick_action_buttons === 'function'){
-        window.refresh_quick_action_buttons(contactResponse)
-      }
-    }).catch(err => { console.error(err) })
-  })
+  $('#confirm-revert').on('click', function () {
+    let id = $(this).data('id');
+    window.API.revert_activity(postType, postId, id)
+      .then((contactResponse) => {
+        refreshActivity();
+        $('#revert-modal').foundation('close');
+        if (typeof refresh_quick_action_buttons === 'function') {
+          window.refresh_quick_action_buttons(contactResponse);
+        }
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  });
 
-  window.onbeforeunload = function() {
-    if ( $('textarea.mention').val() ){
+  window.onbeforeunload = function () {
+    if ($('textarea.mention').val()) {
       return true;
     }
   };
-
 });

--- a/dt-assets/js/details.js
+++ b/dt-assets/js/details.js
@@ -1,42 +1,48 @@
-"use strict";
-jQuery(document).ready(function($) {
-  let post_id = window.detailsSettings.post_id
-  let post_type = window.detailsSettings.post_type
-  let post = window.detailsSettings.post_fields
-  let post_settings = window.detailsSettings.post_settings
-  let field_settings = window.detailsSettings.post_settings.fields
-  window.post_type_fields = field_settings
-  let rest_api = window.API
-  let typeaheadTotals = {}
+'use strict';
+jQuery(document).ready(function ($) {
+  let post_id = window.detailsSettings.post_id;
+  let post_type = window.detailsSettings.post_type;
+  let post = window.detailsSettings.post_fields;
+  let post_settings = window.detailsSettings.post_settings;
+  let field_settings = window.detailsSettings.post_settings.fields;
+  window.post_type_fields = field_settings;
+  let rest_api = window.API;
+  let typeaheadTotals = {};
   let current_record = -1;
-  let next_record    = -1;
-  let records_list   = window.SHAREDFUNCTIONS.get_json_cookie('records_list');
+  let next_record = -1;
+  let records_list = window.SHAREDFUNCTIONS.get_json_cookie('records_list');
 
-
-  window.masonGrid = $('.grid') // responsible for resizing and moving the tiles
+  window.masonGrid = $('.grid'); // responsible for resizing and moving the tiles
   window.masonGrid.masonry({
     itemSelector: '.grid-item',
     columnWidth: '.grid-item:not(.hidden-grid-item)',
-    percentPosition: true
+    percentPosition: true,
   });
 
-  const detailsBarCreatedOnElements = document.querySelectorAll('.details-bar-created-on')
+  const detailsBarCreatedOnElements = document.querySelectorAll(
+    '.details-bar-created-on',
+  );
   detailsBarCreatedOnElements.forEach((element) => {
-    const postDate = post.post_date.timestamp
-    const formattedDate = window.SHAREDFUNCTIONS.formatDate(postDate)
-    element.innerHTML = window.SHAREDFUNCTIONS.escapeHTML( window.detailsSettings.translations.created_on.replace('%s', formattedDate) )
-  })
+    const postDate = post.post_date.timestamp;
+    const formattedDate = window.SHAREDFUNCTIONS.formatDate(postDate);
+    element.innerHTML = window.SHAREDFUNCTIONS.escapeHTML(
+      window.detailsSettings.translations.created_on.replace(
+        '%s',
+        formattedDate,
+      ),
+    );
+  });
 
-  const updateTextMetaOnChange = updateTextMeta()
-  $('input.text-input').change(updateTextMetaOnChange)
-  $('input.text-input').blur(updateTextMetaOnChange)
+  const updateTextMetaOnChange = updateTextMeta();
+  $('input.text-input').change(updateTextMetaOnChange);
+  $('input.text-input').blur(updateTextMetaOnChange);
 
   function updateTextMeta() {
-    let isUpdating = false
+    let isUpdating = false;
 
-    return function() {
-      if (isUpdating) return
-      isUpdating = true
+    return function () {
+      if (isUpdating) return;
+      isUpdating = true;
 
       const id = $(this).attr('id');
       if ($(this).prop('required') && $(this).val() === '') {
@@ -49,36 +55,38 @@ jQuery(document).ready(function($) {
       const max = parseInt(this.max);
 
       if (min && intVal < min) {
-        $(this).val(this.min)
-        val = parseInt(this.min)
+        $(this).val(this.min);
+        val = parseInt(this.min);
       }
       if (max && intVal > max) {
-        $(this).val(this.max)
-        val = parseInt(this.max)
+        $(this).val(this.max);
+        val = parseInt(this.max);
       }
 
       $(`#${id}-spinner`).addClass('active');
-      rest_api.update_post(post_type, post_id, { [id]: val }).then((newPost) => {
-        $(`#${id}-spinner`).removeClass('active');
-        $(document).trigger("text-input-updated", [newPost, id, val]);
-        isUpdating = false
-      }).catch((error) => {
-        window.handleAjaxError(error)
-        isUpdating = false
-      })
-    }
+      rest_api
+        .update_post(post_type, post_id, { [id]: val })
+        .then((newPost) => {
+          $(`#${id}-spinner`).removeClass('active');
+          $(document).trigger('text-input-updated', [newPost, id, val]);
+          isUpdating = false;
+        })
+        .catch((error) => {
+          window.handleAjaxError(error);
+          isUpdating = false;
+        });
+    };
   }
 
-
   /* breadcrumb: new-field-type Update record */
-  $('input.link-input').change(function(){
+  $('input.link-input').change(function () {
     const link_input = $(this);
-    const fieldKey = $(link_input).data('field-key')
-    const type = $(link_input).data('type')
-    const meta_id = $(link_input).data('meta-id')
-    const value = $(link_input).val()
+    const fieldKey = $(link_input).data('field-key');
+    const type = $(link_input).data('type');
+    const meta_id = $(link_input).data('meta-id');
+    const value = $(link_input).val();
 
-    if ( $(link_input).prop('required') && value === ''){
+    if ($(link_input).prop('required') && value === '') {
       return;
     }
 
@@ -88,381 +96,466 @@ jQuery(document).ready(function($) {
           value,
           type,
           meta_id,
+        },
+      ],
+    };
+    $(`#${fieldKey}-spinner`).addClass('active');
+    rest_api
+      .update_post(post_type, post_id, { [fieldKey]: fieldValues })
+      .then((newPost) => {
+        $(`#${fieldKey}-spinner`).removeClass('active');
+        post = newPost;
+
+        // Make sure a key exists for the new link field.
+        if (post && post[fieldKey] && post[fieldKey].length > 0) {
+          let updated_values = post[fieldKey].filter((option) => {
+            return option['type'] === type && option['value'] === value;
+          });
+
+          // This ensures any immediate updates, are assigned to correct link input and not to a new/duplicated input field.
+          if (
+            updated_values &&
+            updated_values[0] &&
+            updated_values[0]['meta_id']
+          ) {
+            $(link_input).data('meta-id', updated_values[0]['meta_id']);
+          }
         }
-      ]
-    }
-    $(`#${fieldKey}-spinner`).addClass('active')
-    rest_api.update_post(post_type, post_id, { [fieldKey]: fieldValues }).then((newPost)=>{
-      $(`#${fieldKey}-spinner`).removeClass('active')
-      post = newPost
-
-      // Make sure a key exists for the new link field.
-      if ( post && post[fieldKey] && post[fieldKey].length > 0 ) {
-        let updated_values = post[fieldKey].filter((option) => {
-          return (option['type'] === type) && (option['value'] === value);
-        });
-
-        // This ensures any immediate updates, are assigned to correct link input and not to a new/duplicated input field.
-        if (updated_values && updated_values[0] && updated_values[0]['meta_id']) {
-          $(link_input).data('meta-id', updated_values[0]['meta_id']);
-        }
-      }
-
-    }).catch(window.handleAjaxError)
-  })
-
-  $('.dt_textarea').change(function(){
-    const id = $(this).attr('id')
-    const val = $(this).val()
-    $(`#${id}-spinner`).addClass('active')
-    rest_api.update_post(post_type, post_id, { [id]: val }).then((newPost)=>{
-      $(`#${id}-spinner`).removeClass('active')
-      $( document ).trigger( "textarea-updated", [ newPost, id, val ] );
-    }).catch(window.handleAjaxError)
-  })
-
-  $('button.dt_multi_select').on('click',function () {
-    let fieldKey = $(this).data("field-key")
-    let optionKey = $(this).val()
-    let fieldValue = {}
-    let data = {}
-    let field = jQuery(`[data-field-key="${fieldKey}"][value="${optionKey}"]`)
-    field.addClass("submitting-select-button")
-    let action = "add"
-    if (field.hasClass("selected-select-button")){
-      fieldValue.values = [{value:optionKey,delete:true}]
-      action = "delete"
-    } else {
-      field.removeClass("empty-select-button")
-      field.addClass("selected-select-button")
-      fieldValue.values = [{value:optionKey}]
-    }
-    data[optionKey] = fieldValue
-    $(`#${fieldKey}-spinner`).addClass('active')
-    rest_api.update_post(post_type, post_id, {[fieldKey]: fieldValue}).then((resp)=>{
-      $(`#${fieldKey}-spinner`).removeClass('active')
-      field.removeClass("submitting-select-button selected-select-button")
-      field.blur();
-      field.addClass( action === "delete" ? "empty-select-button" : "selected-select-button");
-      $( document ).trigger( "dt_multi_select-updated", [ resp, fieldKey, optionKey, action ] );
-    }).catch(err=>{
-      field.removeClass("submitting-select-button selected-select-button")
-      field.addClass( action === "add" ? "empty-select-button" : "selected-select-button")
-      window.handleAjaxError(err)
-    })
-  })
-
-  $('.dt_date_group .dt_date_picker').datepicker({
-    constrainInput: false,
-    dateFormat: 'yy-mm-dd',
-    onClose: function (date) {
-      date = window.SHAREDFUNCTIONS.convertArabicToEnglishNumbers(date);
-
-      if (!$(this).val()) {
-        date = " ";//null;
-      }
-
-      let id = $(this).attr('id')
-      $(`#${id}-spinner`).addClass('active')
-      rest_api.update_post( post_type, post_id, { [id]: window.moment.utc(date).unix() }).then((resp)=>{
-        $(`#${id}-spinner`).removeClass('active')
-        if (this.value) {
-          this.value = window.SHAREDFUNCTIONS.formatDate(resp[id]["timestamp"], false, false, );
-        }
-        $( document ).trigger( "dt_date_picker-updated", [ resp, id, date ] );
-      }).catch(window.handleAjaxError)
-    },
-    changeMonth: true,
-    changeYear: true,
-    yearRange: "1900:2050",
-  }).each(function() {
-    if (this.value && window.moment.unix(this.value).isValid()) {
-      this.value = window.SHAREDFUNCTIONS.formatDate(this.value);
-    }
-  })
-
-
-  $('.dt_date_time_group').each(function setTimePickers() {
-    const timestamp = this.dataset.timestamp
-
-    const timePicker = $(this).children('.dt_time_picker')
-
-    if ( timePicker ) {
-      timePicker.val(toTimeInputFormat(timestamp))
-    }
-  })
-
-  function toTimeInputFormat(timestamp) {
-      const date = window.moment( Number(timestamp) * 1000 )
-      return date.format('HH:mm')
-  }
-
-  $('.dt_date_time_group .dt_date_picker').datepicker({
-    constrainInput: false,
-    dateFormat: 'yy-mm-dd',
-    onClose: function (date) {
-      date = window.SHAREDFUNCTIONS.convertArabicToEnglishNumbers(date);
-
-      if (!$(this).val()) {
-        date = " ";//null;
-      }
-
-      let id = $(this).attr('id')
-
-      const dateTimeGroup = $(`.${id}.dt_date_time_group`)
-      const currentTimestamp = dateTimeGroup.data('timestamp')
-
-      const currentDateTime = window.moment(currentTimestamp * 1000)
-      const hours = currentDateTime.get('h')
-      const minutes = currentDateTime.get('m')
-
-      const updatedTimestamp = window.moment(date).set({ h: hours, m: minutes }).unix()
-
-      dateTimeGroup.data('timestamp', updatedTimestamp)
-
-      $(`#${id}-spinner`).addClass('active')
-      rest_api.update_post( post_type, post_id, { [id]: updatedTimestamp }).then((resp)=>{
-        $(`#${id}-spinner`).removeClass('active')
-        if (this.value) {
-          this.value = window.SHAREDFUNCTIONS.formatDate(resp[id]["timestamp"], false, false, true);
-        }
-        $( document ).trigger( "dt_date_picker-updated", [ resp, id, date ] );
-      }).catch(window.handleAjaxError)
-    },
-    changeMonth: true,
-    changeYear: true,
-    yearRange: "1900:2050",
-  }).each(function() {
-    if (this.value && window.moment.unix(this.value).isValid()) {
-      this.value = window.SHAREDFUNCTIONS.formatDate(this.value, false, false, true);
-    }
-  })
-
-  $('.dt_time_picker').on('blur' ,function() {
-    const fieldId = this.dataset.fieldId
-
-    const dateTimeGroup = $(`.${fieldId}.dt_date_time_group`)
-
-    const timestamp = dateTimeGroup.data('timestamp')
-    const [ hours, minutes ] = this.value.split(':')
-
-    const updatedTimestamp = window.moment(timestamp * 1000).set({ h: hours, m: minutes }).unix()
-
-    dateTimeGroup.data('timestamp', updatedTimestamp)
-
-    $(`#${fieldId}-spinner`).addClass('active')
-    rest_api.update_post( post_type, post_id, { [fieldId]: updatedTimestamp }).then((resp)=>{
-      $(`#${fieldId}-spinner`).removeClass('active')
-      $( document ).trigger( "dt_datetime_picker-updated", [ resp, fieldId, updatedTimestamp ] );
-    }).catch(window.handleAjaxError)
-
-  })
-
-
-  let mcleardate = $(".clear-date-button");
-  mcleardate.click(function() {
-    let input_id = this.dataset.inputid;
-    $(`#${input_id}`).val("");
-    let date = null;
-    $(`#${input_id}-spinner`).addClass('active')
-    rest_api.update_post(post_type, post_id, { [input_id]: date }).then((resp) => {
-      $(`#${input_id}-spinner`).removeClass('active')
-      $(document).trigger("dt_date_picker-updated", [resp, input_id, date]);
-
-    }).catch(window.handleAjaxError)
+      })
+      .catch(window.handleAjaxError);
   });
 
-  $('select.select-field').change(e => {
-    const id = $(e.currentTarget).attr('id')
-    const val = $(e.currentTarget).val()
-    $(`#${id}-spinner`).addClass('active')
+  $('.dt_textarea').change(function () {
+    const id = $(this).attr('id');
+    const val = $(this).val();
+    $(`#${id}-spinner`).addClass('active');
+    rest_api
+      .update_post(post_type, post_id, { [id]: val })
+      .then((newPost) => {
+        $(`#${id}-spinner`).removeClass('active');
+        $(document).trigger('textarea-updated', [newPost, id, val]);
+      })
+      .catch(window.handleAjaxError);
+  });
 
-    rest_api.update_post(post_type, post_id, { [id]: val }).then(resp => {
-      $(`#${id}-spinner`).removeClass('active')
-      $( document ).trigger( "select-field-updated", [ resp, id, val ] );
-      if ( $(e.currentTarget).hasClass( "color-select")){
-        $(`#${id}`).css("background-color", window.lodash.get(window.detailsSettings, `post_settings.fields[${id}].default[${val}].color`) )
+  $('button.dt_multi_select').on('click', function () {
+    let fieldKey = $(this).data('field-key');
+    let optionKey = $(this).val();
+    let fieldValue = {};
+    let data = {};
+    let field = jQuery(`[data-field-key="${fieldKey}"][value="${optionKey}"]`);
+    field.addClass('submitting-select-button');
+    let action = 'add';
+    if (field.hasClass('selected-select-button')) {
+      fieldValue.values = [{ value: optionKey, delete: true }];
+      action = 'delete';
+    } else {
+      field.removeClass('empty-select-button');
+      field.addClass('selected-select-button');
+      fieldValue.values = [{ value: optionKey }];
+    }
+    data[optionKey] = fieldValue;
+    $(`#${fieldKey}-spinner`).addClass('active');
+    rest_api
+      .update_post(post_type, post_id, { [fieldKey]: fieldValue })
+      .then((resp) => {
+        $(`#${fieldKey}-spinner`).removeClass('active');
+        field.removeClass('submitting-select-button selected-select-button');
+        field.blur();
+        field.addClass(
+          action === 'delete'
+            ? 'empty-select-button'
+            : 'selected-select-button',
+        );
+        $(document).trigger('dt_multi_select-updated', [
+          resp,
+          fieldKey,
+          optionKey,
+          action,
+        ]);
+      })
+      .catch((err) => {
+        field.removeClass('submitting-select-button selected-select-button');
+        field.addClass(
+          action === 'add' ? 'empty-select-button' : 'selected-select-button',
+        );
+        window.handleAjaxError(err);
+      });
+  });
+
+  $('.dt_date_group .dt_date_picker')
+    .datepicker({
+      constrainInput: false,
+      dateFormat: 'yy-mm-dd',
+      onClose: function (date) {
+        date = window.SHAREDFUNCTIONS.convertArabicToEnglishNumbers(date);
+
+        if (!$(this).val()) {
+          date = ' '; //null;
+        }
+
+        let id = $(this).attr('id');
+        $(`#${id}-spinner`).addClass('active');
+        rest_api
+          .update_post(post_type, post_id, {
+            [id]: window.moment.utc(date).unix(),
+          })
+          .then((resp) => {
+            $(`#${id}-spinner`).removeClass('active');
+            if (this.value) {
+              this.value = window.SHAREDFUNCTIONS.formatDate(
+                resp[id]['timestamp'],
+                false,
+                false,
+              );
+            }
+            $(document).trigger('dt_date_picker-updated', [resp, id, date]);
+          })
+          .catch(window.handleAjaxError);
+      },
+      changeMonth: true,
+      changeYear: true,
+      yearRange: '1900:2050',
+    })
+    .each(function () {
+      if (this.value && window.moment.unix(this.value).isValid()) {
+        this.value = window.SHAREDFUNCTIONS.formatDate(this.value);
       }
-    }).catch(window.handleAjaxError)
-  })
+    });
 
-  $('input.number-input').on("blur", function(){
-    const id = $(this).attr('id')
-    const val = $(this).val()
-    $(`#${id}-spinner`).addClass('active')
-    rest_api.update_post(post_type, post_id, { [id]: val }).then((resp)=>{
-      $(`#${id}-spinner`).removeClass('active')
-      $( document ).trigger( "number-input-updated", [ resp, id, val ] );
-    }).catch(window.handleAjaxError)
-  })
+  $('.dt_date_time_group').each(function setTimePickers() {
+    const timestamp = this.dataset.timestamp;
 
-  $('.dt_contenteditable').on('blur', function(){
-    const id = $(this).attr('id')
+    const timePicker = $(this).children('.dt_time_picker');
+
+    if (timePicker) {
+      timePicker.val(toTimeInputFormat(timestamp));
+    }
+  });
+
+  function toTimeInputFormat(timestamp) {
+    const date = window.moment(Number(timestamp) * 1000);
+    return date.format('HH:mm');
+  }
+
+  $('.dt_date_time_group .dt_date_picker')
+    .datepicker({
+      constrainInput: false,
+      dateFormat: 'yy-mm-dd',
+      onClose: function (date) {
+        date = window.SHAREDFUNCTIONS.convertArabicToEnglishNumbers(date);
+
+        if (!$(this).val()) {
+          date = ' '; //null;
+        }
+
+        let id = $(this).attr('id');
+
+        const dateTimeGroup = $(`.${id}.dt_date_time_group`);
+        const currentTimestamp = dateTimeGroup.data('timestamp');
+
+        const currentDateTime = window.moment(currentTimestamp * 1000);
+        const hours = currentDateTime.get('h');
+        const minutes = currentDateTime.get('m');
+
+        const updatedTimestamp = window
+          .moment(date)
+          .set({ h: hours, m: minutes })
+          .unix();
+
+        dateTimeGroup.data('timestamp', updatedTimestamp);
+
+        $(`#${id}-spinner`).addClass('active');
+        rest_api
+          .update_post(post_type, post_id, { [id]: updatedTimestamp })
+          .then((resp) => {
+            $(`#${id}-spinner`).removeClass('active');
+            if (this.value) {
+              this.value = window.SHAREDFUNCTIONS.formatDate(
+                resp[id]['timestamp'],
+                false,
+                false,
+                true,
+              );
+            }
+            $(document).trigger('dt_date_picker-updated', [resp, id, date]);
+          })
+          .catch(window.handleAjaxError);
+      },
+      changeMonth: true,
+      changeYear: true,
+      yearRange: '1900:2050',
+    })
+    .each(function () {
+      if (this.value && window.moment.unix(this.value).isValid()) {
+        this.value = window.SHAREDFUNCTIONS.formatDate(
+          this.value,
+          false,
+          false,
+          true,
+        );
+      }
+    });
+
+  $('.dt_time_picker').on('blur', function () {
+    const fieldId = this.dataset.fieldId;
+
+    const dateTimeGroup = $(`.${fieldId}.dt_date_time_group`);
+
+    const timestamp = dateTimeGroup.data('timestamp');
+    const [hours, minutes] = this.value.split(':');
+
+    const updatedTimestamp = window
+      .moment(timestamp * 1000)
+      .set({ h: hours, m: minutes })
+      .unix();
+
+    dateTimeGroup.data('timestamp', updatedTimestamp);
+
+    $(`#${fieldId}-spinner`).addClass('active');
+    rest_api
+      .update_post(post_type, post_id, { [fieldId]: updatedTimestamp })
+      .then((resp) => {
+        $(`#${fieldId}-spinner`).removeClass('active');
+        $(document).trigger('dt_datetime_picker-updated', [
+          resp,
+          fieldId,
+          updatedTimestamp,
+        ]);
+      })
+      .catch(window.handleAjaxError);
+  });
+
+  let mcleardate = $('.clear-date-button');
+  mcleardate.click(function () {
+    let input_id = this.dataset.inputid;
+    $(`#${input_id}`).val('');
+    let date = null;
+    $(`#${input_id}-spinner`).addClass('active');
+    rest_api
+      .update_post(post_type, post_id, { [input_id]: date })
+      .then((resp) => {
+        $(`#${input_id}-spinner`).removeClass('active');
+        $(document).trigger('dt_date_picker-updated', [resp, input_id, date]);
+      })
+      .catch(window.handleAjaxError);
+  });
+
+  $('select.select-field').change((e) => {
+    const id = $(e.currentTarget).attr('id');
+    const val = $(e.currentTarget).val();
+    $(`#${id}-spinner`).addClass('active');
+
+    rest_api
+      .update_post(post_type, post_id, { [id]: val })
+      .then((resp) => {
+        $(`#${id}-spinner`).removeClass('active');
+        $(document).trigger('select-field-updated', [resp, id, val]);
+        if ($(e.currentTarget).hasClass('color-select')) {
+          $(`#${id}`).css(
+            'background-color',
+            window.lodash.get(
+              window.detailsSettings,
+              `post_settings.fields[${id}].default[${val}].color`,
+            ),
+          );
+        }
+      })
+      .catch(window.handleAjaxError);
+  });
+
+  $('input.number-input').on('blur', function () {
+    const id = $(this).attr('id');
+    const val = $(this).val();
+    $(`#${id}-spinner`).addClass('active');
+    rest_api
+      .update_post(post_type, post_id, { [id]: val })
+      .then((resp) => {
+        $(`#${id}-spinner`).removeClass('active');
+        $(document).trigger('number-input-updated', [resp, id, val]);
+      })
+      .catch(window.handleAjaxError);
+  });
+
+  $('.dt_contenteditable').on('blur', function () {
+    const id = $(this).attr('id');
     let val = $(this).text();
-    if ( id === "title" && val === '' ){
+    if (id === 'title' && val === '') {
       return;
     }
-    rest_api.update_post(post_type, post_id, { [id]: val }).then((resp)=>{
-      $( document ).trigger( "contenteditable-updated", [ resp, id, val ] );
-    }).catch(window.handleAjaxError)
-  })
+    rest_api
+      .update_post(post_type, post_id, { [id]: val })
+      .then((resp) => {
+        $(document).trigger('contenteditable-updated', [resp, id, val]);
+      })
+      .catch(window.handleAjaxError);
+  });
 
   // Clicking the plus sign next to the field label
-  $('button.add-button').on('click', e => {
-    const field = $(e.currentTarget).data('list-class')
-    const $list = $(`#edit-${field}`)
+  $('button.add-button').on('click', (e) => {
+    const field = $(e.currentTarget).data('list-class');
+    const $list = $(`#edit-${field}`);
 
     $list.append(`<div class="input-group">
-          <input type="text" data-field="${window.SHAREDFUNCTIONS.escapeHTML( field )}" class="dt-communication-channel input-group-field" dir="auto" />
+          <input type="text" data-field="${window.SHAREDFUNCTIONS.escapeHTML(field)}" class="dt-communication-channel input-group-field" dir="auto" />
           <div class="input-group-button">
-          <button class="button alert input-height delete-button-style channel-delete-button delete-button new-${window.SHAREDFUNCTIONS.escapeHTML( field )}" data-key="new" data-field="${window.SHAREDFUNCTIONS.escapeHTML( field )}">&times;</button>
-          </div></div>`)
-   })
+          <button class="button alert input-height delete-button-style channel-delete-button delete-button new-${window.SHAREDFUNCTIONS.escapeHTML(field)}" data-key="new" data-field="${window.SHAREDFUNCTIONS.escapeHTML(field)}">&times;</button>
+          </div></div>`);
+  });
 
-  $('.add-link-dropdown[data-only-one-option]').on('click', window.SHAREDFUNCTIONS.addLink)
+  $('.add-link-dropdown[data-only-one-option]').on(
+    'click',
+    window.SHAREDFUNCTIONS.addLink,
+  );
 
   $('.add-link__option').on('click', (event) => {
-    window.SHAREDFUNCTIONS.addLink(event)
-    $(event.target).parent().hide()
+    window.SHAREDFUNCTIONS.addLink(event);
+    $(event.target).parent().hide();
     setTimeout(() => {
-      event.target.parentElement.removeAttribute('style')
-    }, 100)
-  })
+      event.target.parentElement.removeAttribute('style');
+    }, 100);
+  });
 
-  $(document).on('click', '.channel-delete-button', function(){
-    let field = $(this).data('field')
-    let key = $(this).data('key')
-    let update = { delete:true }
-    if ( key === 'new' ){
-      $(this).parent().remove()
-    } else if ( key ){
-      $(`#${field}-spinner`).addClass('active')
-      update["key"] = key;
-      window.API.update_post(post_type, post_id, { [field]: [update]}).then((updatedContact)=>{
-        $(this).parent().parent().remove()
-        let list = $(`#edit-${field}`)
-        if ( list.children().length === 0 ){
-          list.append(`<div class="input-group">
-            <input type="text" data-field="${window.SHAREDFUNCTIONS.escapeHTML( field )}" class="dt-communication-channel input-group-field" dir="auto" />
-            </div>`)
-        }
-        $(`#${field}-spinner`).removeClass('active')
-        post = updatedContact
-        resetDetailsFields()
-      }).catch(window.handleAjaxError)
+  $(document).on('click', '.channel-delete-button', function () {
+    let field = $(this).data('field');
+    let key = $(this).data('key');
+    let update = { delete: true };
+    if (key === 'new') {
+      $(this).parent().remove();
+    } else if (key) {
+      $(`#${field}-spinner`).addClass('active');
+      update['key'] = key;
+      window.API.update_post(post_type, post_id, { [field]: [update] })
+        .then((updatedContact) => {
+          $(this).parent().parent().remove();
+          let list = $(`#edit-${field}`);
+          if (list.children().length === 0) {
+            list.append(`<div class="input-group">
+            <input type="text" data-field="${window.SHAREDFUNCTIONS.escapeHTML(field)}" class="dt-communication-channel input-group-field" dir="auto" />
+            </div>`);
+          }
+          $(`#${field}-spinner`).removeClass('active');
+          post = updatedContact;
+          resetDetailsFields();
+        })
+        .catch(window.handleAjaxError);
     }
-  })
+  });
 
-  $(document).on('click', '.link-delete-button', function(){
-    let metaId = $(this).data('meta-id')
-    let fieldKey = $(this).data('field-key')
+  $(document).on('click', '.link-delete-button', function () {
+    let metaId = $(this).data('meta-id');
+    let fieldKey = $(this).data('field-key');
 
-    $(this).closest('.input-group').remove()
+    $(this).closest('.input-group').remove();
 
-    if (!metaId || metaId === "") {
-      return
+    if (!metaId || metaId === '') {
+      return;
     }
 
-    $(`#${fieldKey}-spinner`).addClass('active')
+    $(`#${fieldKey}-spinner`).addClass('active');
 
     const update = {
       values: [
         {
           delete: true,
           meta_id: metaId,
-        }
-      ]
-    }
+        },
+      ],
+    };
 
-    window.API.update_post(post_type, post_id, { [fieldKey]: update }).then((updatedContact)=>{
-      $(`#${fieldKey}-spinner`).removeClass('active')
-      post = updatedContact
-      resetDetailsFields()
-    }).catch(window.handleAjaxError)
-  })
+    window.API.update_post(post_type, post_id, { [fieldKey]: update })
+      .then((updatedContact) => {
+        $(`#${fieldKey}-spinner`).removeClass('active');
+        post = updatedContact;
+        resetDetailsFields();
+      })
+      .catch(window.handleAjaxError);
+  });
 
-  $(document).on('blur', 'input.dt-communication-channel', function(){
-    let field_key = $(this).data('field')
-    let value = $(this).val()
-    let id = $(this).attr('id')
-    let update = { value }
-    if ( id ) {
-      update["key"] = id;
+  $(document).on('blur', 'input.dt-communication-channel', function () {
+    let field_key = $(this).data('field');
+    let value = $(this).val();
+    let id = $(this).attr('id');
+    let update = { value };
+    if (id) {
+      update['key'] = id;
     }
-    if ( !value && !id ){
+    if (!value && !id) {
       return;
     }
-    $(`#${field_key}-spinner`).addClass('active')
-    window.API.update_post(post_type, post_id, { [field_key]: [update]}).then((updatedContact)=>{
-      $(`#${field_key}-spinner`).removeClass('active')
-      let key = window.lodash.last(updatedContact[field_key]).key
-      $(this).attr('id', key)
-      if ( $(this).next('div.input-group-button').length === 1 ) {
-        $(this).parent().find('.channel-delete-button').data('key', key)
-      } else {
-        $(this).parent().append(`<div class="input-group-button">
-            <button class="button alert delete-button-style input-height channel-delete-button delete-button" data-key="${window.SHAREDFUNCTIONS.escapeHTML( key )}" data-field="${window.SHAREDFUNCTIONS.escapeHTML( field_key )}">&times;</button>
-        </div>`)
-      }
-      post = updatedContact
-      resetDetailsFields()
-    }).catch(window.handleAjaxError)
-  })
+    $(`#${field_key}-spinner`).addClass('active');
+    window.API.update_post(post_type, post_id, { [field_key]: [update] })
+      .then((updatedContact) => {
+        $(`#${field_key}-spinner`).removeClass('active');
+        let key = window.lodash.last(updatedContact[field_key]).key;
+        $(this).attr('id', key);
+        if ($(this).next('div.input-group-button').length === 1) {
+          $(this).parent().find('.channel-delete-button').data('key', key);
+        } else {
+          $(this).parent().append(`<div class="input-group-button">
+            <button class="button alert delete-button-style input-height channel-delete-button delete-button" data-key="${window.SHAREDFUNCTIONS.escapeHTML(key)}" data-field="${window.SHAREDFUNCTIONS.escapeHTML(field_key)}">&times;</button>
+        </div>`);
+        }
+        post = updatedContact;
+        resetDetailsFields();
+      })
+      .catch(window.handleAjaxError);
+  });
 
-  $( document ).on( 'select-field-updated', function (e, newContact, id, val) {
-  })
+  $(document).on('select-field-updated', function (e, newContact, id, val) {});
 
-  $( document ).on( 'text-input-updated', function (e, newContact, id, val){
-    if ( id === "name" ){
-      $("#title").html(window.SHAREDFUNCTIONS.escapeHTML(val))
-      $("#second-bar-name").text(window.SHAREDFUNCTIONS.escapeHTML(val))
+  $(document).on('text-input-updated', function (e, newContact, id, val) {
+    if (id === 'name') {
+      $('#title').html(window.SHAREDFUNCTIONS.escapeHTML(val));
+      $('#second-bar-name').text(window.SHAREDFUNCTIONS.escapeHTML(val));
     }
-  })
+  });
 
-  $( document ).on( 'contenteditable-updated', function (e, newContact, id, val){
-    if ( id === "title" ){
-      $("#name").val(window.SHAREDFUNCTIONS.escapeHTML(val))
-      $("#second-bar-name").text(window.SHAREDFUNCTIONS.escapeHTML(val))
+  $(document).on('contenteditable-updated', function (e, newContact, id, val) {
+    if (id === 'title') {
+      $('#name').val(window.SHAREDFUNCTIONS.escapeHTML(val));
+      $('#second-bar-name').text(window.SHAREDFUNCTIONS.escapeHTML(val));
     }
-  })
+  });
 
-  $( document ).on( 'dt_date_picker-updated', function (e, newContact, id, date){
-  })
+  $(document).on(
+    'dt_date_picker-updated',
+    function (e, newContact, id, date) {},
+  );
 
-  $( document ).on( 'dt_multi_select-updated', function (e, newContact, fieldKey, optionKey, action) {
-  })
+  $(document).on(
+    'dt_multi_select-updated',
+    function (e, newContact, fieldKey, optionKey, action) {},
+  );
 
-  $( document ).on( 'dt_record_updated', function (e, response, request ){
+  $(document).on('dt_record_updated', function (e, response, request) {
     post = response;
-    resetDetailsFields()
-    record_updated(window.lodash.get(response, "requires_update", false));
-
-  })
-
-
+    resetDetailsFields();
+    record_updated(window.lodash.get(response, 'requires_update', false));
+  });
 
   /**
    * Update Needed
    */
   $('.update-needed.dt-switch').change(function () {
-    let updateNeeded = $(this).is(':checked')
-    window.API.update_post( post_type, post_id, {"requires_update":updateNeeded}).then(resp=>{
-      post = resp
-    })
-  })
+    let updateNeeded = $(this).is(':checked');
+    window.API.update_post(post_type, post_id, {
+      requires_update: updateNeeded,
+    }).then((resp) => {
+      post = resp;
+    });
+  });
 
-
-
-  $('.show-details-section').on( "click", function (){
-    $('#details-section').toggle()
-    $('#show-details-edit-button').toggle()
-    $(`#details-section .typeahead__query input`).each((i, element)=>{
-      let field_key = $(element).data("field")
-      if ( window.Typeahead[`.js-typeahead-${field_key}`]){
-        window.Typeahead[`.js-typeahead-${field_key}`].adjustInputSize()
+  $('.show-details-section').on('click', function () {
+    $('#details-section').toggle();
+    $('#show-details-edit-button').toggle();
+    $(`#details-section .typeahead__query input`).each((i, element) => {
+      let field_key = $(element).data('field');
+      if (window.Typeahead[`.js-typeahead-${field_key}`]) {
+        window.Typeahead[`.js-typeahead-${field_key}`].adjustInputSize();
       }
-    })
-  })
+    });
+  });
 
   /**
    * Links
@@ -471,9 +564,9 @@ jQuery(document).ready(function($) {
   /**
    * user select typeahead
    */
-  $('.dt_user_select').each((key, el)=>{
-    let field_key = $(el).attr('id')
-    let user_input = $(`.js-typeahead-${field_key}`)
+  $('.dt_user_select').each((key, el) => {
+    let field_key = $(el).attr('id');
+    let user_input = $(`.js-typeahead-${field_key}`);
     $.typeahead({
       input: `.js-typeahead-${field_key}`,
       minLength: 0,
@@ -481,62 +574,81 @@ jQuery(document).ready(function($) {
       accent: true,
       searchOnFocus: true,
       source: window.TYPEAHEADS.typeaheadUserSource(),
-      templateValue: "{{name}}",
+      templateValue: '{{name}}',
       template: function (query, item) {
         return `<div class="assigned-to-row" dir="auto">
           <span>
               <span class="avatar"><img style="vertical-align: text-bottom" src="{{avatar}}"/></span>
-              ${window.SHAREDFUNCTIONS.escapeHTML( item.name )}
+              ${window.SHAREDFUNCTIONS.escapeHTML(item.name)}
           </span>
-          ${ item.status_color ? `<span class="status-square" style="background-color: ${window.SHAREDFUNCTIONS.escapeHTML(item.status_color)};">&nbsp;</span>` : '' }
-          ${ item.update_needed && item.update_needed > 0 ? `<span>
-            <img style="height: 12px;" src="${window.SHAREDFUNCTIONS.escapeHTML( window.wpApiShare.template_dir )}/dt-assets/images/broken.svg"/>
+          ${item.status_color ? `<span class="status-square" style="background-color: ${window.SHAREDFUNCTIONS.escapeHTML(item.status_color)};">&nbsp;</span>` : ''}
+          ${
+            item.update_needed && item.update_needed > 0
+              ? `<span>
+            <img style="height: 12px;" src="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.template_dir)}/dt-assets/images/broken.svg"/>
             <span style="font-size: 14px">${window.SHAREDFUNCTIONS.escapeHTML(item.update_needed)}</span>
-          </span>` : '' }
-        </div>`
+          </span>`
+              : ''
+          }
+        </div>`;
       },
       dynamic: true,
       hint: true,
-      emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.no_records_found),
+      emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(
+        window.wpApiShare.translations.no_records_found,
+      ),
       callback: {
-        onClick: function(node, a, item){
-          window.API.update_post(post_type, post_id, {[field_key]: 'user-' + item.ID}).then(function (response) {
-            window.lodash.set(post, field_key, response[field_key])
-            user_input.val(post[field_key].display)
-            user_input.blur()
-          }).catch(err => { console.error(err) })
+        onClick: function (node, a, item) {
+          window.API.update_post(post_type, post_id, {
+            [field_key]: 'user-' + item.ID,
+          })
+            .then(function (response) {
+              window.lodash.set(post, field_key, response[field_key]);
+              user_input.val(post[field_key].display);
+              user_input.blur();
+            })
+            .catch((err) => {
+              console.error(err);
+            });
         },
         onResult: function (node, query, result, resultCount) {
-          let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+          let text = window.TYPEAHEADS.typeaheadHelpText(
+            resultCount,
+            query,
+            result,
+          );
           $(`#${field_key}-result-container`).html(text);
         },
         onHideLayout: function () {
-          $(`.${field_key}-result-container`).html("");
+          $(`.${field_key}-result-container`).html('');
         },
         onReady: function (node) {
           //if the input is disabled don't allow clicks on the cancel button.
-          if($(node).attr('disabled') == 'disabled') {
-           let cancelButton = $(`#${el.id} .typeahead__cancel-button`);
-           cancelButton.css('pointerEvents','none');
-         }
-          if (window.lodash.get(post,  `${field_key}.display`)){
-            $(`.js-typeahead-${field_key}`).val(post[field_key].display)
+          if ($(node).attr('disabled') == 'disabled') {
+            let cancelButton = $(`#${el.id} .typeahead__cancel-button`);
+            cancelButton.css('pointerEvents', 'none');
           }
-        }
+          if (window.lodash.get(post, `${field_key}.display`)) {
+            $(`.js-typeahead-${field_key}`).val(post[field_key].display);
+          }
+        },
       },
     });
     $(`.search_${field_key}`).on('click', function () {
-      user_input.val("")
-      user_input.trigger('input.typeahead')
-      user_input.focus()
-    })
-  })
+      user_input.val('');
+      user_input.trigger('input.typeahead');
+      user_input.focus();
+    });
+  });
 
-
-  $('.dt_typeahead').each((key, el)=>{
-    let div_id = $(el).attr('id')
-    let field_id = $(`#${div_id} input`).data('field')
-    let listing_post_type = window.lodash.get(window.detailsSettings.post_settings.fields[field_id], "post_type", 'contacts')
+  $('.dt_typeahead').each((key, el) => {
+    let div_id = $(el).attr('id');
+    let field_id = $(`#${div_id} input`).data('field');
+    let listing_post_type = window.lodash.get(
+      window.detailsSettings.post_settings.fields[field_id],
+      'post_type',
+      'contacts',
+    );
     $.typeahead({
       input: `.js-typeahead-${field_id}`,
       minLength: 0,
@@ -545,113 +657,143 @@ jQuery(document).ready(function($) {
       searchOnFocus: $(el).hasClass('disabled') ? false : true,
       template: window.TYPEAHEADS.contactListRowTemplate,
       matcher: function (item) {
-        return parseInt(item.ID) !== parseInt(post_id)
+        return parseInt(item.ID) !== parseInt(post_id);
       },
       filter: function (item) {
-        return parseInt(item.ID) !== parseInt(post_id)
+        return parseInt(item.ID) !== parseInt(post_id);
       },
-      source: window.TYPEAHEADS.typeaheadPostsSource(listing_post_type, {field_key:field_id}),
-      display: ["name", "label"],
-      templateValue: function() {
-          if (this.items[this.items.length - 1].label) {
-            return "{{label}}"
-          } else {
-            return "{{name}}"
-          }
+      source: window.TYPEAHEADS.typeaheadPostsSource(listing_post_type, {
+        field_key: field_id,
+      }),
+      display: ['name', 'label'],
+      templateValue: function () {
+        if (this.items[this.items.length - 1].label) {
+          return '{{label}}';
+        } else {
+          return '{{name}}';
+        }
       },
       dynamic: true,
       multiselect: {
-        matchOn: ["ID"],
+        matchOn: ['ID'],
         data: function () {
-          return (post[field_id] || []).map(g => {
+          return (post[field_id] || []).map((g) => {
             return {
               ID: g.ID,
               name: g.post_title,
               label: g.label,
-              status: g['status'] ?? null
-            }
-          })
+              status: g['status'] ?? null,
+            };
+          });
         },
         callback: {
           onCancel: function (node, item) {
-            $(`#${field_id}-spinner`).addClass('active')
-            window.API.update_post(post_type, post_id, {[field_id]: {values:[{value:item.ID, delete:true}]}}).then(()=>{
-              $(`#${field_id}-spinner`).removeClass('active')
-            }).catch(err => { console.error(err) })
-          }
+            $(`#${field_id}-spinner`).addClass('active');
+            window.API.update_post(post_type, post_id, {
+              [field_id]: { values: [{ value: item.ID, delete: true }] },
+            })
+              .then(() => {
+                $(`#${field_id}-spinner`).removeClass('active');
+              })
+              .catch((err) => {
+                console.error(err);
+              });
+          },
         },
         href: function (item) {
-          return window.wpApiShare.site_url + `/${listing_post_type}/${item.ID}`
-        }
+          return (
+            window.wpApiShare.site_url + `/${listing_post_type}/${item.ID}`
+          );
+        },
       },
       callback: {
-        onReady: function(node) {
+        onReady: function (node) {
           //if the input is disabled don't allow clicks on the cancel button.
-           if($(node).attr('disabled') == 'disabled') {
+          if ($(node).attr('disabled') == 'disabled') {
             let cancelButton = $(`#${el.id} .typeahead__cancel-button`);
-            cancelButton.css('pointerEvents','none');
+            cancelButton.css('pointerEvents', 'none');
           }
 
           // If available, display item status colours within labels
           set_item_label_status(this);
         },
-        onClick: function(node, a, item, event){
-          $(`#${field_id}-spinner`).addClass('active')
-          window.API.update_post(post_type, post_id, {[field_id]: {values:[{"value":item.ID}]}}).then(new_post=>{
-            $(`#${field_id}-spinner`).removeClass('active')
-            $( document ).trigger( "dt-post-connection-added", [ new_post, field_id ] );
-          }).catch(err => { console.error(err) })
+        onClick: function (node, a, item, event) {
+          $(`#${field_id}-spinner`).addClass('active');
+          window.API.update_post(post_type, post_id, {
+            [field_id]: { values: [{ value: item.ID }] },
+          })
+            .then((new_post) => {
+              $(`#${field_id}-spinner`).removeClass('active');
+              $(document).trigger('dt-post-connection-added', [
+                new_post,
+                field_id,
+              ]);
+            })
+            .catch((err) => {
+              console.error(err);
+            });
 
           // If present, adjust status label, so as to remain uniform
           if (item['status']) {
-            item['status']['label'] = item['status']['label'] ? '[' + window.SHAREDFUNCTIONS.escapeHTML(item['status']['label']).toLowerCase() + ']' : '';
+            item['status']['label'] = item['status']['label']
+              ? '[' +
+                window.SHAREDFUNCTIONS.escapeHTML(
+                  item['status']['label'],
+                ).toLowerCase() +
+                ']'
+              : '';
           }
 
-          this.addMultiselectItemLayout(item)
-          event.preventDefault()
+          this.addMultiselectItemLayout(item);
+          event.preventDefault();
           this.hideLayout();
           this.resetInput();
-          window.masonGrid.masonry('layout')
+          window.masonGrid.masonry('layout');
         },
         onResult: function (node, query, result, resultCount) {
-          let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+          let text = window.TYPEAHEADS.typeaheadHelpText(
+            resultCount,
+            query,
+            result,
+          );
           $(`#${field_id}-result-container`).html(text);
         },
         onHideLayout: function (event, query) {
           set_item_label_status(this);
-          if ( !query ){
-            $(`#${field_id}-result-container`).empty()
+          if (!query) {
+            $(`#${field_id}-result-container`).empty();
           }
-          window.masonGrid.masonry('layout')
+          window.masonGrid.masonry('layout');
         },
-        onShowLayout (){
-          window.masonGrid.masonry('layout')
-        }
-      }
-    })
-  })
+        onShowLayout() {
+          window.masonGrid.masonry('layout');
+        },
+      },
+    });
+  });
 
   function set_item_label_status(field_typeahead) {
     if (field_typeahead) {
       $.each(field_typeahead.items, function (idx, item) {
         if (item['ID'] && item['status'] && item['status']['color']) {
-          $(field_typeahead.label.container[0]).find("a[href$=\\/" + item['ID']).each(function () {
+          $(field_typeahead.label.container[0])
+            .find('a[href$=\\/' + item['ID'])
+            .each(function () {
+              // Obtain label handle
+              let label = $(this).parent();
 
-            // Obtain label handle
-            let label = $(this).parent();
+              // Once we have a handle, adjust colour styling accordingly
+              label.css('border-left', '3px solid ' + item['status']['color']);
 
-            // Once we have a handle, adjust colour styling accordingly
-            label.css('border-left', '3px solid ' + item['status']['color']);
-
-            // Assign corresponding tooltip, using title as trigger
-            if (item['status']['label']) {
-              label.attr('title', '');
-              label.tooltip({
-                content: item['status']['label'],
-                show: {effect: 'fade', duration: 100}
-              });
-            }
-          });
+              // Assign corresponding tooltip, using title as trigger
+              if (item['status']['label']) {
+                label.attr('title', '');
+                label.tooltip({
+                  content: item['status']['label'],
+                  show: { effect: 'fade', duration: 100 },
+                });
+              }
+            });
         }
       });
 
@@ -660,50 +802,60 @@ jQuery(document).ready(function($) {
   }
 
   //multi_select typeaheads
-  for (let input of $(".multi_select .typeahead__query input")) {
-    let field = $(input).data('field')
-    let typeahead_name = `.js-typeahead-${field}`
+  for (let input of $('.multi_select .typeahead__query input')) {
+    let field = $(input).data('field');
+    let typeahead_name = `.js-typeahead-${field}`;
 
     if (window.Typeahead[typeahead_name]) {
-      return
+      return;
     }
 
-    let source_data =  { data: [] }
-    let field_options = window.lodash.get(field_settings, `${field}.default`, {})
-    if ( Object.keys(field_options).length > 0 ){
-      window.lodash.forOwn(field_options, (val, key)=>{
-        if ( !val.deleted ){
+    let source_data = { data: [] };
+    let field_options = window.lodash.get(
+      field_settings,
+      `${field}.default`,
+      {},
+    );
+    if (Object.keys(field_options).length > 0) {
+      window.lodash.forOwn(field_options, (val, key) => {
+        if (!val.deleted) {
           source_data.data.push({
             key: key,
-            name:key,
-            value: val.label || key
-          })
+            name: key,
+            value: val.label || key,
+          });
         }
-      })
+      });
     } else {
       source_data = {
         [field]: {
-          display: ["value"],
+          display: ['value'],
           ajax: {
-            url: window.wpApiShare.root + `dt-posts/v2/${post_type}/multi-select-values`,
+            url:
+              window.wpApiShare.root +
+              `dt-posts/v2/${post_type}/multi-select-values`,
             data: {
-              s: "{{query}}",
-              field
+              s: '{{query}}',
+              field,
             },
             beforeSend: function (xhr) {
               xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce);
             },
             callback: {
               done: function (data) {
-                return (data || []).map(tag => {
-                  let label = window.lodash.get(field_options, tag + ".label", tag)
-                  return {value: label, key: tag}
-                })
-              }
-            }
-          }
-        }
-      }
+                return (data || []).map((tag) => {
+                  let label = window.lodash.get(
+                    field_options,
+                    tag + '.label',
+                    tag,
+                  );
+                  return { value: label, key: tag };
+                });
+              },
+            },
+          },
+        },
+      };
     }
     $.typeahead({
       input: `.js-typeahead-${field}`,
@@ -711,390 +863,500 @@ jQuery(document).ready(function($) {
       maxItem: 20,
       searchOnFocus: true,
       template: function (query, item) {
-        return `<span>${window.SHAREDFUNCTIONS.escapeHTML(item.value)}</span>`
+        return `<span>${window.SHAREDFUNCTIONS.escapeHTML(item.value)}</span>`;
       },
       source: source_data,
-      display: "value",
-      templateValue: "{{value}}",
+      display: 'value',
+      templateValue: '{{value}}',
       dynamic: true,
       multiselect: {
-        matchOn: ["key"],
-        data: function (){
-          return (post[field] || [] ).map(g=>{
-            return {key:g, value:window.lodash.get(field_settings, `${field}.default.${g}.label`, g)}
-          })
+        matchOn: ['key'],
+        data: function () {
+          return (post[field] || []).map((g) => {
+            return {
+              key: g,
+              value: window.lodash.get(
+                field_settings,
+                `${field}.default.${g}.label`,
+                g,
+              ),
+            };
+          });
         },
         callback: {
           onCancel: function (node, item, event) {
-            $(`#${field}-spinner`).addClass('active')
-            window.API.update_post(post_type, post_id, {[field]: {values:[{value:item.key, delete:true}]}}).then((new_post)=>{
-              $(`#${field}-spinner`).removeClass('active')
-              this.hideLayout();
-              this.resetInput();
-              $( document ).trigger( "dt_multi_select-updated", [ new_post, field ] );
-            }).catch(err => { console.error(err) })
-          }
+            $(`#${field}-spinner`).addClass('active');
+            window.API.update_post(post_type, post_id, {
+              [field]: { values: [{ value: item.key, delete: true }] },
+            })
+              .then((new_post) => {
+                $(`#${field}-spinner`).removeClass('active');
+                this.hideLayout();
+                this.resetInput();
+                $(document).trigger('dt_multi_select-updated', [
+                  new_post,
+                  field,
+                ]);
+              })
+              .catch((err) => {
+                console.error(err);
+              });
+          },
         },
         href: function (item) {
-          const postType = window.wpApiShare.post_type
-          const query =  window.SHAREDFUNCTIONS.createCustomFilter(field, [item.value])
-          const field_label = field_settings[field].name || field
-          const labels = [{ id: `${field}_${item.value}`, name: `${field_label}: ${item.value}`}]
-          return window.SHAREDFUNCTIONS.create_url_for_list_query(postType, query, labels);
-        }
+          const postType = window.wpApiShare.post_type;
+          const query = window.SHAREDFUNCTIONS.createCustomFilter(field, [
+            item.value,
+          ]);
+          const field_label = field_settings[field].name || field;
+          const labels = [
+            {
+              id: `${field}_${item.value}`,
+              name: `${field_label}: ${item.value}`,
+            },
+          ];
+          return window.SHAREDFUNCTIONS.create_url_for_list_query(
+            postType,
+            query,
+            labels,
+          );
+        },
       },
       callback: {
-        onClick: function(node, a, item, event){
-          $(`#${field}-spinner`).addClass('active')
-          window.API.update_post(post_type, post_id, {[field]: {values:[{"value":item.key}]}}).then(new_post=>{
-            $(`#${field}-spinner`).removeClass('active')
-            $( document ).trigger( "dt_multi_select-updated", [ new_post, field ] );
-            this.addMultiselectItemLayout(item)
-            event.preventDefault()
-            this.hideLayout();
-            this.resetInput();
-          }).catch(err => { console.error(err) })
+        onClick: function (node, a, item, event) {
+          $(`#${field}-spinner`).addClass('active');
+          window.API.update_post(post_type, post_id, {
+            [field]: { values: [{ value: item.key }] },
+          })
+            .then((new_post) => {
+              $(`#${field}-spinner`).removeClass('active');
+              $(document).trigger('dt_multi_select-updated', [new_post, field]);
+              this.addMultiselectItemLayout(item);
+              event.preventDefault();
+              this.hideLayout();
+              this.resetInput();
+            })
+            .catch((err) => {
+              console.error(err);
+            });
         },
         onResult: function (node, query, result, resultCount) {
-          let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
-          if ( Object.keys(field_options).length > 0 ){
+          let text = window.TYPEAHEADS.typeaheadHelpText(
+            resultCount,
+            query,
+            result,
+          );
+          if (Object.keys(field_options).length > 0) {
             //adding the result text moves the input. The timeout helps keep the dropdown from closing as the user clicks and cursor moves away from the input.
-            setTimeout( () => {
-                $(`#${field}-result-container`).html(text);
-              },200 );
+            setTimeout(() => {
+              $(`#${field}-result-container`).html(text);
+            }, 200);
           } else {
             $(`#${field}-result-container`).html(text);
           }
         },
         onHideLayout: function () {
-          $(`#${field}-result-container`).html("");
-        }
-      }
+          $(`#${field}-result-container`).html('');
+        },
+      },
     });
   }
 
-
-  let connection_type = null
+  let connection_type = null;
   //new record off a typeahead
-  $('.create-new-record').on('click', function(){
+  $('.create-new-record').on('click', function () {
     connection_type = $(this).data('connection-key');
     $('#create-record-modal').foundation('open');
     $('.js-create-record .error-text').empty();
-    $(".js-create-record-button").attr("disabled", false).removeClass("alert")
-    $(".reveal-after-record-create").hide()
-    $(".hide-after-record-create").show()
-    $(".js-create-record input[name=title]").val('')
+    $('.js-create-record-button').attr('disabled', false).removeClass('alert');
+    $('.reveal-after-record-create').hide();
+    $('.hide-after-record-create').show();
+    $('.js-create-record input[name=title]').val('');
     //create new record
-  })
-  $(".js-create-record").on("submit", function(e) {
+  });
+  $('.js-create-record').on('submit', function (e) {
     e.preventDefault();
-    $(".js-create-record-button").attr("disabled", true).addClass("loading");
-    let title = $(".js-create-record input[name=title]").val()
-    if ( !connection_type){
-      $(".js-create-record .error-text").text(
-        "Something went wrong. Please refresh and try again"
+    $('.js-create-record-button').attr('disabled', true).addClass('loading');
+    let title = $('.js-create-record input[name=title]').val();
+    if (!connection_type) {
+      $('.js-create-record .error-text').text(
+        'Something went wrong. Please refresh and try again',
       );
       return;
     }
     let update_field = connection_type;
-    window.API.create_post( field_settings[update_field].post_type, {
+    window.API.create_post(field_settings[update_field].post_type, {
       title,
       additional_meta: {
         created_from: post_id,
-        add_connection: connection_type
-      }
-    }).then((newRecord)=>{
-      $(".js-create-record-button").attr("disabled", false).removeClass("loading");
-      $(".reveal-after-record-create").show()
-      $("#new-record-link").html(`<a href="${window.SHAREDFUNCTIONS.escapeHTML( newRecord.permalink )}">${window.SHAREDFUNCTIONS.escapeHTML( title )}</a>`)
-      $(".hide-after-record-create").hide()
-      $('#go-to-record').attr('href', window.SHAREDFUNCTIONS.escapeHTML( newRecord.permalink ));
-      $( document ).trigger( "dt-post-connection-created", [ post, update_field ] );
-      if ( window.Typeahead[`.js-typeahead-${connection_type}`] ){
-        window.Typeahead[`.js-typeahead-${connection_type}`].addMultiselectItemLayout({ID:newRecord.ID.toString(), name:title})
-        window.masonGrid.masonry('layout')
-      }
+        add_connection: connection_type,
+      },
     })
-    .catch(function(error) {
-      $(".js-create-record-button").removeClass("loading").addClass("alert");
-      $(".js-create-record .error-text").text(
-        window.lodash.get( error, "responseJSON.message", "Something went wrong. Please refresh and try again" )
-      );
-      console.error(error);
-    });
-  })
+      .then((newRecord) => {
+        $('.js-create-record-button')
+          .attr('disabled', false)
+          .removeClass('loading');
+        $('.reveal-after-record-create').show();
+        $('#new-record-link').html(
+          `<a href="${window.SHAREDFUNCTIONS.escapeHTML(newRecord.permalink)}">${window.SHAREDFUNCTIONS.escapeHTML(title)}</a>`,
+        );
+        $('.hide-after-record-create').hide();
+        $('#go-to-record').attr(
+          'href',
+          window.SHAREDFUNCTIONS.escapeHTML(newRecord.permalink),
+        );
+        $(document).trigger('dt-post-connection-created', [post, update_field]);
+        if (window.Typeahead[`.js-typeahead-${connection_type}`]) {
+          window.Typeahead[
+            `.js-typeahead-${connection_type}`
+          ].addMultiselectItemLayout({
+            ID: newRecord.ID.toString(),
+            name: title,
+          });
+          window.masonGrid.masonry('layout');
+        }
+      })
+      .catch(function (error) {
+        $('.js-create-record-button').removeClass('loading').addClass('alert');
+        $('.js-create-record .error-text').text(
+          window.lodash.get(
+            error,
+            'responseJSON.message',
+            'Something went wrong. Please refresh and try again',
+          ),
+        );
+        console.error(error);
+      });
+  });
 
-  $('.dt_location_grid').each((key, el)=> {
-    let field_id = $(el).data('id') || 'location_grid'
+  $('.dt_location_grid').each((key, el) => {
+    let field_id = $(el).data('id') || 'location_grid';
     $.typeahead({
       input: `.js-typeahead-${field_id}`,
       minLength: 0,
       accent: true,
       searchOnFocus: true,
       maxItem: 20,
-      dropdownFilter: [{
-        key: 'group',
-        value: 'focus',
-        template: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.regions_of_focus),
-        all: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.all_locations),
-      }],
+      dropdownFilter: [
+        {
+          key: 'group',
+          value: 'focus',
+          template: window.SHAREDFUNCTIONS.escapeHTML(
+            window.wpApiShare.translations.regions_of_focus,
+          ),
+          all: window.SHAREDFUNCTIONS.escapeHTML(
+            window.wpApiShare.translations.all_locations,
+          ),
+        },
+      ],
       source: {
         focus: {
-          display: "name",
+          display: 'name',
           ajax: {
-            url: window.wpApiShare.root + 'dt/v1/mapping_module/search_location_grid_by_name',
+            url:
+              window.wpApiShare.root +
+              'dt/v1/mapping_module/search_location_grid_by_name',
             data: {
-              s: "{{query}}",
+              s: '{{query}}',
               filter: function () {
-                return window.lodash.get(window.Typeahead[`.js-typeahead-${field_id}`].filters.dropdown, 'value', 'all')
-              }
+                return window.lodash.get(
+                  window.Typeahead[`.js-typeahead-${field_id}`].filters
+                    .dropdown,
+                  'value',
+                  'all',
+                );
+              },
             },
             beforeSend: function (xhr) {
               xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce);
             },
             callback: {
               done: function (data) {
-                if (typeof window.typeaheadTotals!=="undefined") {
-                  window.typeaheadTotals.field = data.total
+                if (typeof window.typeaheadTotals !== 'undefined') {
+                  window.typeaheadTotals.field = data.total;
                 }
-                return data.location_grid
-              }
-            }
-          }
-        }
+                return data.location_grid;
+              },
+            },
+          },
+        },
       },
-      display: "name",
-      templateValue: "{{name}}",
+      display: 'name',
+      templateValue: '{{name}}',
       dynamic: true,
       multiselect: {
-        matchOn: ["ID"],
+        matchOn: ['ID'],
         data: function () {
-          return (post[field_id] || []).map(g => {
-            return {ID: g.id, name: g.label}
-          })
-
-        }, callback: {
+          return (post[field_id] || []).map((g) => {
+            return { ID: g.id, name: g.label };
+          });
+        },
+        callback: {
           onCancel: function (node, item) {
-            window.API.update_post(post_type, post_id, {[field_id]: {values:[{value:item.ID, delete:true}]}})
-            .catch(err => { console.error(err) })
-          }
-        }
+            window.API.update_post(post_type, post_id, {
+              [field_id]: { values: [{ value: item.ID, delete: true }] },
+            }).catch((err) => {
+              console.error(err);
+            });
+          },
+        },
       },
       callback: {
         onClick: function (node, a, item, event) {
-          window.API.update_post(post_type, post_id, {[field_id]: {values:[{"value":item.ID}]}}).catch(err => { console.error(err) })
-          this.addMultiselectItemLayout(item)
-          event.preventDefault()
+          window.API.update_post(post_type, post_id, {
+            [field_id]: { values: [{ value: item.ID }] },
+          }).catch((err) => {
+            console.error(err);
+          });
+          this.addMultiselectItemLayout(item);
+          event.preventDefault();
           this.hideLayout();
           this.resetInput();
-          window.masonGrid.masonry('layout')
+          window.masonGrid.masonry('layout');
         },
         onReady() {
-          this.filters.dropdown = {key: "group", value: "focus", template: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.regions_of_focus)}
+          this.filters.dropdown = {
+            key: 'group',
+            value: 'focus',
+            template: window.SHAREDFUNCTIONS.escapeHTML(
+              window.wpApiShare.translations.regions_of_focus,
+            ),
+          };
           this.container
-          .removeClass("filter")
-          .find("." + this.options.selector.filterButton)
-          .html(window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.regions_of_focus));
+            .removeClass('filter')
+            .find('.' + this.options.selector.filterButton)
+            .html(
+              window.SHAREDFUNCTIONS.escapeHTML(
+                window.wpApiShare.translations.regions_of_focus,
+              ),
+            );
         },
         onResult: function (node, query, result, resultCount) {
-          resultCount = typeaheadTotals[field_id]
-          let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+          resultCount = typeaheadTotals[field_id];
+          let text = window.TYPEAHEADS.typeaheadHelpText(
+            resultCount,
+            query,
+            result,
+          );
           $(`#${field_id}-result-container`).html(text);
         },
         onHideLayout: function () {
-          $(`#${field_id}-result-container`).html("");
-        }
-      }
+          $(`#${field_id}-result-container`).html('');
+        },
+      },
     });
-  })
+  });
 
   /**
    * Follow
    */
-  $('button.follow').on("click", function () {
-    let following = !($(this).data('value') === "following")
-    $(this).data("value", following ? "following" : "" )
+  $('button.follow').on('click', function () {
+    let following = !($(this).data('value') === 'following');
+    $(this).data('value', following ? 'following' : '');
     if ($(this).hasClass('mobile')) {
-      $(this).html( following ? "<i class='fi-eye'></i>" : "<i class='fi-eye'></i>")
+      $(this).html(
+        following ? "<i class='fi-eye'></i>" : "<i class='fi-eye'></i>",
+      );
     } else {
-      $(this).html( following ? "Following <i class='fi-eye'></i>" : "Follow <i class='fi-eye'></i>")
+      $(this).html(
+        following
+          ? "Following <i class='fi-eye'></i>"
+          : "Follow <i class='fi-eye'></i>",
+      );
     }
-    $(this).toggleClass( "hollow" )
+    $(this).toggleClass('hollow');
     let update = {
-      follow: {values:[{value:window.detailsSettings.current_user_id, delete:!following}]},
-      unfollow: {values:[{value:window.detailsSettings.current_user_id, delete:following}]}
-    }
-    rest_api.update_post( post_type, post_id, update )
-  })
-
-
+      follow: {
+        values: [
+          { value: window.detailsSettings.current_user_id, delete: !following },
+        ],
+      },
+      unfollow: {
+        values: [
+          { value: window.detailsSettings.current_user_id, delete: following },
+        ],
+      },
+    };
+    rest_api.update_post(post_type, post_id, update);
+  });
 
   /**
    * Share
    */
-  let shareTypeahead = null
-  $('.open-share').on("click", function(){
+  let shareTypeahead = null;
+  $('.open-share').on('click', function () {
     $('#share-contact-modal').foundation('open');
-    if  (!shareTypeahead) {
-      shareTypeahead = window.TYPEAHEADS.share(post_type, post_id )
+    if (!shareTypeahead) {
+      shareTypeahead = window.TYPEAHEADS.share(post_type, post_id);
     }
-  })
+  });
 
-
-
-  let build_task_list = ()=>{
-    let tasks = window.lodash.sortBy(post.tasks || [], ['date']).reverse()
-    let html = ``
-    tasks.forEach(task=>{
-      let task_done = ( task.category === "reminder" && task.value.notification === 'notification_sent' )
-                      || ( task.category !== "reminder" && task.value.status === 'task_complete' )
-      let show_complete_button = task.category !== "reminder" && task.value.status !== 'task_complete'
-      let task_row = `<strong>${window.SHAREDFUNCTIONS.escapeHTML( window.moment(task.date).format("MMM D YYYY") )}</strong> `
-      if ( task.category === "reminder" ){
-        task_row += window.SHAREDFUNCTIONS.escapeHTML( window.detailsSettings.translations.reminder )
-        if ( task.value.note ){
-          task_row += ' ' + window.SHAREDFUNCTIONS.escapeHTML(task.value.note)
+  let build_task_list = () => {
+    let tasks = window.lodash.sortBy(post.tasks || [], ['date']).reverse();
+    let html = ``;
+    tasks.forEach((task) => {
+      let task_done =
+        (task.category === 'reminder' &&
+          task.value.notification === 'notification_sent') ||
+        (task.category !== 'reminder' && task.value.status === 'task_complete');
+      let show_complete_button =
+        task.category !== 'reminder' && task.value.status !== 'task_complete';
+      let task_row = `<strong>${window.SHAREDFUNCTIONS.escapeHTML(window.moment(task.date).format('MMM D YYYY'))}</strong> `;
+      if (task.category === 'reminder') {
+        task_row += window.SHAREDFUNCTIONS.escapeHTML(
+          window.detailsSettings.translations.reminder,
+        );
+        if (task.value.note) {
+          task_row += ' ' + window.SHAREDFUNCTIONS.escapeHTML(task.value.note);
         }
       } else {
-         task_row += window.SHAREDFUNCTIONS.escapeHTML(task.value.note || window.detailsSettings.translations.no_note )
+        task_row += window.SHAREDFUNCTIONS.escapeHTML(
+          task.value.note || window.detailsSettings.translations.no_note,
+        );
       }
       html += `<li>
         <span style="${task_done ? 'text-decoration:line-through' : ''}">
         ${task_row}
-        ${ show_complete_button ? `<button type="button" data-id="${window.SHAREDFUNCTIONS.escapeHTML(task.id)}" class="existing-task-action complete-task">${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.complete).toLowerCase()}</button>` : '' }
+        ${show_complete_button ? `<button type="button" data-id="${window.SHAREDFUNCTIONS.escapeHTML(task.id)}" class="existing-task-action complete-task">${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.complete).toLowerCase()}</button>` : ''}
         <button type="button" data-id="${window.SHAREDFUNCTIONS.escapeHTML(task.id)}" class="existing-task-action remove-task" style="color: red;">${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.remove).toLowerCase()}</button>
-      </li>`
-    })
-    if (!html ){
-      $('#tasks-modal .existing-tasks').html(`<li>${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.no_tasks)}</li>`)
+      </li>`;
+    });
+    if (!html) {
+      $('#tasks-modal .existing-tasks').html(
+        `<li>${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.no_tasks)}</li>`,
+      );
     } else {
-      $('#tasks-modal .existing-tasks').html(html)
+      $('#tasks-modal .existing-tasks').html(html);
     }
 
-    $('.complete-task').on("click", function () {
-      $('#tasks-spinner').addClass('active')
-      let id = $(this).data('id')
+    $('.complete-task').on('click', function () {
+      $('#tasks-spinner').addClass('active');
+      let id = $(this).data('id');
       window.API.update_post(post_type, post_id, {
-          "tasks": { values: [ { id, value: {status: 'task_complete'}, } ] }
-      }).then(resp => {
-        post = resp
-        build_task_list()
-        $('#tasks-spinner').removeClass('active')
-      })
-    })
-    $('.remove-task').on("click", function () {
-      $('#tasks-spinner').addClass('active')
-      let id = $(this).data('id')
+        tasks: { values: [{ id, value: { status: 'task_complete' } }] },
+      }).then((resp) => {
+        post = resp;
+        build_task_list();
+        $('#tasks-spinner').removeClass('active');
+      });
+    });
+    $('.remove-task').on('click', function () {
+      $('#tasks-spinner').addClass('active');
+      let id = $(this).data('id');
       window.API.update_post(post_type, post_id, {
-          "tasks": { values: [ { id, delete: true } ] }
-      }).then(resp => {
-        post = resp
-        build_task_list()
-        $('#tasks-spinner').removeClass('active')
-      })
-    })
-  }
+        tasks: { values: [{ id, delete: true }] },
+      }).then((resp) => {
+        post = resp;
+        build_task_list();
+        $('#tasks-spinner').removeClass('active');
+      });
+    });
+  };
   //open the create task modal
-  $('.open-set-task').on( "click", function () {
+  $('.open-set-task').on('click', function () {
     $('.js-add-task-form .error-text').empty();
-    build_task_list()
+    build_task_list();
     $('#tasks-modal').foundation('open');
-  })
+  });
   $('#task-custom-text').on('click', function () {
-    $('input:radio[name="task-type"]').filter('[value="custom"]').prop('checked', true);
-  })
+    $('input:radio[name="task-type"]')
+      .filter('[value="custom"]')
+      .prop('checked', true);
+  });
   $('#create-task-date').daterangepicker({
-    "singleDatePicker": true,
+    singleDatePicker: true,
     // "autoUpdateInput": false,
     // "timePicker": true,
     // "timePickerIncrement": 60,
-    "locale": {
-      "format": "YYYY/MM/DD",
-      "separator": " - ",
-      "daysOfWeek": window.SHAREDFUNCTIONS.get_days_of_the_week_initials(),
-      "monthNames": window.SHAREDFUNCTIONS.get_months_labels(),
+    locale: {
+      format: 'YYYY/MM/DD',
+      separator: ' - ',
+      daysOfWeek: window.SHAREDFUNCTIONS.get_days_of_the_week_initials(),
+      monthNames: window.SHAREDFUNCTIONS.get_months_labels(),
     },
-    "firstDay": 1,
-    "startDate": window.moment().add(1, "day"),
-    "opens": "center",
-    "drops": "down"
+    firstDay: 1,
+    startDate: window.moment().add(1, 'day'),
+    opens: 'center',
+    drops: 'down',
   });
-  let task_note = $('#tasks-modal #task-custom-text')
+  let task_note = $('#tasks-modal #task-custom-text');
   //submit the create task form
-  $(".js-add-task-form").on("submit", function(e) {
+  $('.js-add-task-form').on('submit', function (e) {
     e.preventDefault();
-    $("#create-task")
-      .attr("disabled", true)
-      .addClass("loading");
-    let date = $('#create-task-date').data('daterangepicker').startDate
-    let note = task_note.val()
-    let task_type = $('#tasks-modal input[name="task-type"]:checked').val()
+    $('#create-task').attr('disabled', true).addClass('loading');
+    let date = $('#create-task-date').data('daterangepicker').startDate;
+    let note = task_note.val();
+    let task_type = $('#tasks-modal input[name="task-type"]:checked').val();
     window.API.update_post(post_type, post_id, {
-      "tasks":{
+      tasks: {
         values: [
           {
-            date: date.startOf('day').add(8, "hours").format(), //time 8am
-            value: {note: note},
-            category: task_type
-          }
-        ]
-      }
-    }).then( resp => {
-      post = resp
-      $("#create-task")
-      .attr("disabled", false)
-      .removeClass("loading");
-      task_note.val('')
-      $('#tasks-modal').foundation('close');
-    }).catch(err => {
-      $("#create-task")
-      .attr("disabled", false)
-      .removeClass("loading");
-      $('.js-add-task-form .error-text').html(window.SHAREDFUNCTIONS.escapeHTML(window.lodash.get(err, "responseJSON.message")));
-      console.error(err)
+            date: date.startOf('day').add(8, 'hours').format(), //time 8am
+            value: { note: note },
+            category: task_type,
+          },
+        ],
+      },
     })
-  })
+      .then((resp) => {
+        post = resp;
+        $('#create-task').attr('disabled', false).removeClass('loading');
+        task_note.val('');
+        $('#tasks-modal').foundation('close');
+      })
+      .catch((err) => {
+        $('#create-task').attr('disabled', false).removeClass('loading');
+        $('.js-add-task-form .error-text').html(
+          window.SHAREDFUNCTIONS.escapeHTML(
+            window.lodash.get(err, 'responseJSON.message'),
+          ),
+        );
+        console.error(err);
+      });
+  });
 
   /**
    * Favorite
    */
   function favorite_check(post_data) {
     if (post_data.favorite) {
-      document.querySelectorAll('.button.favorite').forEach( function(button) {
-          button.dataset.favorite = true
-      })
+      document.querySelectorAll('.button.favorite').forEach(function (button) {
+        button.dataset.favorite = true;
+      });
       $('.button.favorite').addClass('selected');
     } else {
-      document.querySelectorAll('.button.favorite').forEach( function(button) {
-          button.dataset.favorite = false
-      })
+      document.querySelectorAll('.button.favorite').forEach(function (button) {
+        button.dataset.favorite = false;
+      });
       $('.button.favorite').removeClass('selected');
     }
   }
 
   favorite_check(window.detailsSettings.post_fields);
 
-  $('.button.favorite').on( "click", function () {
-    var favorited = this.dataset.favorite
+  $('.button.favorite').on('click', function () {
+    var favorited = this.dataset.favorite;
     var favoritedValue;
-    if (favorited == "true") {
-      this.dataset.favorite = false
+    if (favorited == 'true') {
+      this.dataset.favorite = false;
       favoritedValue = false;
-    } else if (favorited == "false") {
-      this.dataset.favorite = true
+    } else if (favorited == 'false') {
+      this.dataset.favorite = true;
       favoritedValue = true;
     }
-    rest_api.update_post(post_type, post_id, {'favorite': favoritedValue}).then((new_post)=>{
-      favorite_check(new_post);
-    })
-  })
+    rest_api
+      .update_post(post_type, post_id, { favorite: favoritedValue })
+      .then((new_post) => {
+        favorite_check(new_post);
+      });
+  });
 
   /**
    * Tags
    */
-  $('.tags .typeahead__query input').each((key, input)=>{
-    let field = $(input).data('field') || 'tags'
-    let typeahead_name = `.js-typeahead-${field}`
+  $('.tags .typeahead__query input').each((key, input) => {
+    let field = $(input).data('field') || 'tags';
+    let typeahead_name = `.js-typeahead-${field}`;
     $.typeahead({
       input: typeahead_name,
       minLength: 0,
@@ -1102,318 +1364,447 @@ jQuery(document).ready(function($) {
       searchOnFocus: true,
       source: {
         tags: {
-          display: ["name"],
+          display: ['name'],
           ajax: {
-            url: window.wpApiShare.root + `dt-posts/v2/${post_type}/multi-select-values`,
+            url:
+              window.wpApiShare.root +
+              `dt-posts/v2/${post_type}/multi-select-values`,
             data: {
-              s: "{{query}}",
-              field: field
+              s: '{{query}}',
+              field: field,
             },
             beforeSend: function (xhr) {
               xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce);
             },
             callback: {
               done: function (data) {
-                return (data || []).map(tag => {
-                  return {name: tag}
-                })
-              }
-            }
-          }
-        }
+                return (data || []).map((tag) => {
+                  return { name: tag };
+                });
+              },
+            },
+          },
+        },
       },
-      display: "name",
-      templateValue: "{{name}}",
-      emptyTemplate: function(query) {
-        const { addNewTagText, tagExistsText} = this.node[0].dataset
+      display: 'name',
+      templateValue: '{{name}}',
+      emptyTemplate: function (query) {
+        const { addNewTagText, tagExistsText } = this.node[0].dataset;
         if (this.comparedItems.includes(query)) {
-          return tagExistsText.replace('%s', query)
+          return tagExistsText.replace('%s', query);
         }
-        const liItem = $('<li>')
+        const liItem = $('<li>');
         const button = $('<button>', {
-          class: "button primary",
+          class: 'button primary',
           text: addNewTagText.replace('%s', query),
-        })
-        const tag = this.query
-        const addTag = addTagOnClick.bind(this)
-        button.on("click", function () {
-          addTag(field, tag)
-        })
-        liItem.append(button)
-        return liItem
+        });
+        const tag = this.query;
+        const addTag = addTagOnClick.bind(this);
+        button.on('click', function () {
+          addTag(field, tag);
+        });
+        liItem.append(button);
+        return liItem;
       },
       dynamic: true,
       multiselect: {
-        matchOn: ["name"],
-        data: function (){
-          return (post[field] || [] ).map(t=>{
-            return {name: t}
-          })
+        matchOn: ['name'],
+        data: function () {
+          return (post[field] || []).map((t) => {
+            return { name: t };
+          });
         },
         callback: {
           onCancel: function (node, item, event) {
-            $(`#${field}-spinner`).addClass('active')
-            window.API.update_post(post_type, post_id, {[field]: {values:[{value:item.name, delete:true}]}}).then((new_post)=>{
-              $(`#${field}-spinner`).removeClass('active')
-              this.hideLayout();
-              this.resetInput();
-              $( document ).trigger( "dt_multi_select-updated", [ new_post, field ] );
-            }).catch(err => { console.error(err) })
-          }
+            $(`#${field}-spinner`).addClass('active');
+            window.API.update_post(post_type, post_id, {
+              [field]: { values: [{ value: item.name, delete: true }] },
+            })
+              .then((new_post) => {
+                $(`#${field}-spinner`).removeClass('active');
+                this.hideLayout();
+                this.resetInput();
+                $(document).trigger('dt_multi_select-updated', [
+                  new_post,
+                  field,
+                ]);
+              })
+              .catch((err) => {
+                console.error(err);
+              });
+          },
         },
         href: function (item) {
-          const postType = window.wpApiShare.post_type
-          const query =  window.SHAREDFUNCTIONS.createCustomFilter(field, [item.name])
-          const field_label = field_settings[field].name || field
-          const labels = [{ id: `${field}_${item.name}`, name: `${field_label}: ${item.name}`}]
-          return window.SHAREDFUNCTIONS.create_url_for_list_query(postType, query, labels);
-        }
+          const postType = window.wpApiShare.post_type;
+          const query = window.SHAREDFUNCTIONS.createCustomFilter(field, [
+            item.name,
+          ]);
+          const field_label = field_settings[field].name || field;
+          const labels = [
+            {
+              id: `${field}_${item.name}`,
+              name: `${field_label}: ${item.name}`,
+            },
+          ];
+          return window.SHAREDFUNCTIONS.create_url_for_list_query(
+            postType,
+            query,
+            labels,
+          );
+        },
       },
       callback: {
         onClick: function (node, a, item, event) {
-          event.preventDefault()
-          const addTag = addTagOnClick.bind(this)
-          addTag(field, item.name)
+          event.preventDefault();
+          const addTag = addTagOnClick.bind(this);
+          addTag(field, item.name);
         },
         onResult: function (node, query, result, resultCount) {
-          let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+          let text = window.TYPEAHEADS.typeaheadHelpText(
+            resultCount,
+            query,
+            result,
+          );
           $(`#${field}-result-container`).html(text);
-          window.masonGrid.masonry('layout')
+          window.masonGrid.masonry('layout');
         },
         onHideLayout: function () {
-          $(`#${field}-result-container`).html("");
-          window.masonGrid.masonry('layout')
+          $(`#${field}-result-container`).html('');
+          window.masonGrid.masonry('layout');
         },
         onShowLayout() {
-          window.masonGrid.masonry('layout')
+          window.masonGrid.masonry('layout');
+        },
+      },
+    });
+  });
+
+  $('.create-new-tag').on('click', function () {
+    let field = $(this).data('field');
+    $('#create-tag-modal').data('field', field);
+  });
+  $('#create-tag-return').on('click', function () {
+    let field = $('#create-tag-modal').data('field');
+    let tag = $('#new-tag').val();
+    window.Typeahead['.js-typeahead-' + field].addMultiselectItemLayout({
+      name: tag,
+    });
+    window.API.update_post(post_type, post_id, {
+      [field]: { values: [{ value: tag }] },
+    });
+  });
+
+  function addTagOnClick(field, tag) {
+    $(`#${field}-spinner`).addClass('active');
+    window.API.update_post(post_type, post_id, {
+      [field]: { values: [{ value: tag }] },
+    })
+      .then((new_post) => {
+        $(`#${field}-spinner`).removeClass('active');
+        this.addMultiselectItemLayout({ name: tag });
+        this.hideLayout();
+        this.resetInput();
+        window.masonGrid.masonry('layout');
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }
+
+  let upgradeUrl = (url) => {
+    if (!url.includes('http')) {
+      url = 'https://' + url;
+    }
+    if (!url.startsWith(window.wpApiShare.template_dir)) {
+      url = url.replace('http://', 'https://');
+    }
+    return url;
+  };
+
+  let urlRegex =
+    /[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/gi;
+  let protocolRegex = /^(?:https?:\/\/)?(?:www.)?/gi;
+  function resetDetailsFields() {
+    window.lodash.forOwn(field_settings, (field_options, field_key) => {
+      if (
+        field_options.tile === 'details' &&
+        !field_options.hidden &&
+        (post[field_key] || field_options.type === 'boolean')
+      ) {
+        if (
+          field_options.only_for_types &&
+          field_options.only_for_types !== true &&
+          field_options.only_for_types.length > 0 &&
+          post['type'] &&
+          !field_options.only_for_types.includes(post['type'].key)
+        ) {
+          return;
+        }
+        let field_value = window.lodash.get(post, field_key, false);
+        let values_html = ``;
+        if (field_options.type === 'text') {
+          values_html = window.SHAREDFUNCTIONS.escapeHTML(field_value);
+        } else if (field_options.type === 'textarea') {
+          values_html = window.SHAREDFUNCTIONS.escapeHTML(field_value);
+        } else if (
+          field_options.type === 'date' ||
+          field_options.type === 'datetime'
+        ) {
+          values_html = window.SHAREDFUNCTIONS.escapeHTML(
+            window.SHAREDFUNCTIONS.formatDate(field_value.timestamp),
+          );
+        } else if (field_options.type === 'boolean') {
+          values_html = window.SHAREDFUNCTIONS.escapeHTML(
+            field_value
+              ? window.detailsSettings.translations.yes
+              : window.detailsSettings.translations.no,
+          );
+        } else if (field_options.type === 'key_select') {
+          values_html = window.SHAREDFUNCTIONS.escapeHTML(field_value.label);
+        } else if (
+          field_options.type === 'multi_select' ||
+          field_options.type === 'tags'
+        ) {
+          values_html = field_value
+            .map((v) => {
+              return `${window.SHAREDFUNCTIONS.escapeHTML(window.lodash.get(field_options, `default[${v}].label`, v))}`;
+            })
+            .join(', ');
+        } else if (['location', 'location_meta'].includes(field_options.type)) {
+          values_html = field_value
+            .map((v) => {
+              return window.SHAREDFUNCTIONS.escapeHTML(
+                v.matched_search || v.label,
+              );
+            })
+            .join(' / ');
+        } else if (
+          field_options.type === 'communication_channel' ||
+          field_options.type === 'link'
+        ) {
+          field_value.forEach((v, index) => {
+            if (index > 0) {
+              values_html += ', ';
+            }
+            let value = window.SHAREDFUNCTIONS.escapeHTML(v.value);
+            if (field_key === 'contact_phone') {
+              values_html += `<a dir="auto" class="phone-link" href="tel:${value}" title="${value}">${value}</a>`;
+            } else if (field_key === 'contact_email') {
+              values_html += `<a dir="auto" href="mailto:${value}" title="${value}">${value}</a>`;
+            } else {
+              let validURL = new RegExp(urlRegex).exec(value);
+              let prefix = new RegExp(protocolRegex).exec(value);
+              if (validURL && prefix) {
+                let urlToDisplay = '';
+                if (
+                  field_options.hide_domain &&
+                  field_options.hide_domain === true
+                ) {
+                  urlToDisplay = validURL[1] || value;
+                } else {
+                  urlToDisplay = value.replace(prefix[0], '');
+                }
+                value = upgradeUrl(value);
+                value = `<a href="${window.SHAREDFUNCTIONS.escapeHTML(value)}" target="_blank" >${window.SHAREDFUNCTIONS.escapeHTML(urlToDisplay)}</a>`;
+              }
+              values_html += value;
+            }
+          });
+          let labels = field_value
+            .map((v) => {
+              return window.SHAREDFUNCTIONS.escapeHTML(v.value);
+            })
+            .join(', ');
+          $(`#collapsed-detail-${field_key} .collapsed-items`).html(
+            `<span title="${labels}">${values_html}</span>`,
+          );
+        } else if (['connection'].includes(field_options.type)) {
+          values_html = field_value
+            .map((v) => {
+              if (v.label) {
+                return window.SHAREDFUNCTIONS.escapeHTML(
+                  v.label || v.post_title,
+                );
+              } else {
+                return `<a href="${window.SHAREDFUNCTIONS.escapeHTML(v.permalink)}" target="_blank" >${window.SHAREDFUNCTIONS.escapeHTML(v.post_title)}</a>`;
+              }
+            })
+            .join(' / ');
+          $(`#collapsed-detail-${field_key} .collapsed-items`).html(
+            `<span>${values_html}</span>`,
+          );
+        } else {
+          values_html = window.SHAREDFUNCTIONS.escapeHTML(field_value);
+        }
+        $(`#collapsed-detail-${field_key}`).toggle(values_html !== ``);
+        if (
+          field_options.type !== 'communication_channel' &&
+          field_options.type !== 'link' &&
+          field_options.type !== 'connection'
+        ) {
+          $(`#collapsed-detail-${field_key} .collapsed-items`).html(
+            `<span title="${values_html}">${values_html}</span>`,
+          );
+        }
+        if (
+          field_options.type === 'text' &&
+          new RegExp(urlRegex).exec(values_html)
+        ) {
+          window.SHAREDFUNCTIONS.make_links_clickable(
+            `#collapsed-detail-${field_key} .collapsed-items span`,
+          );
         }
       }
     });
-  })
-
-  $(".create-new-tag").on("click", function () {
-    let field = $(this).data("field");
-    $("#create-tag-modal").data("field", field)
-
-  });
-  $("#create-tag-return").on("click", function () {
-    let field = $("#create-tag-modal").data("field");
-    let tag = $("#new-tag").val()
-    window.Typeahead['.js-typeahead-' + field].addMultiselectItemLayout({name: tag})
-    window.API.update_post(post_type, post_id, {[field]: {values: [{value: tag}]}})
-  })
-
-  function addTagOnClick(field, tag) {
-    $(`#${field}-spinner`).addClass('active')
-    window.API.update_post(post_type, post_id, {[field]: {values:[{"value":tag}]}}).then(new_post=>{
-      $(`#${field}-spinner`).removeClass('active')
-      this.addMultiselectItemLayout({name: tag})
-      this.hideLayout();
-      this.resetInput();
-      window.masonGrid.masonry('layout')
-    }).catch(err => { console.error(err) })
-  }
-
-  let upgradeUrl = (url)=>{
-    if ( !url.includes("http")){
-      url = "https://" + url
-    }
-    if ( !url.startsWith(window.wpApiShare.template_dir)){
-      url = url.replace( 'http://', 'https://' )
-    }
-    return url
-  }
-
-  let urlRegex = /[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/gi
-  let protocolRegex = /^(?:https?:\/\/)?(?:www.)?/gi
-  function resetDetailsFields(){
-    window.lodash.forOwn( field_settings, (field_options, field_key)=>{
-
-      if ( field_options.tile === 'details' && !field_options.hidden && ( post[field_key] || field_options.type === 'boolean' ) ){
-
-        if ( field_options.only_for_types && field_options.only_for_types !== true && ( field_options.only_for_types.length > 0 && ( post["type"] && !field_options.only_for_types.includes(post["type"].key) ) ) ){
-          return
-        }
-        let field_value = window.lodash.get( post, field_key, false )
-        let values_html = ``
-        if ( field_options.type === 'text' ){
-          values_html = window.SHAREDFUNCTIONS.escapeHTML( field_value )
-        } else if ( field_options.type === 'textarea' ){
-          values_html = window.SHAREDFUNCTIONS.escapeHTML( field_value )
-        } else if ( field_options.type === 'date' || field_options.type === 'datetime' ) {
-          values_html = window.SHAREDFUNCTIONS.escapeHTML(window.SHAREDFUNCTIONS.formatDate(field_value.timestamp))
-        } else if ( field_options.type === 'boolean' ){
-          values_html = window.SHAREDFUNCTIONS.escapeHTML( field_value ? window.detailsSettings.translations.yes : window.detailsSettings.translations.no )
-        } else if ( field_options.type === 'key_select' ){
-          values_html = window.SHAREDFUNCTIONS.escapeHTML( field_value.label )
-        } else if ( field_options.type === 'multi_select' || field_options.type === 'tags' ){
-          values_html = field_value.map(v=>{
-            return `${window.SHAREDFUNCTIONS.escapeHTML( window.lodash.get( field_options, `default[${v}].label`, v ))}`;
-          }).join(', ')
-        } else if ( ['location', 'location_meta' ].includes(field_options.type) ){
-          values_html = field_value.map(v=>{
-            return window.SHAREDFUNCTIONS.escapeHTML(v.matched_search || v.label);
-          }).join(' / ')
-        } else if ( field_options.type === 'communication_channel' || field_options.type === 'link' ){
-          field_value.forEach((v, index)=>{
-            if ( index > 0 ){
-              values_html += ', '
-            }
-            let value = window.SHAREDFUNCTIONS.escapeHTML(v.value)
-            if ( field_key === 'contact_phone' ){
-              values_html += `<a dir="auto" class="phone-link" href="tel:${value}" title="${value}">${value}</a>`
-            } else if (field_key === "contact_email") {
-              values_html += `<a dir="auto" href="mailto:${value}" title="${value}">${value}</a>`
-            } else {
-              let validURL = new RegExp(urlRegex).exec(value)
-              let prefix = new RegExp(protocolRegex).exec(value)
-              if (validURL && prefix) {
-                let urlToDisplay = ""
-                if (field_options.hide_domain && field_options.hide_domain===true) {
-                  urlToDisplay = validURL[1] || value
-                } else {
-                  urlToDisplay = value.replace(prefix[0], "")
-                }
-                value = upgradeUrl(value)
-                value = `<a href="${window.SHAREDFUNCTIONS.escapeHTML(value)}" target="_blank" >${window.SHAREDFUNCTIONS.escapeHTML(urlToDisplay)}</a>`
-              }
-              values_html += value
-            }
-          })
-          let labels = field_value.map(v=>{
-            return window.SHAREDFUNCTIONS.escapeHTML(v.value);
-          }).join(', ')
-          $(`#collapsed-detail-${field_key} .collapsed-items`).html(`<span title="${labels}">${values_html}</span>`)
-
-        } else if ( ['connection'].includes(field_options.type) ){
-          values_html = field_value.map(v=>{
-            if ( v.label ){
-              return window.SHAREDFUNCTIONS.escapeHTML(v.label || v.post_title);
-            } else {
-              return `<a href="${window.SHAREDFUNCTIONS.escapeHTML(v.permalink)}" target="_blank" >${window.SHAREDFUNCTIONS.escapeHTML(v.post_title)}</a>`
-            }
-          }).join(' / ')
-          $(`#collapsed-detail-${field_key} .collapsed-items`).html(`<span>${values_html}</span>`)
-        } else {
-          values_html = window.SHAREDFUNCTIONS.escapeHTML( field_value )
-        }
-        $(`#collapsed-detail-${field_key}`).toggle(values_html !== ``)
-        if (field_options.type !== 'communication_channel' && field_options.type !== 'link' && field_options.type !== 'connection') {
-          $(`#collapsed-detail-${field_key} .collapsed-items`).html(`<span title="${values_html}">${values_html}</span>`)
-        }
-        if ( field_options.type === "text" && new RegExp(urlRegex).exec(values_html) ){
-          window.SHAREDFUNCTIONS.make_links_clickable(`#collapsed-detail-${field_key} .collapsed-items span`)
-        }
-      }
-
-    })
     phoneLinkClick();
-    $( document ).trigger( "dt_record_details_reset", [post] );
+    $(document).trigger('dt_record_details_reset', [post]);
   }
   resetDetailsFields();
 
   function phoneLinkClick() {
-    $('.phone-link').on('click', function(event){
+    $('.phone-link').on('click', function (event) {
       event.preventDefault();
-      let phoneNumber = this.href.substring(4).replaceAll(/\s/g, "");
-      if ($(`.phone-open-with-container.__${phoneNumber.replace(/^((\+)|(00))/,"")}`).length && $(this).next(`.phone-open-with-container.__${phoneNumber.replace(/^((\+)|(00))/,"")}`)) {
-          $(`.phone-open-with-container.__${phoneNumber.replace(/^((\+)|(00))/,"")}`).remove();
+      let phoneNumber = this.href.substring(4).replaceAll(/\s/g, '');
+      if (
+        $(
+          `.phone-open-with-container.__${phoneNumber.replace(/^((\+)|(00))/, '')}`,
+        ).length &&
+        $(this).next(
+          `.phone-open-with-container.__${phoneNumber.replace(/^((\+)|(00))/, '')}`,
+        )
+      ) {
+        $(
+          `.phone-open-with-container.__${phoneNumber.replace(/^((\+)|(00))/, '')}`,
+        ).remove();
       } else {
         $('.phone-open-with-container').remove();
         let PhoneLink = this;
-        let messagingServices = window.post_type_fields.contact_phone.messagingServices;
+        let messagingServices =
+          window.post_type_fields.contact_phone.messagingServices;
         let messagingServicesLinks = ``;
 
         for (const service in messagingServices) {
-          let link = messagingServices[service].link.replace('PHONE_NUMBER_NO_PLUS', phoneNumber.replace(/^((\+)|(00))/,"")).replace('PHONE_NUMBER', phoneNumber);
+          let link = messagingServices[service].link
+            .replace(
+              'PHONE_NUMBER_NO_PLUS',
+              phoneNumber.replace(/^((\+)|(00))/, ''),
+            )
+            .replace('PHONE_NUMBER', phoneNumber);
 
-          messagingServicesLinks = messagingServicesLinks + `<li><a href="${link}" title="${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.Open_with)} ${messagingServices[service].name}" target="_blank" class="phone-open-with-link"><img src="${messagingServices[service].icon}"/>${messagingServices[service].name}</a></li>`
+          messagingServicesLinks =
+            messagingServicesLinks +
+            `<li><a href="${link}" title="${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.Open_with)} ${messagingServices[service].name}" target="_blank" class="phone-open-with-link"><img src="${messagingServices[service].icon}"/>${messagingServices[service].name}</a></li>`;
         }
 
-        let openWithDiv = `<div class="phone-open-with-container __${phoneNumber.replace(/^((\+)|(00))/,"")}">
+        let openWithDiv = `<div class="phone-open-with-container __${phoneNumber.replace(/^((\+)|(00))/, '')}">
         <strong>${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.Open_with)}...</strong>
           <ul>
-            <li><a href="${PhoneLink}" title="${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.Open_with)} ${window.post_type_fields.contact_phone.name}" target="_blank" class="phone-open-with-link"><img src="${window.SHAREDFUNCTIONS.escapeHTML( window.wpApiShare.template_dir )}/dt-assets/images/phone.svg"/>${window.post_type_fields.contact_phone.name}</a></li>
-            ${(navigator.platform === "MacIntel" || navigator.platform == "iPhone" || navigator.platform == "iPad" || navigator.platform == "iPod") ? `<li><a href="iMessage://${phoneNumber}" title="${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.Open_with)} iMessage" target="_blank" class="phone-open-with-link"><img src="${window.SHAREDFUNCTIONS.escapeHTML( window.wpApiShare.template_dir )}/dt-assets/images/imessage.svg"/> iMessage</a></li>` : ""
+            <li><a href="${PhoneLink}" title="${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.Open_with)} ${window.post_type_fields.contact_phone.name}" target="_blank" class="phone-open-with-link"><img src="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.template_dir)}/dt-assets/images/phone.svg"/>${window.post_type_fields.contact_phone.name}</a></li>
+            ${
+              navigator.platform === 'MacIntel' ||
+              navigator.platform == 'iPhone' ||
+              navigator.platform == 'iPad' ||
+              navigator.platform == 'iPod'
+                ? `<li><a href="iMessage://${phoneNumber}" title="${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.Open_with)} iMessage" target="_blank" class="phone-open-with-link"><img src="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.template_dir)}/dt-assets/images/imessage.svg"/> iMessage</a></li>`
+                : ''
             }
             ${messagingServicesLinks}
           </ul>
-        </div>`
+        </div>`;
 
-        this.insertAdjacentHTML("afterend", openWithDiv);
+        this.insertAdjacentHTML('afterend', openWithDiv);
 
-        $('.phone-open-with-link').on('click', function() {
+        $('.phone-open-with-link').on('click', function () {
           $(this).parents('.phone-open-with-container').remove();
-        })
+        });
       }
     });
   }
 
-  $('#delete-record').on('click', function(){
-    $(this).attr("disabled", true).addClass("loading");
-    window.API.delete_post( post_type, post_id ).then(()=>{
-      window.location = window.wpApiShare.site_url + '/' + post_type
-    })
-  })
-  $('#archive-record').on('click', function(){
-    $(this).attr("disabled", true).addClass("loading");
-    window.API.update_post( post_type, post_id, {overall_status:"closed"} ).then(()=>{
-      $(this).attr("disabled", false).removeClass("loading");
+  $('#delete-record').on('click', function () {
+    $(this).attr('disabled', true).addClass('loading');
+    window.API.delete_post(post_type, post_id).then(() => {
+      window.location = window.wpApiShare.site_url + '/' + post_type;
+    });
+  });
+  $('#archive-record').on('click', function () {
+    $(this).attr('disabled', true).addClass('loading');
+    window.API.update_post(post_type, post_id, {
+      overall_status: 'closed',
+    }).then(() => {
+      $(this).attr('disabled', false).removeClass('loading');
       $('#archive-record-modal').foundation('close');
-      $('.archived-notification').show()
-    })
-  })
-  $('#unarchive-record').on('click', function(){
-    $(this).attr("disabled", true).addClass("loading");
-    window.API.update_post( post_type, post_id, {overall_status:"active"} ).then(()=>{
-      $(this).attr("disabled", false).removeClass("loading");
-      $('.archived-notification').hide()
-    })
-  })
+      $('.archived-notification').show();
+    });
+  });
+  $('#unarchive-record').on('click', function () {
+    $(this).attr('disabled', true).addClass('loading');
+    window.API.update_post(post_type, post_id, {
+      overall_status: 'active',
+    }).then(() => {
+      $(this).attr('disabled', false).removeClass('loading');
+      $('.archived-notification').hide();
+    });
+  });
 
   //autofocus the first input when a modal is opened.
-  $(".reveal").on("open.zf.reveal", function () {
-    const firstField = $(this).find("input").filter(
-      ":not([disabled],[hidden],[opacity=0]):visible:first"
-    );
+  $('.reveal').on('open.zf.reveal', function () {
+    const firstField = $(this)
+      .find('input')
+      .filter(':not([disabled],[hidden],[opacity=0]):visible:first');
     if (firstField.length !== 0) {
       firstField.focus();
     }
   });
 
   if (records_list.length > 0) {
-    $.each(records_list, function(record_id, post_id_array) {
+    $.each(records_list, function (record_id, post_id_array) {
       if (post_id === post_id_array.ID) {
         current_record = record_id;
-        next_record    = record_id+1;
+        next_record = record_id + 1;
       }
     });
 
-    if ( current_record === 0 || typeof(records_list[current_record-1]) === 'undefined') {
+    if (
+      current_record === 0 ||
+      typeof records_list[current_record - 1] === 'undefined'
+    ) {
       $(document).find('.navigation-previous').hide();
     } else {
-      let link = window.wpApiShare.site_url + '/' + window.detailsSettings.post_type + '/' + records_list[current_record-1].ID
+      let link =
+        window.wpApiShare.site_url +
+        '/' +
+        window.detailsSettings.post_type +
+        '/' +
+        records_list[current_record - 1].ID;
       $(document).find('.navigation-previous').attr('href', link);
       $(document).find('.navigation-previous').removeAttr('style');
     }
 
-    if (typeof (records_list[next_record]) !== 'undefined') {
-      let link = window.wpApiShare.site_url + '/' + window.detailsSettings.post_type + '/' + records_list[next_record].ID
+    if (typeof records_list[next_record] !== 'undefined') {
+      let link =
+        window.wpApiShare.site_url +
+        '/' +
+        window.detailsSettings.post_type +
+        '/' +
+        records_list[next_record].ID;
       $(document).find('.navigation-next').attr('href', link);
       $(document).find('.navigation-next').removeAttr('style');
     } else {
       $(document).find('.navigation-next').hide();
     }
-
   } else {
-    $(document).find('.navigation-next').removeAttr('style').attr('style', 'display: none;');
+    $(document)
+      .find('.navigation-next')
+      .removeAttr('style')
+      .attr('style', 'display: none;');
   }
 
   /**
    * Merging
    */
 
-  $('.open-merge-with-post').on("click", function (evt) {
+  $('.open-merge-with-post').on('click', function (evt) {
     let merge_post_type = $(evt.currentTarget).data('post_type');
     if (!window.Typeahead['.js-typeahead-merge_with']) {
       $.typeahead({
@@ -1421,34 +1812,42 @@ jQuery(document).ready(function($) {
         minLength: 0,
         accent: true,
         searchOnFocus: true,
-        source: window.TYPEAHEADS.typeaheadPostsSource(merge_post_type, {'include-users': false}),
-        templateValue: "{{name}}",
+        source: window.TYPEAHEADS.typeaheadPostsSource(merge_post_type, {
+          'include-users': false,
+        }),
+        templateValue: '{{name}}',
         template: window.TYPEAHEADS.contactListRowTemplate,
         dynamic: true,
         hint: true,
-        emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.no_records_found),
+        emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(
+          window.wpApiShare.translations.no_records_found,
+        ),
         callback: {
           onClick: function (node, a, item) {
-            $('.confirm-merge-with-post').show()
-            $('#confirm-merge-with-post-id').val(item.ID)
-            $('#name-of-post-to-merge').html(item.name)
+            $('.confirm-merge-with-post').show();
+            $('#confirm-merge-with-post-id').val(item.ID);
+            $('#name-of-post-to-merge').html(item.name);
           },
           onResult: function (node, query, result, resultCount) {
-            let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+            let text = window.TYPEAHEADS.typeaheadHelpText(
+              resultCount,
+              query,
+              result,
+            );
             $('#merge_with-result-container').html(text);
           },
           onHideLayout: function () {
-            $('.merge_with-result-container').html("");
+            $('.merge_with-result-container').html('');
           },
         },
       });
     }
-    let user_select_input = $(`.js-typeahead-merge_with`)
+    let user_select_input = $(`.js-typeahead-merge_with`);
     $('.search_merge_with').on('click', function () {
-      user_select_input.val("")
-      user_select_input.trigger('input.typeahead')
-      user_select_input.focus()
-    })
+      user_select_input.val('');
+      user_select_input.trigger('input.typeahead');
+      user_select_input.focus();
+    });
     $('#merge-with-post-modal').foundation('open');
   });
 
@@ -1457,7 +1856,7 @@ jQuery(document).ready(function($) {
    */
 
   $(document).on('click', '#hidden_tiles_section_show_but', function (e) {
-    $('.hidden-grid-item').removeClass('hidden-grid-item')
+    $('.hidden-grid-item').removeClass('hidden-grid-item');
     window.masonGrid.masonry('layout');
 
     // Hide show hidden tiles section.
@@ -1474,19 +1873,19 @@ jQuery(document).ready(function($) {
     // First, determine the total number of hidden sections.
     $('.custom-tile-section').each(function (idx, section) {
       if ($(section).is(':hidden')) {
-
         // Increment count accordingly, ensuring certain sections are ignored.
-        if (!window.lodash.includes(['details', 'status'], $(section).attr('id'))) {
+        if (
+          !window.lodash.includes(['details', 'status'], $(section).attr('id'))
+        ) {
           hidden_count++;
         }
       }
     });
 
     // Display show hidden tiles option accordingly based on count.
-    hidden_tiles_section_count.html((hidden_count > 0) ? hidden_count : 0);
+    hidden_tiles_section_count.html(hidden_count > 0 ? hidden_count : 0);
     if (hidden_count === 0) {
       hidden_tiles_section.fadeOut('fast');
-
     } else {
       hidden_tiles_section.fadeIn('fast');
     }
@@ -1495,12 +1894,10 @@ jQuery(document).ready(function($) {
   /**
    * Custom Tile Display - [END]
    */
-
-})
-
+});
 
 // change update needed notification and switch if needed.
 function record_updated(updateNeeded) {
-  jQuery('.update-needed-notification').toggle(updateNeeded)
-  jQuery('.update-needed').prop("checked", updateNeeded)
+  jQuery('.update-needed-notification').toggle(updateNeeded);
+  jQuery('.update-needed').prop('checked', updateNeeded);
 }

--- a/dt-assets/js/footer-scripts.js
+++ b/dt-assets/js/footer-scripts.js
@@ -3,14 +3,15 @@ These functions make sure WordPress
 and Foundation play nice together.
 */
 if (window.Foundation.MediaQuery.current == 'small') {
-  jQuery('.title-bar').removeAttr('data-sticky').removeClass('is-anchored is-at-bottom').attr('style', '');
+  jQuery('.title-bar')
+    .removeAttr('data-sticky')
+    .removeClass('is-anchored is-at-bottom')
+    .attr('style', '');
 }
 
 jQuery(document).foundation();
 
-
 jQuery(document).ready(function () {
-
   // Remove empty P tags created by WP inside of Accordion and Orbit
   jQuery('.accordion p:empty, .orbit p:empty').remove();
 
@@ -18,40 +19,45 @@ jQuery(document).ready(function () {
   jQuery('.archive-grid .columns').last().addClass('end');
 
   // Adds Flex Video to YouTube and Vimeo Embeds
-  jQuery('iframe[src*="youtube.com"], iframe[src*="vimeo.com"]').each(function () {
-    if (jQuery(this).innerWidth() / jQuery(this).innerHeight() > 1.5) {
-      jQuery(this).wrap("<div class='widescreen flex-video'/>");
-    } else {
-      jQuery(this).wrap("<div class='flex-video'/>");
-    }
-  });
-
+  jQuery('iframe[src*="youtube.com"], iframe[src*="vimeo.com"]').each(
+    function () {
+      if (jQuery(this).innerWidth() / jQuery(this).innerHeight() > 1.5) {
+        jQuery(this).wrap("<div class='widescreen flex-video'/>");
+      } else {
+        jQuery(this).wrap("<div class='flex-video'/>");
+      }
+    },
+  );
 });
 
 /**
-* Custom javascript for Disciple.Tools
-*
-* */
-jQuery(document).ready($ => {
+ * Custom javascript for Disciple.Tools
+ *
+ * */
+jQuery(document).ready(($) => {
   // This adds padding to the top of the offcanvas menu, if the wp admin bar is turned on for the profile.
-  $('#wpadminbar').addClass('add')
+  $('#wpadminbar').addClass('add');
 });
 
 /* Makes sure the inner-content area is no less than the full height of the screen.
-* This prevents dropdowns or other elements from being cut off on short pages */
+ * This prevents dropdowns or other elements from being cut off on short pages */
 jQuery(document).ready(function () {
-  jQuery('#inner-content ').css('min-height', window.innerHeight)
-})
+  jQuery('#inner-content ').css('min-height', window.innerHeight);
+});
 
 //Hide Top Menu More button if all items are showing
 document.addEventListener('DOMContentLoaded', top_bar_menu_more_button);
 window.addEventListener('resize', top_bar_menu_more_button);
 
-function top_bar_menu_more_button () {
-  if ( jQuery("#top-bar-menu > div.top-bar-left > ul > li:nth-last-child(2)").is(':visible')) {
-    jQuery("#more-menu-button").hide();
+function top_bar_menu_more_button() {
+  if (
+    jQuery('#top-bar-menu > div.top-bar-left > ul > li:nth-last-child(2)').is(
+      ':visible',
+    )
+  ) {
+    jQuery('#more-menu-button').hide();
   } else {
-    jQuery("#more-menu-button").show();
+    jQuery('#more-menu-button').show();
   }
 }
 
@@ -59,14 +65,18 @@ function top_bar_menu_more_button () {
  * Ensure correct side menu highlights are maintained
  */
 jQuery(document).ready(function ($) {
-
   // Determine selected menu item
-  let selected_menu_item = (window.wpApiShare.url_path === 'metrics') ? 'metrics/personal/overview' : window.wpApiShare.url_path;
+  let selected_menu_item =
+    window.wpApiShare.url_path === 'metrics'
+      ? 'metrics/personal/overview'
+      : window.wpApiShare.url_path;
 
   // Ignore url search parameters
   selected_menu_item = window.lodash.split(selected_menu_item, '?', 1)[0];
 
-  let item = $('#metrics-side-section a[href*="' + selected_menu_item + '"]').last();
+  let item = $(
+    '#metrics-side-section a[href*="' + selected_menu_item + '"]',
+  ).last();
 
   // Apply class highlight for initial
   item.parent().addClass('side-menu-item-highlight');
@@ -76,5 +86,4 @@ jQuery(document).ready(function ($) {
   if (required_parent.parent() && required_parent.parent().is('ul')) {
     required_parent.find('a').first().addClass('side-menu-item-highlight');
   }
-
 });

--- a/dt-assets/js/merge-post-details.js
+++ b/dt-assets/js/merge-post-details.js
@@ -1,5 +1,4 @@
 jQuery(function ($) {
-
   /**
    * Initial States...
    */
@@ -30,7 +29,6 @@ jQuery(function ($) {
    */
 
   function handle_primary_post_Selection() {
-
     // First, toggle post id previous selections
     let toggled_archiving_post_id = $('#main_archiving_current_post_id').val();
     let toggled_primary_post_id = $('#main_primary_current_post_id').val();
@@ -43,25 +41,36 @@ jQuery(function ($) {
 
     // Assuming valid posts have been located, proceed with refreshing layout view
     if (primary_post && archiving_post) {
-
       // Update merge column titles & post url links
-      $('#main_archiving_post_id_title').text(archiving_post['record']['title'] + ' #' + archiving_post['record']['ID']);
-      $('#main_primary_post_id_title').text(primary_post['record']['title'] + ' #' +  primary_post['record']['ID']);
+      $('#main_archiving_post_id_title').text(
+        archiving_post['record']['title'] +
+          ' #' +
+          archiving_post['record']['ID'],
+      );
+      $('#main_primary_post_id_title').text(
+        primary_post['record']['title'] + ' #' + primary_post['record']['ID'],
+      );
       $('#main_updated_post_id_title').text(primary_post['record']['ID']);
 
-      let archiving_id_link = window.merge_post_details['site_url'] + window.merge_post_details['post_settings']['post_type'] + '/' + archiving_post['record']['ID'];
-      let primary_id_link = window.merge_post_details['site_url'] + window.merge_post_details['post_settings']['post_type'] + '/' + primary_post['record']['ID'];
+      let archiving_id_link =
+        window.merge_post_details['site_url'] +
+        window.merge_post_details['post_settings']['post_type'] +
+        '/' +
+        archiving_post['record']['ID'];
+      let primary_id_link =
+        window.merge_post_details['site_url'] +
+        window.merge_post_details['post_settings']['post_type'] +
+        '/' +
+        primary_post['record']['ID'];
       $('#main_archiving_post_id_title_link').attr('href', archiving_id_link);
       $('#main_primary_post_id_title_link').attr('href', primary_id_link);
 
       // Refresh post fields
       refresh_fields(primary_post, archiving_post);
-
     }
   }
 
   function fetch_post_by_merge_type(is_primary) {
-
     // Currently selected id to be viewed as primary
     let primary_post_id = $('#main_primary_current_post_id').val();
 
@@ -69,11 +78,12 @@ jQuery(function ($) {
     let archiving_post_id = $('#main_archiving_current_post_id').val();
 
     // Return identified post
-    return (is_primary) ? window.merge_post_details['posts'][primary_post_id] : window.merge_post_details['posts'][archiving_post_id];
+    return is_primary
+      ? window.merge_post_details['posts'][primary_post_id]
+      : window.merge_post_details['posts'][archiving_post_id];
   }
 
   function refresh_fields(primary_post, archiving_post) {
-
     // Obtain dom-ref handles
     let main_archiving_fields_div = $('#main_archiving_fields_div');
     let main_primary_fields_div = $('#main_primary_fields_div');
@@ -83,77 +93,97 @@ jQuery(function ($) {
     main_archiving_fields_div.fadeOut('fast', function () {
       main_primary_fields_div.fadeOut('fast', function () {
         main_updated_fields_div.fadeOut('fast', function () {
-
           // Reset archiving & primary post fields accordingly
           main_archiving_fields_div.html(archiving_post['html']);
           main_primary_fields_div.html(primary_post['html']);
 
           // Updating fields to revert back to default blank state
-          main_updated_fields_div.html(window.merge_post_details['post_fields_default_html']);
+          main_updated_fields_div.html(
+            window.merge_post_details['post_fields_default_html'],
+          );
 
           // Initialise/Activate recently added html fields
-          init_fields(archiving_post['record'], main_archiving_fields_div, true);
+          init_fields(
+            archiving_post['record'],
+            main_archiving_fields_div,
+            true,
+          );
           init_fields(primary_post['record'], main_primary_fields_div, true);
           init_fields(null, main_updated_fields_div, false);
 
           // Adjust & trigger field selections to default states; which should set updating fields accordingly
-          main_primary_fields_div.find('.field-select').each(function (idx, input) {
-            let post_field_id = $(input).data('merge_update_field_id');
+          main_primary_fields_div
+            .find('.field-select')
+            .each(function (idx, input) {
+              let post_field_id = $(input).data('merge_update_field_id');
 
-            if (primary_post['record'][post_field_id] && can_select_field($(input).parent().parent())) {
-              $(input).prop('checked', true);
-              $(input).trigger('change');
-
-            } else {
-
-              // Otherwise, attempt to default to valid corresponding archiving field
-              if ($(input).attr('type') === 'radio') {
-
-                // Attempt to identify corresponding archive radio input
-                let archive_input = main_archiving_fields_div.find('input[data-merge_field_id="' + archiving_post['record']['ID'] + '_' + post_field_id + '"]');
-                if (archiving_post['record'][post_field_id] && archive_input && can_select_field($(archive_input).parent().parent())) {
-                  $(archive_input).prop('checked', true);
-                  $(archive_input).trigger('change');
-
+              if (
+                primary_post['record'][post_field_id] &&
+                can_select_field($(input).parent().parent())
+              ) {
+                $(input).prop('checked', true);
+                $(input).trigger('change');
+              } else {
+                // Otherwise, attempt to default to valid corresponding archiving field
+                if ($(input).attr('type') === 'radio') {
+                  // Attempt to identify corresponding archive radio input
+                  let archive_input = main_archiving_fields_div.find(
+                    'input[data-merge_field_id="' +
+                      archiving_post['record']['ID'] +
+                      '_' +
+                      post_field_id +
+                      '"]',
+                  );
+                  if (
+                    archiving_post['record'][post_field_id] &&
+                    archive_input &&
+                    can_select_field($(archive_input).parent().parent())
+                  ) {
+                    $(archive_input).prop('checked', true);
+                    $(archive_input).trigger('change');
+                  }
                 }
               }
-            }
-          });
+            });
 
           // Select any archiving fields suitable for auto merging
-          main_archiving_fields_div.find('.field-select').each(function (idx, input) {
-            if ($(input).attr('type') === 'checkbox') {
-              let post_field_id = $(input).data('merge_update_field_id');
-              if (archiving_post['record'][post_field_id]) {
-                $(input).prop('checked', can_select_field($(input).parent().parent()));
-                $(input).trigger('change');
+          main_archiving_fields_div
+            .find('.field-select')
+            .each(function (idx, input) {
+              if ($(input).attr('type') === 'checkbox') {
+                let post_field_id = $(input).data('merge_update_field_id');
+                if (archiving_post['record'][post_field_id]) {
+                  $(input).prop(
+                    'checked',
+                    can_select_field($(input).parent().parent()),
+                  );
+                  $(input).trigger('change');
+                }
               }
-            }
-          });
+            });
 
           // Display refreshed post fields
           main_archiving_fields_div.fadeIn('fast', function () {
             main_primary_fields_div.fadeIn('fast', function () {
               main_updated_fields_div.fadeIn('fast', function () {
-
                 // Housekeeping - Ensure all typeahead input fields are displayed nicely ;-)
                 $.each(window.Typeahead, function (key, typeahead) {
-                  if ((typeof typeahead.adjustInputSize === 'function') && !$.isEmptyObject(typeahead.label)) {
+                  if (
+                    typeof typeahead.adjustInputSize === 'function' &&
+                    !$.isEmptyObject(typeahead.label)
+                  ) {
                     typeahead.adjustInputSize();
                   }
                 });
-
               });
             });
           });
-
         });
       });
     });
   }
 
   function can_select_field(td_field_input) {
-
     // Ensure field has a value in order to be selected
     let field_id = $(td_field_input).find('#merge_field_id').val();
     let field_type = $(td_field_input).find('#merge_field_type').val();
@@ -168,10 +198,15 @@ jQuery(function ($) {
         return !window.lodash.isEmpty($('#' + field_id).val());
 
       case 'key_select':
-        return !window.lodash.isEmpty($('#' + field_id).val()) || !window.lodash.isEmpty($('#' + post_field_id).val());
+        return (
+          !window.lodash.isEmpty($('#' + field_id).val()) ||
+          !window.lodash.isEmpty($('#' + post_field_id).val())
+        );
 
       case 'multi_select':
-        return !window.lodash.isEmpty($(td_field_input).find('button.selected-select-button'));
+        return !window.lodash.isEmpty(
+          $(td_field_input).find('button.selected-select-button'),
+        );
 
       case 'tags':
       case 'location': {
@@ -180,377 +215,435 @@ jQuery(function ($) {
       }
 
       case 'link':
-        return !window.lodash.isEmpty($(td_field_input).find('input.link-input').not('[value=""]'));
+        return !window.lodash.isEmpty(
+          $(td_field_input).find('input.link-input').not('[value=""]'),
+        );
 
       case 'communication_channel':
       case 'location_meta':
-        return !window.lodash.isEmpty($(td_field_input).find('input.input-group-field').not('[value=""]'));
+        return !window.lodash.isEmpty(
+          $(td_field_input).find('input.input-group-field').not('[value=""]'),
+        );
 
       case 'user_select': {
-        let user_select_typeahead = window.Typeahead['.js-typeahead-' + field_id];
-        return user_select_typeahead && !window.lodash.isEmpty(user_select_typeahead.item);
+        let user_select_typeahead =
+          window.Typeahead['.js-typeahead-' + field_id];
+        return (
+          user_select_typeahead &&
+          !window.lodash.isEmpty(user_select_typeahead.item)
+        );
       }
 
       case 'connection': {
-        let connection_typeahead = window.Typeahead['.js-typeahead-' + field_id];
-        return connection_typeahead && !window.lodash.isEmpty(connection_typeahead.items);
+        let connection_typeahead =
+          window.Typeahead['.js-typeahead-' + field_id];
+        return (
+          connection_typeahead &&
+          !window.lodash.isEmpty(connection_typeahead.items)
+        );
       }
     }
 
     return false;
-
   }
 
   function init_fields(post, fields_div, read_only) {
-
     let url_root = window.merge_post_details['url_root'];
     let post_type = window.merge_post_details['post_settings']['post_type'];
     let nonce = window.merge_post_details['nonce'];
 
-    $(fields_div).find('table tbody tr .td-field-input').each(function (idx, td) {
+    $(fields_div)
+      .find('table tbody tr .td-field-input')
+      .each(function (idx, td) {
+        // Determine field id and type + meta
+        let field_id = $(td).find('#merge_field_id').val();
+        let field_type = $(td).find('#merge_field_type').val();
+        let field_meta = $(td).find('#field_meta');
 
-      // Determine field id and type + meta
-      let field_id = $(td).find('#merge_field_id').val();
-      let field_type = $(td).find('#merge_field_type').val();
-      let field_meta = $(td).find('#field_meta');
+        // Remove field prefix, ahead of further downstream processing
+        let post_field_id = post
+          ? window.lodash.replace(field_id, post['ID'] + '_', '')
+          : $(td).find('#post_field_id').val();
 
-      // Remove field prefix, ahead of further downstream processing
-      let post_field_id = post ? window.lodash.replace(field_id, post['ID'] + '_', '') : $(td).find('#post_field_id').val();
+        // Activate field accordingly, based on type and read-only flag
+        switch (field_type) {
+          case 'textarea':
+          case 'number':
+          case 'boolean':
+          case 'text':
+            // Disable field accordingly, based on read-only flag
+            $(td)
+              .find('#' + field_id)
+              .prop('disabled', read_only);
+            break;
 
-      // Activate field accordingly, based on type and read-only flag
-      switch (field_type) {
-        case 'textarea':
-        case 'number':
-        case 'boolean':
-        case 'text':
+          case 'key_select': {
+            // Disable field accordingly, based on read-only flag and select type
+            let key_select = null;
 
-          // Disable field accordingly, based on read-only flag
-          $(td).find('#' + field_id).prop('disabled', read_only);
-          break;
-
-        case 'key_select': {
-
-          // Disable field accordingly, based on read-only flag and select type
-          let key_select = null;
-
-          // Determine select type
-          if ($(td).find('#' + field_id).length > 0) {
-            key_select = $(td).find('#' + field_id);
-          } else if (($(td).find('#' + post_field_id).length > 0) && !window.lodash.isEmpty($(td).find('#' + post_field_id).css('background-color'))) {
-            key_select = $(td).find('#' + post_field_id);
-          }
-
-          // Assuming we have a handle on a valid select, disable accoridngly
-          if (key_select) {
-            key_select.prop('disabled', read_only);
-          }
-
-          break;
-        }
-
-        case 'date': {
-
-          /**
-           * Load Date Range Picker
-           */
-
-          let date_format = 'MMMM D, YYYY';
-          let date_config = {
-            autoUpdateInput: false,
-            singleDatePicker: true,
-            timePicker: true,
-            locale: {
-              format: date_format
+            // Determine select type
+            if ($(td).find('#' + field_id).length > 0) {
+              key_select = $(td).find('#' + field_id);
+            } else if (
+              $(td).find('#' + post_field_id).length > 0 &&
+              !window.lodash.isEmpty(
+                $(td)
+                  .find('#' + post_field_id)
+                  .css('background-color'),
+              )
+            ) {
+              key_select = $(td).find('#' + post_field_id);
             }
-          };
 
-          // Adjust start date based on post's date timestamp; if present
-          let post_timestamp = $(td).find('#' + field_id).val();
-          let hasStartDate = (post_timestamp && post && post[post_field_id] !== undefined);
-          if (hasStartDate) {
-            date_config['startDate'] = window.moment.unix(post_timestamp);
-            field_meta.val(post_timestamp);
+            // Assuming we have a handle on a valid select, disable accoridngly
+            if (key_select) {
+              key_select.prop('disabled', read_only);
+            }
+
+            break;
           }
 
-          // Initialise date range picker and respond to selections
-          $(td).find('#' + field_id).daterangepicker(date_config, function (start, end, label) {
-            if (start) {
-              field_meta.val(start.unix());
-            }
-          });
-
-          // Render start date display accoridngly, post initialisation
-          if (hasStartDate) {
-            let start_date = $(td).find('#' + field_id).data('daterangepicker').startDate.format(date_format);
-            $(td).find('#' + field_id).val(start_date);
-          }
-
-          // Respond to apply date events
-          $(td).find('#' + field_id).on('apply.daterangepicker', function (evt, picker) {
-            $(td).find('#' + field_id).val(picker.startDate.format(date_format));
-          });
-
-          // Disable field accordingly, based on read-only flag
-          $(td).find('#' + field_id).prop('disabled', read_only);
-          $(td).find('.clear-date-button').prop('disabled', read_only);
-
-          /**
-           * Clear Date
-           */
-
-          $(td).find('.clear-date-button').on('click', evt => {
-            let input_id = $(evt.currentTarget).data('inputid');
-
-            if (input_id) {
-              $(td).find('#' + input_id).val('');
-              field_meta.val('');
-            }
-          });
-
-          break;
-        }
-
-        case 'multi_select':
-
-          /**
-           * Handle Selections
-           */
-
-          if (!read_only) {
-            $(td).find('.dt_multi_select').on("click", function (evt) {
-              let multi_select = $(evt.currentTarget);
-              if (multi_select.hasClass('empty-select-button')) {
-                multi_select.removeClass('empty-select-button');
-                multi_select.addClass('selected-select-button');
-              } else {
-                multi_select.removeClass('selected-select-button');
-                multi_select.addClass('empty-select-button');
-              }
-            });
-          }
-
-          break;
-
-        case 'tags': {
-
-          /**
-           * Activate
-           */
-
-          let typeahead_tags_field_input = '.js-typeahead-' + field_id;
-
-          // Disable field accordingly, based on read-only flag
-          $(td).find(typeahead_tags_field_input).prop('disabled', read_only);
-
-          // Hide new button and default to single entry
-          $(td).find('.create-new-tag').hide();
-
-          $(td).find(typeahead_tags_field_input).typeahead({
-            input: typeahead_tags_field_input,
-            minLength: 0,
-            maxItem: 20,
-            searchOnFocus: true,
-            source: {
-              tags: {
-                display: ["name"],
-                ajax: {
-                  url: url_root + `dt-posts/v2/${post_type}/multi-select-values`,
-                  data: {
-                    s: "{{query}}",
-                    field: field_id
-                  },
-                  beforeSend: function (xhr) {
-                    xhr.setRequestHeader('X-WP-Nonce', nonce);
-                  },
-                  callback: {
-                    done: function (data) {
-                      return (data || []).map(tag => {
-                        return {name: tag}
-                      })
-                    }
-                  }
-                }
-              }
-            },
-            display: "name",
-            templateValue: "{{name}}",
-            emptyTemplate: function (query) {
-              const {addNewTagText, tagExistsText} = this.node[0].dataset
-              if (this.comparedItems.includes(query)) {
-                return tagExistsText.replace('%s', query)
-              }
-              const liItem = jQuery('<li>')
-              const button = jQuery('<button>', {
-                class: "button primary",
-                text: addNewTagText.replace('%s', query),
-              })
-              const tag = this.query
-              button.on("click", function () {
-                window.Typeahead[typeahead_tags_field_input].addMultiselectItemLayout({name: tag});
-              })
-              liItem.append(button);
-              return liItem;
-            },
-            dynamic: true,
-            multiselect: {
-              matchOn: ["name"],
-              data: function () {
-                if (post && post[post_field_id]) {
-                  return (post[post_field_id] || []).map(t => {
-                    return {name: t}
-                  })
-                } else {
-                  return {};
-                }
-              },
-              callback: {
-                onCancel: function (node, item, event) {
-                  // Keep a record of deleted tags
-                  let deleted_items = (field_meta.val()) ? JSON.parse(field_meta.val()) : [];
-                  deleted_items.push(item);
-                  field_meta.val(JSON.stringify(deleted_items));
-                }
-              },
-              href: function (item) {
-              },
-            },
-            callback: {
-              onClick: function (node, a, item, event) {
-                event.preventDefault();
-                this.addMultiselectItemLayout({name: item.name});
-              },
-              onResult: function (node, query, result, resultCount) {
-                let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
-                $(td).find(`#${field_id}-result-container`).html(text);
-              },
-              onHideLayout: function () {
-                $(td).find(`#${field_id}-result-container`).html("");
-              },
-              onShowLayout() {
-              }
-            }
-          });
-
-          /**
-           * Load
-           */
-
-          // If available, load previous post record tags
-          if (post && post[post_field_id]) {
-            let typeahead_tags = window.Typeahead[typeahead_tags_field_input];
-            let post_tags = post[post_field_id];
-
-            if ((post_tags !== undefined) && typeahead_tags) {
-              jQuery.each(post_tags, function (idx, tag) {
-                typeahead_tags.addMultiselectItemLayout({
-                  name: window.SHAREDFUNCTIONS.escapeHTML(tag)
-                });
-              });
-            }
-          }
-
-          break;
-        }
-
-        case 'link': {
-
-          // Disable/Display field accordingly, based on read-only flag
-          $(td).find('input.link-input').prop('disabled', read_only);
-          $(td).find('button.link-delete-button').prop('disabled', read_only);
-
-          // Ensure add link functionality is suppressed.
-          $(td).find('div.add-link-dropdown').remove();
-
-          if (!read_only) {
-            $(td).find('input.link-input').each(function (idx, input) {
-              if (window.lodash.isEmpty($(input).val())) {
-                $(input).parent().hide();
-              }
-            });
-
+          case 'date': {
             /**
-             * Remove
+             * Load Date Range Picker
              */
 
-            $(document).on('click', '.link-delete-button', evt => {
-              const delete_but = $(evt.currentTarget);
+            let date_format = 'MMMM D, YYYY';
+            let date_config = {
+              autoUpdateInput: false,
+              singleDatePicker: true,
+              timePicker: true,
+              locale: {
+                format: date_format,
+              },
+            };
 
-              // Keep a record of deleted meta_ids.
-              let meta_id = $(delete_but).data('meta-id');
-              let deleted_items = $(field_meta).val() ? JSON.parse($(field_meta).val()) : [];
-              if ( !window.lodash.includes( deleted_items, meta_id ) ) {
-                deleted_items.push( meta_id );
-                $(field_meta).val(JSON.stringify(deleted_items));
-              }
+            // Adjust start date based on post's date timestamp; if present
+            let post_timestamp = $(td)
+              .find('#' + field_id)
+              .val();
+            let hasStartDate =
+              post_timestamp && post && post[post_field_id] !== undefined;
+            if (hasStartDate) {
+              date_config['startDate'] = window.moment.unix(post_timestamp);
+              field_meta.val(post_timestamp);
+            }
 
-              // Finally, remove from parent.
-              $(delete_but).parent().parent().remove();
-            });
+            // Initialise date range picker and respond to selections
+            $(td)
+              .find('#' + field_id)
+              .daterangepicker(date_config, function (start, end, label) {
+                if (start) {
+                  field_meta.val(start.unix());
+                }
+              });
+
+            // Render start date display accoridngly, post initialisation
+            if (hasStartDate) {
+              let start_date = $(td)
+                .find('#' + field_id)
+                .data('daterangepicker')
+                .startDate.format(date_format);
+              $(td)
+                .find('#' + field_id)
+                .val(start_date);
+            }
+
+            // Respond to apply date events
+            $(td)
+              .find('#' + field_id)
+              .on('apply.daterangepicker', function (evt, picker) {
+                $(td)
+                  .find('#' + field_id)
+                  .val(picker.startDate.format(date_format));
+              });
+
+            // Disable field accordingly, based on read-only flag
+            $(td)
+              .find('#' + field_id)
+              .prop('disabled', read_only);
+            $(td).find('.clear-date-button').prop('disabled', read_only);
+
+            /**
+             * Clear Date
+             */
+
+            $(td)
+              .find('.clear-date-button')
+              .on('click', (evt) => {
+                let input_id = $(evt.currentTarget).data('inputid');
+
+                if (input_id) {
+                  $(td)
+                    .find('#' + input_id)
+                    .val('');
+                  field_meta.val('');
+                }
+              });
+
+            break;
           }
 
-          break;
-        }
+          case 'multi_select':
+            /**
+             * Handle Selections
+             */
 
-        case 'communication_channel':
+            if (!read_only) {
+              $(td)
+                .find('.dt_multi_select')
+                .on('click', function (evt) {
+                  let multi_select = $(evt.currentTarget);
+                  if (multi_select.hasClass('empty-select-button')) {
+                    multi_select.removeClass('empty-select-button');
+                    multi_select.addClass('selected-select-button');
+                  } else {
+                    multi_select.removeClass('selected-select-button');
+                    multi_select.addClass('empty-select-button');
+                  }
+                });
+            }
 
-          // Disable/Display field accordingly, based on read-only flag
-          $(td).find('input.dt-communication-channel').prop('disabled', read_only);
+            break;
 
-          if (!read_only) {
-            $(td).find('input.dt-communication-channel').each(function (idx, input) {
-              if (window.lodash.isEmpty($(input).val())) {
-                $(input).parent().hide();
+          case 'tags': {
+            /**
+             * Activate
+             */
+
+            let typeahead_tags_field_input = '.js-typeahead-' + field_id;
+
+            // Disable field accordingly, based on read-only flag
+            $(td).find(typeahead_tags_field_input).prop('disabled', read_only);
+
+            // Hide new button and default to single entry
+            $(td).find('.create-new-tag').hide();
+
+            $(td)
+              .find(typeahead_tags_field_input)
+              .typeahead({
+                input: typeahead_tags_field_input,
+                minLength: 0,
+                maxItem: 20,
+                searchOnFocus: true,
+                source: {
+                  tags: {
+                    display: ['name'],
+                    ajax: {
+                      url:
+                        url_root +
+                        `dt-posts/v2/${post_type}/multi-select-values`,
+                      data: {
+                        s: '{{query}}',
+                        field: field_id,
+                      },
+                      beforeSend: function (xhr) {
+                        xhr.setRequestHeader('X-WP-Nonce', nonce);
+                      },
+                      callback: {
+                        done: function (data) {
+                          return (data || []).map((tag) => {
+                            return { name: tag };
+                          });
+                        },
+                      },
+                    },
+                  },
+                },
+                display: 'name',
+                templateValue: '{{name}}',
+                emptyTemplate: function (query) {
+                  const { addNewTagText, tagExistsText } = this.node[0].dataset;
+                  if (this.comparedItems.includes(query)) {
+                    return tagExistsText.replace('%s', query);
+                  }
+                  const liItem = jQuery('<li>');
+                  const button = jQuery('<button>', {
+                    class: 'button primary',
+                    text: addNewTagText.replace('%s', query),
+                  });
+                  const tag = this.query;
+                  button.on('click', function () {
+                    window.Typeahead[
+                      typeahead_tags_field_input
+                    ].addMultiselectItemLayout({ name: tag });
+                  });
+                  liItem.append(button);
+                  return liItem;
+                },
+                dynamic: true,
+                multiselect: {
+                  matchOn: ['name'],
+                  data: function () {
+                    if (post && post[post_field_id]) {
+                      return (post[post_field_id] || []).map((t) => {
+                        return { name: t };
+                      });
+                    } else {
+                      return {};
+                    }
+                  },
+                  callback: {
+                    onCancel: function (node, item, event) {
+                      // Keep a record of deleted tags
+                      let deleted_items = field_meta.val()
+                        ? JSON.parse(field_meta.val())
+                        : [];
+                      deleted_items.push(item);
+                      field_meta.val(JSON.stringify(deleted_items));
+                    },
+                  },
+                  href: function (item) {},
+                },
+                callback: {
+                  onClick: function (node, a, item, event) {
+                    event.preventDefault();
+                    this.addMultiselectItemLayout({ name: item.name });
+                  },
+                  onResult: function (node, query, result, resultCount) {
+                    let text = window.TYPEAHEADS.typeaheadHelpText(
+                      resultCount,
+                      query,
+                      result,
+                    );
+                    $(td).find(`#${field_id}-result-container`).html(text);
+                  },
+                  onHideLayout: function () {
+                    $(td).find(`#${field_id}-result-container`).html('');
+                  },
+                  onShowLayout() {},
+                },
+              });
+
+            /**
+             * Load
+             */
+
+            // If available, load previous post record tags
+            if (post && post[post_field_id]) {
+              let typeahead_tags = window.Typeahead[typeahead_tags_field_input];
+              let post_tags = post[post_field_id];
+
+              if (post_tags !== undefined && typeahead_tags) {
+                jQuery.each(post_tags, function (idx, tag) {
+                  typeahead_tags.addMultiselectItemLayout({
+                    name: window.SHAREDFUNCTIONS.escapeHTML(tag),
+                  });
+                });
               }
-            });
+            }
+
+            break;
           }
 
-          /**
-           * Add
-           */
+          case 'link': {
+            // Disable/Display field accordingly, based on read-only flag
+            $(td).find('input.link-input').prop('disabled', read_only);
+            $(td).find('button.link-delete-button').prop('disabled', read_only);
 
-          $(td).find('button.add-button').on('click', evt => {
-            let field = $(evt.currentTarget).data('list-class');
-            let list = $(td).find(`#edit-${field}`);
+            // Ensure add link functionality is suppressed.
+            $(td).find('div.add-link-dropdown').remove();
 
-            list.append(`
+            if (!read_only) {
+              $(td)
+                .find('input.link-input')
+                .each(function (idx, input) {
+                  if (window.lodash.isEmpty($(input).val())) {
+                    $(input).parent().hide();
+                  }
+                });
+
+              /**
+               * Remove
+               */
+
+              $(document).on('click', '.link-delete-button', (evt) => {
+                const delete_but = $(evt.currentTarget);
+
+                // Keep a record of deleted meta_ids.
+                let meta_id = $(delete_but).data('meta-id');
+                let deleted_items = $(field_meta).val()
+                  ? JSON.parse($(field_meta).val())
+                  : [];
+                if (!window.lodash.includes(deleted_items, meta_id)) {
+                  deleted_items.push(meta_id);
+                  $(field_meta).val(JSON.stringify(deleted_items));
+                }
+
+                // Finally, remove from parent.
+                $(delete_but).parent().parent().remove();
+              });
+            }
+
+            break;
+          }
+
+          case 'communication_channel':
+            // Disable/Display field accordingly, based on read-only flag
+            $(td)
+              .find('input.dt-communication-channel')
+              .prop('disabled', read_only);
+
+            if (!read_only) {
+              $(td)
+                .find('input.dt-communication-channel')
+                .each(function (idx, input) {
+                  if (window.lodash.isEmpty($(input).val())) {
+                    $(input).parent().hide();
+                  }
+                });
+            }
+
+            /**
+             * Add
+             */
+
+            $(td)
+              .find('button.add-button')
+              .on('click', (evt) => {
+                let field = $(evt.currentTarget).data('list-class');
+                let list = $(td).find(`#edit-${field}`);
+
+                list.append(`
                 <div class="input-group">
                     <input type="text" data-field="${window.SHAREDFUNCTIONS.escapeHTML(field)}" class="dt-communication-channel input-group-field" dir="auto" />
                     <div class="input-group-button">
                         <button class="button alert input-height delete-button-style channel-delete-button delete-button new-${window.SHAREDFUNCTIONS.escapeHTML(field)}" data-key="new" data-field="${window.SHAREDFUNCTIONS.escapeHTML(field)}">&times;</button>
                     </div>
                 </div>`);
-          });
+              });
 
-          /**
-           * Remove
-           */
+            /**
+             * Remove
+             */
 
-          $(document).on('click', '.channel-delete-button', evt => {
-            let field = $(evt.currentTarget).data('field');
-            let key = $(evt.currentTarget).data('key');
+            $(document).on('click', '.channel-delete-button', (evt) => {
+              let field = $(evt.currentTarget).data('field');
+              let key = $(evt.currentTarget).data('key');
 
-            // If needed, keep a record of key for future api removal.
-            if (key !== 'new') {
-              let deleted_keys = (field_meta.val()) ? JSON.parse(field_meta.val()) : [];
-              deleted_keys.push(key);
-              field_meta.val(JSON.stringify(deleted_keys));
-            }
+              // If needed, keep a record of key for future api removal.
+              if (key !== 'new') {
+                let deleted_keys = field_meta.val()
+                  ? JSON.parse(field_meta.val())
+                  : [];
+                deleted_keys.push(key);
+                field_meta.val(JSON.stringify(deleted_keys));
+              }
 
-            // Final removal of input group
-            $(evt.currentTarget).parent().parent().remove();
-          });
+              // Final removal of input group
+              $(evt.currentTarget).parent().parent().remove();
+            });
 
-          break;
+            break;
 
-        case 'location_meta': {
+          case 'location_meta': {
+            let mapbox = window.merge_post_details['mapbox'];
 
-          let mapbox = window.merge_post_details['mapbox'];
+            /**
+             * Load
+             */
 
-          /**
-           * Load
-           */
-
-          $(td).find('#mapbox-wrapper').empty().append(`
+            $(td).find('#mapbox-wrapper').empty().append(`
               <div id="location-grid-meta-results"></div>
               <div class="reveal" id="mapping-modal" data-v-offset="0" data-reveal>
                 <div id="mapping-modal-contents"></div>
@@ -560,20 +653,24 @@ jQuery(function ($) {
               </div>
           `);
 
-          // Display previously saved locations
-          let lgm_results = $(td).find('#location-grid-meta-results');
-          if (post && post['location_grid_meta'] !== undefined && post['location_grid_meta'].length !== 0) {
-            $.each(post['location_grid_meta'], function (i, v) {
-              if (v.grid_meta_id) {
-                lgm_results.append(`<div class="input-group">
+            // Display previously saved locations
+            let lgm_results = $(td).find('#location-grid-meta-results');
+            if (
+              post &&
+              post['location_grid_meta'] !== undefined &&
+              post['location_grid_meta'].length !== 0
+            ) {
+              $.each(post['location_grid_meta'], function (i, v) {
+                if (v.grid_meta_id) {
+                  lgm_results.append(`<div class="input-group">
                     <input type="text" class="active-location input-group-field" id="location-${window.SHAREDFUNCTIONS.escapeHTML(v.grid_meta_id)}" dir="auto" value="${window.SHAREDFUNCTIONS.escapeHTML(v.label)}" readonly />
                     <div class="input-group-button">
                       <button type="button" class="button success delete-button-style open-mapping-grid-modal" title="${window.SHAREDFUNCTIONS.escapeHTML(mapbox['translations']['open_modal'])}" data-id="${window.SHAREDFUNCTIONS.escapeHTML(v.grid_meta_id)}"><i class="fi-map"></i></button>
                       <button type="button" class="button alert delete-button-style delete-button mapbox-delete-button" title="${window.SHAREDFUNCTIONS.escapeHTML(mapbox['translations']['delete_location'])}" data-id="${window.SHAREDFUNCTIONS.escapeHTML(v.grid_meta_id)}">&times;</button>
                     </div>
                   </div>`);
-              } else {
-                lgm_results.append(`<div class="input-group">
+                } else {
+                  lgm_results.append(`<div class="input-group">
                     <input type="text" class="dt-communication-channel input-group-field" id="${window.SHAREDFUNCTIONS.escapeHTML(v.key)}" value="${window.SHAREDFUNCTIONS.escapeHTML(v.label)}" dir="auto" data-field="contact_address" />
                     <div class="input-group-button">
                       <button type="button" class="button success delete-button-style open-mapping-address-modal"
@@ -586,20 +683,21 @@ jQuery(function ($) {
                       <button type="button" class="button alert input-height delete-button-style channel-delete-button delete-button" title="${window.SHAREDFUNCTIONS.escapeHTML(mapbox['translations']['delete_location'])}" data-id="${window.SHAREDFUNCTIONS.escapeHTML(v.key)}" data-field="contact_address" data-key="${window.SHAREDFUNCTIONS.escapeHTML(v.key)}">&times;</button>
                     </div>
                   </div>`);
-              }
-            })
-          }
+                }
+              });
+            }
 
-          /**
-           * Add
-           */
+            /**
+             * Add
+             */
 
-          if (!read_only) {
-            $(td).find('#new-mapbox-search').on('click', evt => {
-
-              // Display search field with autosubmit disabled!
-              if ($(td).find('#mapbox-autocomplete').length === 0) {
-                $(td).find('#mapbox-wrapper').prepend(`
+            if (!read_only) {
+              $(td)
+                .find('#new-mapbox-search')
+                .on('click', (evt) => {
+                  // Display search field with autosubmit disabled!
+                  if ($(td).find('#mapbox-autocomplete').length === 0) {
+                    $(td).find('#mapbox-wrapper').prepend(`
               <div id="mapbox-autocomplete" class="mapbox-autocomplete input-group" data-autosubmit="false">
                   <input id="mapbox-search" type="text" name="mapbox_search" placeholder="${window.SHAREDFUNCTIONS.escapeHTML(mapbox['translations']['search_location'])}" autocomplete="off" dir="auto" />
                   <div class="input-group-button">
@@ -608,307 +706,370 @@ jQuery(function ($) {
                   </div>
                   <div id="mapbox-autocomplete-list" class="mapbox-autocomplete-items"></div>
               </div>`);
-              }
+                  }
 
-              // Switch over to standard workflow, with autosubmit disabled!
-              window.write_input_widget();
+                  // Switch over to standard workflow, with autosubmit disabled!
+                  window.write_input_widget();
+                });
+
+              // Hide new button and default to single entry
+              $(td).find('#new-mapbox-search').hide();
+              $(td).find('#new-mapbox-search').trigger('click');
+            }
+
+            /**
+             * Remove
+             */
+
+            $(document).on('click', '.mapbox-delete-button', (evt) => {
+              let id = $(evt.currentTarget).data('id');
+
+              // If needed, keep a record of key for future api removal.
+              if (id !== undefined) {
+                let deleted_ids = field_meta.val()
+                  ? JSON.parse(field_meta.val())
+                  : [];
+                deleted_ids.push(id);
+                field_meta.val(JSON.stringify(deleted_ids));
+
+                // Final removal of input group
+                $(evt.currentTarget).parent().parent().remove();
+              } else {
+                // Remove global selected location
+                window.selected_location_grid_meta = null;
+              }
             });
 
-            // Hide new button and default to single entry
-            $(td).find('#new-mapbox-search').hide();
-            $(td).find('#new-mapbox-search').trigger('click');
-          }
+            /**
+             * Open Modal
+             */
 
-          /**
-           * Remove
-           */
+            $(td)
+              .find('.open-mapping-grid-modal')
+              .on('click', (evt) => {
+                let grid_meta_id = $(evt.currentTarget).data('id');
+                let post_location_grid_meta = post
+                  ? post['location_grid_meta']
+                  : undefined;
 
-          $(document).on('click', '.mapbox-delete-button', evt => {
-            let id = $(evt.currentTarget).data('id');
-
-            // If needed, keep a record of key for future api removal.
-            if (id !== undefined) {
-              let deleted_ids = (field_meta.val()) ? JSON.parse(field_meta.val()) : [];
-              deleted_ids.push(id);
-              field_meta.val(JSON.stringify(deleted_ids));
-
-              // Final removal of input group
-              $(evt.currentTarget).parent().parent().remove();
-
-            } else {
-
-              // Remove global selected location
-              window.selected_location_grid_meta = null;
-            }
-          });
-
-          /**
-           * Open Modal
-           */
-
-          $(td).find('.open-mapping-grid-modal').on('click', evt => {
-            let grid_meta_id = $(evt.currentTarget).data('id');
-            let post_location_grid_meta = post ? post['location_grid_meta'] : undefined;
-
-            if (post_location_grid_meta !== undefined && post_location_grid_meta.length !== 0) {
-              $.each(post_location_grid_meta, function (i, v) {
-                if (String(grid_meta_id) === String(v.grid_meta_id)) {
-                  return window.load_modal(v.lng, v.lat, v.level, v.label, v.grid_id);
+                if (
+                  post_location_grid_meta !== undefined &&
+                  post_location_grid_meta.length !== 0
+                ) {
+                  $.each(post_location_grid_meta, function (i, v) {
+                    if (String(grid_meta_id) === String(v.grid_meta_id)) {
+                      return window.load_modal(
+                        v.lng,
+                        v.lat,
+                        v.level,
+                        v.label,
+                        v.grid_id,
+                      );
+                    }
+                  });
                 }
               });
-            }
-          });
 
-          // Disable field accordingly, based on read-only flag
-          $(td).find('#mapbox-search').prop('disabled', read_only);
+            // Disable field accordingly, based on read-only flag
+            $(td).find('#mapbox-search').prop('disabled', read_only);
 
-          break;
-        }
+            break;
+          }
 
-        case 'location': {
+          case 'location': {
+            let translations = window.merge_post_details['translations'];
 
-          let translations = window.merge_post_details['translations'];
+            let typeahead_field_input = '.js-typeahead-' + field_id;
 
-          let typeahead_field_input = '.js-typeahead-' + field_id;
+            // Disable field accordingly, based on read-only flag
+            $(td).find(typeahead_field_input).prop('disabled', read_only);
 
-          // Disable field accordingly, based on read-only flag
-          $(td).find(typeahead_field_input).prop('disabled', read_only);
+            /**
+             * Load Typeahead
+             */
 
-          /**
-           * Load Typeahead
-           */
-
-          $(td).find(typeahead_field_input).typeahead({
-            input: typeahead_field_input,
-            minLength: 0,
-            accent: true,
-            searchOnFocus: true,
-            maxItem: 20,
-            dropdownFilter: [{
-              key: 'group',
-              value: 'focus',
-              template: window.SHAREDFUNCTIONS.escapeHTML(translations['regions_of_focus']),
-              all: window.SHAREDFUNCTIONS.escapeHTML(translations['all_locations'])
-            }],
-            source: {
-              focus: {
-                display: "name",
-                ajax: {
-                  url: url_root + 'dt/v1/mapping_module/search_location_grid_by_name',
-                  data: {
-                    s: "{{query}}",
-                    filter: function () {
-                      return window.lodash.get(window.Typeahead[typeahead_field_input].filters.dropdown, 'value', 'all');
-                    }
+            $(td)
+              .find(typeahead_field_input)
+              .typeahead({
+                input: typeahead_field_input,
+                minLength: 0,
+                accent: true,
+                searchOnFocus: true,
+                maxItem: 20,
+                dropdownFilter: [
+                  {
+                    key: 'group',
+                    value: 'focus',
+                    template: window.SHAREDFUNCTIONS.escapeHTML(
+                      translations['regions_of_focus'],
+                    ),
+                    all: window.SHAREDFUNCTIONS.escapeHTML(
+                      translations['all_locations'],
+                    ),
                   },
-                  beforeSend: function (xhr) {
-                    xhr.setRequestHeader('X-WP-Nonce', nonce);
+                ],
+                source: {
+                  focus: {
+                    display: 'name',
+                    ajax: {
+                      url:
+                        url_root +
+                        'dt/v1/mapping_module/search_location_grid_by_name',
+                      data: {
+                        s: '{{query}}',
+                        filter: function () {
+                          return window.lodash.get(
+                            window.Typeahead[typeahead_field_input].filters
+                              .dropdown,
+                            'value',
+                            'all',
+                          );
+                        },
+                      },
+                      beforeSend: function (xhr) {
+                        xhr.setRequestHeader('X-WP-Nonce', nonce);
+                      },
+                      callback: {
+                        done: function (data) {
+                          return data.location_grid;
+                        },
+                      },
+                    },
+                  },
+                },
+                display: 'name',
+                templateValue: '{{name}}',
+                dynamic: true,
+                multiselect: {
+                  matchOn: ['ID'],
+                  data: function () {
+                    return [];
                   },
                   callback: {
-                    done: function (data) {
-                      return data.location_grid;
-                    }
-                  }
-                }
-              }
-            },
-            display: "name",
-            templateValue: "{{name}}",
-            dynamic: true,
-            multiselect: {
-              matchOn: ["ID"],
-              data: function () {
-                return [];
-              }, callback: {
-                onCancel: function (node, item) {
-                  // Keep a record of deleted options
-                  let deleted_items = (field_meta.val()) ? JSON.parse(field_meta.val()) : [];
-                  deleted_items.push(item);
-                  field_meta.val(JSON.stringify(deleted_items));
-                }
-              }
-            },
-            callback: {
-              onClick: function (node, a, item, event) {
-              },
-              onReady() {
-                this.filters.dropdown = {
-                  key: "group",
-                  value: "focus",
-                  template: window.SHAREDFUNCTIONS.escapeHTML(translations['regions_of_focus'])
-                };
-                this.container
-                  .removeClass("filter")
-                  .find("." + this.options.selector.filterButton)
-                  .html(window.SHAREDFUNCTIONS.escapeHTML(translations['regions_of_focus']));
-              }
-            }
-          });
-
-          // If available, load previous post record locations
-          let typeahead = window.Typeahead[typeahead_field_input];
-          let post_locations = post ? post[post_field_id] : undefined;
-
-          if ((post_locations !== undefined) && typeahead) {
-            $.each(post_locations, function (idx, location) {
-              typeahead.addMultiselectItemLayout({
-                ID: location['id'],
-                name: window.SHAREDFUNCTIONS.escapeHTML(location['label'])
+                    onCancel: function (node, item) {
+                      // Keep a record of deleted options
+                      let deleted_items = field_meta.val()
+                        ? JSON.parse(field_meta.val())
+                        : [];
+                      deleted_items.push(item);
+                      field_meta.val(JSON.stringify(deleted_items));
+                    },
+                  },
+                },
+                callback: {
+                  onClick: function (node, a, item, event) {},
+                  onReady() {
+                    this.filters.dropdown = {
+                      key: 'group',
+                      value: 'focus',
+                      template: window.SHAREDFUNCTIONS.escapeHTML(
+                        translations['regions_of_focus'],
+                      ),
+                    };
+                    this.container
+                      .removeClass('filter')
+                      .find('.' + this.options.selector.filterButton)
+                      .html(
+                        window.SHAREDFUNCTIONS.escapeHTML(
+                          translations['regions_of_focus'],
+                        ),
+                      );
+                  },
+                },
               });
-            });
+
+            // If available, load previous post record locations
+            let typeahead = window.Typeahead[typeahead_field_input];
+            let post_locations = post ? post[post_field_id] : undefined;
+
+            if (post_locations !== undefined && typeahead) {
+              $.each(post_locations, function (idx, location) {
+                typeahead.addMultiselectItemLayout({
+                  ID: location['id'],
+                  name: window.SHAREDFUNCTIONS.escapeHTML(location['label']),
+                });
+              });
+            }
+
+            break;
           }
 
-          break;
-        }
+          case 'user_select': {
+            let user_select_typeahead_field_input = '.js-typeahead-' + field_id;
 
-        case 'user_select': {
+            // Disable field accordingly, based on read-only flag
+            $(td)
+              .find(user_select_typeahead_field_input)
+              .prop('disabled', read_only);
 
-          let user_select_typeahead_field_input = '.js-typeahead-' + field_id;
+            /**
+             * Load Typeahead
+             */
 
-          // Disable field accordingly, based on read-only flag
-          $(td).find(user_select_typeahead_field_input).prop('disabled', read_only);
-
-          /**
-           * Load Typeahead
-           */
-
-          $(td).find(user_select_typeahead_field_input).typeahead({
-            input: user_select_typeahead_field_input,
-            minLength: 0,
-            maxItem: 0,
-            accent: true,
-            searchOnFocus: true,
-            source: window.TYPEAHEADS.typeaheadUserSource(),
-            templateValue: "{{name}}",
-            template: function (query, item) {
-              return `<div class="assigned-to-row" dir="auto">
+            $(td)
+              .find(user_select_typeahead_field_input)
+              .typeahead({
+                input: user_select_typeahead_field_input,
+                minLength: 0,
+                maxItem: 0,
+                accent: true,
+                searchOnFocus: true,
+                source: window.TYPEAHEADS.typeaheadUserSource(),
+                templateValue: '{{name}}',
+                template: function (query, item) {
+                  return `<div class="assigned-to-row" dir="auto">
                   <span>
                       <span class="avatar"><img style="vertical-align: text-bottom" src="{{avatar}}"/></span>
                       ${window.SHAREDFUNCTIONS.escapeHTML(item.name)}
                   </span>
                   ${item.status_color ? `<span class="status-square" style="background-color: ${window.SHAREDFUNCTIONS.escapeHTML(item.status_color)};">&nbsp;</span>` : ''}
-                  ${item.update_needed && item.update_needed > 0 ? `<span>
+                  ${
+                    item.update_needed && item.update_needed > 0
+                      ? `<span>
                     <img style="height: 12px;" src="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.template_dir)}/dt-assets/images/broken.svg"/>
                     <span style="font-size: 14px">${window.SHAREDFUNCTIONS.escapeHTML(item.update_needed)}</span>
-                  </span>` : ''}
-                </div>`;
-            },
-            dynamic: true,
-            hint: true,
-            emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.no_records_found),
-            callback: {
-              onClick: function (node, a, item) {
-              },
-              onResult: function (node, query, result, resultCount) {
-                let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
-                $(`#${field_id}-result-container`).html(text);
-              },
-              onHideLayout: function () {
-                $(`.${field_id}-result-container`).html("");
-              }
-            }
-          });
-
-          // If available, load previous post record user selection
-          let user_select_typeahead = window.Typeahead[user_select_typeahead_field_input];
-          let post_user_select = post ? post[post_field_id] : undefined;
-
-          if ((post_user_select !== undefined) && user_select_typeahead) {
-            $(user_select_typeahead_field_input).val(post_user_select['display']);
-            user_select_typeahead.item = {
-              ID: post_user_select['id'],
-              name: post_user_select['display']
-            };
-          }
-
-          break;
-        }
-
-        case 'connection': {
-
-          let connection_typeahead_field_input = '.js-typeahead-' + field_id;
-
-          // Disable field accordingly, based on read-only flag
-          $(td).find(connection_typeahead_field_input).prop('disabled', read_only);
-
-          // Hide typeahead search button
-          $(td).find('.typeahead__button').hide();
-
-          /**
-           * Load Typeahead
-           */
-
-          if ( $(td).find(connection_typeahead_field_input).length ){
-            $(td).find(connection_typeahead_field_input).typeahead({
-              input: connection_typeahead_field_input,
-              minLength: 0,
-              accent: true,
-              searchOnFocus: true,
-              maxItem: 20,
-              template: window.TYPEAHEADS.contactListRowTemplate,
-              source: window.TYPEAHEADS.typeaheadPostsSource(post_type, field_id),
-              display: ["name", "label"],
-              templateValue: function () {
-                if (this.items[this.items.length - 1].label) {
-                  return "{{label}}"
-                } else {
-                  return "{{name}}"
-                }
-              },
-              dynamic: true,
-              multiselect: {
-                matchOn: ["ID"],
-                data: [],
-                callback: {
-                  onCancel: function (node, item) {
-                    // Keep a record of deleted options
-                    let deleted_items = (field_meta.val()) ? JSON.parse(field_meta.val()) : [];
-                    deleted_items.push(item);
-                    field_meta.val(JSON.stringify(deleted_items));
+                  </span>`
+                      : ''
                   }
-                }
-              },
-              callback: {
-                onResult: function (node, query, result, resultCount) {
-                  let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result);
-                  $(`#${field_id}-result-container`).html(text);
+                </div>`;
                 },
-                onHideLayout: function () {
-                  $(`#${field_id}-result-container`).html("");
+                dynamic: true,
+                hint: true,
+                emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(
+                  window.wpApiShare.translations.no_records_found,
+                ),
+                callback: {
+                  onClick: function (node, a, item) {},
+                  onResult: function (node, query, result, resultCount) {
+                    let text = window.TYPEAHEADS.typeaheadHelpText(
+                      resultCount,
+                      query,
+                      result,
+                    );
+                    $(`#${field_id}-result-container`).html(text);
+                  },
+                  onHideLayout: function () {
+                    $(`.${field_id}-result-container`).html('');
+                  },
                 },
-                onClick: function (node, a, item, event) {
-                  // Stop list from opening again
-                  this.addMultiselectItemLayout(item)
-                  event.preventDefault()
-                  this.hideLayout();
-                  this.resetInput();
-                }
-              }
-            });
-          }
-
-          // If available, load previous post record locations
-          let connection_typeahead = window.Typeahead[connection_typeahead_field_input];
-          let post_connections = post ? post[post_field_id] : undefined;
-
-          if ((post_connections !== undefined) && connection_typeahead) {
-            $.each(post_connections, function (idx, connection) {
-              connection_typeahead.addMultiselectItemLayout({
-                ID: connection['ID'],
-                name: window.SHAREDFUNCTIONS.escapeHTML(connection['post_title'])
               });
-            });
+
+            // If available, load previous post record user selection
+            let user_select_typeahead =
+              window.Typeahead[user_select_typeahead_field_input];
+            let post_user_select = post ? post[post_field_id] : undefined;
+
+            if (post_user_select !== undefined && user_select_typeahead) {
+              $(user_select_typeahead_field_input).val(
+                post_user_select['display'],
+              );
+              user_select_typeahead.item = {
+                ID: post_user_select['id'],
+                name: post_user_select['display'],
+              };
+            }
+
+            break;
           }
 
-          break;
-        }
-      }
+          case 'connection': {
+            let connection_typeahead_field_input = '.js-typeahead-' + field_id;
 
-    });
+            // Disable field accordingly, based on read-only flag
+            $(td)
+              .find(connection_typeahead_field_input)
+              .prop('disabled', read_only);
+
+            // Hide typeahead search button
+            $(td).find('.typeahead__button').hide();
+
+            /**
+             * Load Typeahead
+             */
+
+            if ($(td).find(connection_typeahead_field_input).length) {
+              $(td)
+                .find(connection_typeahead_field_input)
+                .typeahead({
+                  input: connection_typeahead_field_input,
+                  minLength: 0,
+                  accent: true,
+                  searchOnFocus: true,
+                  maxItem: 20,
+                  template: window.TYPEAHEADS.contactListRowTemplate,
+                  source: window.TYPEAHEADS.typeaheadPostsSource(
+                    post_type,
+                    field_id,
+                  ),
+                  display: ['name', 'label'],
+                  templateValue: function () {
+                    if (this.items[this.items.length - 1].label) {
+                      return '{{label}}';
+                    } else {
+                      return '{{name}}';
+                    }
+                  },
+                  dynamic: true,
+                  multiselect: {
+                    matchOn: ['ID'],
+                    data: [],
+                    callback: {
+                      onCancel: function (node, item) {
+                        // Keep a record of deleted options
+                        let deleted_items = field_meta.val()
+                          ? JSON.parse(field_meta.val())
+                          : [];
+                        deleted_items.push(item);
+                        field_meta.val(JSON.stringify(deleted_items));
+                      },
+                    },
+                  },
+                  callback: {
+                    onResult: function (node, query, result, resultCount) {
+                      let text = window.TYPEAHEADS.typeaheadHelpText(
+                        resultCount,
+                        query,
+                        result,
+                      );
+                      $(`#${field_id}-result-container`).html(text);
+                    },
+                    onHideLayout: function () {
+                      $(`#${field_id}-result-container`).html('');
+                    },
+                    onClick: function (node, a, item, event) {
+                      // Stop list from opening again
+                      this.addMultiselectItemLayout(item);
+                      event.preventDefault();
+                      this.hideLayout();
+                      this.resetInput();
+                    },
+                  },
+                });
+            }
+
+            // If available, load previous post record locations
+            let connection_typeahead =
+              window.Typeahead[connection_typeahead_field_input];
+            let post_connections = post ? post[post_field_id] : undefined;
+
+            if (post_connections !== undefined && connection_typeahead) {
+              $.each(post_connections, function (idx, connection) {
+                connection_typeahead.addMultiselectItemLayout({
+                  ID: connection['ID'],
+                  name: window.SHAREDFUNCTIONS.escapeHTML(
+                    connection['post_title'],
+                  ),
+                });
+              });
+            }
+
+            break;
+          }
+        }
+      });
   }
 
   function handle_field_selection(evt) {
-
     // Determine selection state, field id and type
     let is_selected = $(evt.currentTarget).is(':checked');
     let update_field_id = $(evt.currentTarget).data('merge_update_field_id');
@@ -916,12 +1077,22 @@ jQuery(function ($) {
     let field_type = $(evt.currentTarget).data('merge_field_type');
 
     // Update selected fields accordingly
-    update_fields($(evt.currentTarget), is_selected, update_field_id, field_id, field_type);
-
+    update_fields(
+      $(evt.currentTarget),
+      is_selected,
+      update_field_id,
+      field_id,
+      field_type,
+    );
   }
 
-  function update_fields(selector, is_selected, update_field_id, field_id, field_type) {
-
+  function update_fields(
+    selector,
+    is_selected,
+    update_field_id,
+    field_id,
+    field_type,
+  ) {
     switch (field_type) {
       case 'textarea':
       case 'number':
@@ -934,28 +1105,39 @@ jQuery(function ($) {
 
       case 'key_select':
         if (is_selected) {
-
           // Determine select type
           let key_select = null;
           let tr = $(selector).parent().parent();
           if ($(tr).find('#' + field_id).length > 0) {
             key_select = $(tr).find('#' + field_id);
-          } else if (($(tr).find('#' + update_field_id).length > 0) && !window.lodash.isEmpty($(tr).find('#' + update_field_id).css('background-color'))) {
+          } else if (
+            $(tr).find('#' + update_field_id).length > 0 &&
+            !window.lodash.isEmpty(
+              $(tr)
+                .find('#' + update_field_id)
+                .css('background-color'),
+            )
+          ) {
             key_select = $(tr).find('#' + update_field_id);
           }
 
           // Assuming we have a handle on a valid select, update accoridngly
           if (key_select) {
-            $('#main_updated_fields_div').find('#' + update_field_id).val($(key_select).val());
+            $('#main_updated_fields_div')
+              .find('#' + update_field_id)
+              .val($(key_select).val());
           }
         }
         break;
 
       case 'date':
         if (is_selected) {
-
-          let source_date_range_picker = $('#' + field_id).data('daterangepicker');
-          let update_date_range_picker = $('#' + update_field_id).data('daterangepicker');
+          let source_date_range_picker = $('#' + field_id).data(
+            'daterangepicker',
+          );
+          let update_date_range_picker = $('#' + update_field_id).data(
+            'daterangepicker',
+          );
 
           // Determine values to be updated
           let updated_date = source_date_range_picker.startDate;
@@ -967,23 +1149,40 @@ jQuery(function ($) {
           $('#' + update_field_id).val(updated_date_ts);
 
           // Transfer metadata info
-          let source_date_field_meta = $('#' + field_id).parent().parent().find('#field_meta');
-          let update_date_field_meta = $('#' + update_field_id).parent().parent().find('#field_meta');
+          let source_date_field_meta = $('#' + field_id)
+            .parent()
+            .parent()
+            .find('#field_meta');
+          let update_date_field_meta = $('#' + update_field_id)
+            .parent()
+            .parent()
+            .find('#field_meta');
           $(update_date_field_meta).val($(source_date_field_meta).val());
-
         }
         break;
 
       case 'multi_select': {
-
         // Determine values to be updated
-        let updated_selections = $(selector.parent().parent()).find('button[data-field-key="' + update_field_id + '"].selected-select-button');
+        let updated_selections = $(selector.parent().parent()).find(
+          'button[data-field-key="' +
+            update_field_id +
+            '"].selected-select-button',
+        );
 
         // Update values accordingly
         $.each(updated_selections, function (idx, source_button) {
-          let update_button = $('#main_updated_fields_div').find('#' + $(source_button).attr('id'));
+          let update_button = $('#main_updated_fields_div').find(
+            '#' + $(source_button).attr('id'),
+          );
           if (update_button) {
-            $(update_button).toggleClass('selected-select-button', is_field_value_still_selected(update_field_id, field_type, source_button));
+            $(update_button).toggleClass(
+              'selected-select-button',
+              is_field_value_still_selected(
+                update_field_id,
+                field_type,
+                source_button,
+              ),
+            );
           }
         });
 
@@ -991,61 +1190,97 @@ jQuery(function ($) {
       }
 
       case 'tags': {
-
         // Determine values to be updated
-        let source_typeahead_tags = window.Typeahead['.js-typeahead-' + field_id];
-        let update_typeahead_tags = window.Typeahead['.js-typeahead-' + update_field_id];
+        let source_typeahead_tags =
+          window.Typeahead['.js-typeahead-' + field_id];
+        let update_typeahead_tags =
+          window.Typeahead['.js-typeahead-' + update_field_id];
 
         // Update values accordingly
         if (source_typeahead_tags && update_typeahead_tags) {
-
           // Obtain handle onto update field meta - deletion array
-          let update_tags_field_meta = $('#main_updated_fields_div').find('#' + update_field_id).parent().find('#field_meta');
-          let deleted_items = (update_tags_field_meta && ($(update_tags_field_meta).length > 0) && $(update_tags_field_meta).val()) ? JSON.parse($(update_tags_field_meta).val()) : [];
+          let update_tags_field_meta = $('#main_updated_fields_div')
+            .find('#' + update_field_id)
+            .parent()
+            .find('#field_meta');
+          let deleted_items =
+            update_tags_field_meta &&
+            $(update_tags_field_meta).length > 0 &&
+            $(update_tags_field_meta).val()
+              ? JSON.parse($(update_tags_field_meta).val())
+              : [];
 
           // Iterate source tags, updating accordingly
           $.each(source_typeahead_tags.items, function (idx, source_tag) {
-            if (is_selected) { // Add, if not already present
+            if (is_selected) {
+              // Add, if not already present
 
-              if (!window.lodash.includes(update_typeahead_tags.items, source_tag)) {
+              if (
+                !window.lodash.includes(update_typeahead_tags.items, source_tag)
+              ) {
                 update_typeahead_tags.addMultiselectItemLayout(source_tag);
 
                 // Keep deleted items in sync
-                let found_tag = window.lodash.find(deleted_items, function (item) {
-                  return new String(item['name']).valueOf() == new String(source_tag['name'].valueOf());
-                });
+                let found_tag = window.lodash.find(
+                  deleted_items,
+                  function (item) {
+                    return (
+                      new String(item['name']).valueOf() ==
+                      new String(source_tag['name'].valueOf())
+                    );
+                  },
+                );
 
                 if (found_tag) {
                   window.lodash.remove(deleted_items, found_tag);
                   $(update_tags_field_meta).val(JSON.stringify(deleted_items));
                 }
               }
+            } else {
+              // Remove, if present and not still selected anywhere else!
 
-            } else { // Remove, if present and not still selected anywhere else!
-
-              if (!is_field_value_still_selected(update_field_id, field_type, source_tag)) {
-
+              if (
+                !is_field_value_still_selected(
+                  update_field_id,
+                  field_type,
+                  source_tag,
+                )
+              ) {
                 // Remove item object
-                window.lodash.remove(update_typeahead_tags.items, function (tag) {
-                  return tag['name'] === source_tag['name'];
-                });
+                window.lodash.remove(
+                  update_typeahead_tags.items,
+                  function (tag) {
+                    return tag['name'] === source_tag['name'];
+                  },
+                );
 
                 // Remove compared item string
-                window.lodash.remove(update_typeahead_tags.comparedItems, function (tag) {
-                  return tag === source_tag['name'];
-                });
+                window.lodash.remove(
+                  update_typeahead_tags.comparedItems,
+                  function (tag) {
+                    return tag === source_tag['name'];
+                  },
+                );
 
                 // Remove matching label container
-                $(update_typeahead_tags.label.container).find('.typeahead__label').each(function (idx, label) {
-                  if ($(label).find('a').text() === source_tag['name']) {
-                    $(label).remove();
-                  }
-                });
+                $(update_typeahead_tags.label.container)
+                  .find('.typeahead__label')
+                  .each(function (idx, label) {
+                    if ($(label).find('a').text() === source_tag['name']) {
+                      $(label).remove();
+                    }
+                  });
 
                 // Keep deleted items in sync
-                let found_tag = window.lodash.find(deleted_items, function (item) {
-                  return new String(item['name']).valueOf() == new String(source_tag['name'].valueOf());
-                });
+                let found_tag = window.lodash.find(
+                  deleted_items,
+                  function (item) {
+                    return (
+                      new String(item['name']).valueOf() ==
+                      new String(source_tag['name'].valueOf())
+                    );
+                  },
+                );
 
                 if (!found_tag) {
                   deleted_items.push(source_tag);
@@ -1056,38 +1291,47 @@ jQuery(function ($) {
           });
 
           update_typeahead_tags.adjustInputSize();
-
         }
 
         break;
       }
 
       case 'link': {
-
         // Determine selector source field link inputs to be processed.
         let source_field_link_inputs = [];
         let tr = $(selector).parent().parent();
-        $(tr).find('.td-field-input input.link-input').each(function (idx, input) {
-          if( $(input).val() ) {
-            source_field_link_inputs.push(input);
-          }
-        });
+        $(tr)
+          .find('.td-field-input input.link-input')
+          .each(function (idx, input) {
+            if ($(input).val()) {
+              source_field_link_inputs.push(input);
+            }
+          });
 
         // Delete/Add updated post record, based on identified source field inputs.
         let main_updated_fields_div = $('#main_updated_fields_div');
-        let link_field_meta_input = $(main_updated_fields_div).find(`.link-list-${update_field_id}`).parent().parent().find('#field_meta');
-        let deleted_items = $(link_field_meta_input).val() ? JSON.parse($(link_field_meta_input).val()) : [];
+        let link_field_meta_input = $(main_updated_fields_div)
+          .find(`.link-list-${update_field_id}`)
+          .parent()
+          .parent()
+          .find('#field_meta');
+        let deleted_items = $(link_field_meta_input).val()
+          ? JSON.parse($(link_field_meta_input).val())
+          : [];
 
         // Locate by link field values.
         $.each(source_field_link_inputs, function (idx, input) {
-          let link_list_section_div = $(main_updated_fields_div).find(`.link-list-${update_field_id} .link-section--${ $(input).data('type') }`);
-          let matched_input = $(link_list_section_div).find(`.input-group input[value="${ $(input).val() }"].link-input`);
+          let link_list_section_div = $(main_updated_fields_div).find(
+            `.link-list-${update_field_id} .link-section--${$(input).data('type')}`,
+          );
+          let matched_input = $(link_list_section_div).find(
+            `.input-group input[value="${$(input).val()}"].link-input`,
+          );
 
           // Handle accordingly, based on incoming selected state.
-          if ( is_selected ) {
-
+          if (is_selected) {
             // Add new updated link fields.
-            if ( matched_input.length === 0 ) {
+            if (matched_input.length === 0) {
               $(link_list_section_div).append(`
                 <div class="input-group">
                     <input type="text" class="link-input input-group-field" value="${window.SHAREDFUNCTIONS.escapeHTML($(input).val())}" data-meta-id="${window.SHAREDFUNCTIONS.escapeHTML($(input).data('meta-id'))}" data-field-key="${window.SHAREDFUNCTIONS.escapeHTML(update_field_id)}" data-type="${window.SHAREDFUNCTIONS.escapeHTML($(input).data('type'))}">
@@ -1102,16 +1346,19 @@ jQuery(function ($) {
               });
               $(link_field_meta_input).val(JSON.stringify(deleted_items));
             }
-
           } else {
-
             // Remove new updated link fields.
-            if ( matched_input.length > 0 ) {
+            if (matched_input.length > 0) {
               $(matched_input).parent().remove();
 
               // Keep a record of deleted meta_ids.
-              if ( !window.lodash.includes( deleted_items, $(matched_input).data('meta-id') ) ) {
-                deleted_items.push( $(matched_input).data('meta-id') );
+              if (
+                !window.lodash.includes(
+                  deleted_items,
+                  $(matched_input).data('meta-id'),
+                )
+              ) {
+                deleted_items.push($(matched_input).data('meta-id'));
                 $(link_field_meta_input).val(JSON.stringify(deleted_items));
               }
             }
@@ -1122,10 +1369,11 @@ jQuery(function ($) {
       }
 
       case 'communication_channel': {
-
         // Determine values to be updated
         let comm_values = [];
-        let comm_elements = $(selector.parent().parent()).find('input[data-field="' + update_field_id + '"].input-group-field');
+        let comm_elements = $(selector.parent().parent()).find(
+          'input[data-field="' + update_field_id + '"].input-group-field',
+        );
         $.each(comm_elements, function (idx, element) {
           if ($(element).val()) {
             comm_values.push($(element).val());
@@ -1134,22 +1382,33 @@ jQuery(function ($) {
 
         // Update values accordingly
         if (comm_values) {
-
           // Obtain handle to existing list
-          let list = $('#main_updated_fields_div').find(`#edit-${update_field_id}`);
+          let list = $('#main_updated_fields_div').find(
+            `#edit-${update_field_id}`,
+          );
 
           // Obtain handle onto update field meta - deletion array
-          let update_field_meta = $('#main_updated_fields_div').find('#merge_field_id[value="' + update_field_id + '"]').parent().find('#field_meta');
-          let deleted_items = (update_field_meta && ($(update_field_meta).length > 0) && $(update_field_meta).val()) ? JSON.parse($(update_field_meta).val()) : [];
+          let update_field_meta = $('#main_updated_fields_div')
+            .find('#merge_field_id[value="' + update_field_id + '"]')
+            .parent()
+            .find('#field_meta');
+          let deleted_items =
+            update_field_meta &&
+            $(update_field_meta).length > 0 &&
+            $(update_field_meta).val()
+              ? JSON.parse($(update_field_meta).val())
+              : [];
 
           // Iterate over values; processing accordingly
           $.each(comm_values, function (idx, value) {
-
             // Determine if the value already exists within update list
             let has_value = false;
             let value_ele = null;
 
-            $(list).find('input[data-field="' + update_field_id + '"].input-group-field')
+            $(list)
+              .find(
+                'input[data-field="' + update_field_id + '"].input-group-field',
+              )
               .each(function (idx, input) {
                 if ($(input).val() === value) {
                   has_value = true;
@@ -1159,7 +1418,6 @@ jQuery(function ($) {
 
             // Add/Remove accordingly
             if (is_selected && !has_value) {
-
               // Add, if not already present
               list.append(`
                 <div class="input-group">
@@ -1170,80 +1428,102 @@ jQuery(function ($) {
                 </div>`);
 
               // If present, remove from deleted list
-              let purged_items = window.lodash.remove(deleted_items, function (deleted) {
-                return window.lodash.includes(value, deleted['value']);
-              });
+              let purged_items = window.lodash.remove(
+                deleted_items,
+                function (deleted) {
+                  return window.lodash.includes(value, deleted['value']);
+                },
+              );
 
               if (purged_items && purged_items.length > 0) {
                 $(update_field_meta).val(JSON.stringify(deleted_items));
               }
-
             } else if (!is_selected && has_value && value_ele) {
-
               // Remove, if present and not still selected anywhere else!
-              if (!is_field_value_still_selected(update_field_id, field_type, value)) {
+              if (
+                !is_field_value_still_selected(
+                  update_field_id,
+                  field_type,
+                  value,
+                )
+              ) {
                 $(value_ele).parent().remove();
 
                 // Keep deleted items in sync
-                if ($(value_ele).attr('id') && $(value_ele).attr('id').length > 0) {
+                if (
+                  $(value_ele).attr('id') &&
+                  $(value_ele).attr('id').length > 0
+                ) {
                   deleted_items.push({
-                    'key': $(value_ele).attr('id'),
-                    'value': value
+                    key: $(value_ele).attr('id'),
+                    value: value,
                   });
                   $(update_field_meta).val(JSON.stringify(deleted_items));
                 }
-
               }
-
             }
-
           });
-
         }
 
         break;
       }
 
       case 'location_meta': {
-
         // Determine values to be updated
-        let location_elements = $(selector.parent().parent()).find('input.input-group-field');
+        let location_elements = $(selector.parent().parent()).find(
+          'input.input-group-field',
+        );
 
         // Update values accordingly
         if (location_elements) {
-
           // Obtain handle to existing list
-          let td = $('#main_updated_fields_div').find('#mapbox-autocomplete').parent();
+          let td = $('#main_updated_fields_div')
+            .find('#mapbox-autocomplete')
+            .parent();
 
           // Obtain handle onto update field meta - deletion array
-          let update_field_meta = $('#main_updated_fields_div').find('#merge_field_id[value="' + update_field_id + '"]').parent().find('#field_meta');
-          let deleted_items = (update_field_meta && ($(update_field_meta).length > 0) && $(update_field_meta).val()) ? JSON.parse($(update_field_meta).val()) : [];
+          let update_field_meta = $('#main_updated_fields_div')
+            .find('#merge_field_id[value="' + update_field_id + '"]')
+            .parent()
+            .find('#field_meta');
+          let deleted_items =
+            update_field_meta &&
+            $(update_field_meta).length > 0 &&
+            $(update_field_meta).val()
+              ? JSON.parse($(update_field_meta).val())
+              : [];
 
           // Iterate over values; processing accordingly
           $.each(location_elements, function (idx, element) {
-
             // Determine if the value already exists within update list
             let has_value = false;
             let value_ele = null;
 
-            $(td).find('input.input-group-field').each(function (idx, input) {
-              if ($(input).val() === $(element).val()) {
-                has_value = true;
-                value_ele = input;
-              }
-            });
+            $(td)
+              .find('input.input-group-field')
+              .each(function (idx, input) {
+                if ($(input).val() === $(element).val()) {
+                  has_value = true;
+                  value_ele = input;
+                }
+              });
 
             // Add/Remove accordingly
             if (is_selected && !has_value) {
-
               // Add, if not already present
               let clone = $(element).clone();
               $(clone).css('margin-bottom', '10px');
               td.append(clone);
 
               // Keep deleted items in sync
-              if ($(clone).attr('id') && ($(clone).attr('id').length > 0) && ($(clone).attr('id').indexOf('-') >= 0)) {
-                let id = $(clone).attr('id').substring($(clone).attr('id').indexOf('-') + 1);
+              if (
+                $(clone).attr('id') &&
+                $(clone).attr('id').length > 0 &&
+                $(clone).attr('id').indexOf('-') >= 0
+              ) {
+                let id = $(clone)
+                  .attr('id')
+                  .substring($(clone).attr('id').indexOf('-') + 1);
                 if (window.lodash.includes(deleted_items, id)) {
                   window.lodash.remove(deleted_items, function (item) {
                     return new String(item).valueOf() == new String(id);
@@ -1252,16 +1532,26 @@ jQuery(function ($) {
                   $(update_field_meta).val(JSON.stringify(deleted_items));
                 }
               }
-
             } else if (!is_selected && has_value && value_ele) {
-
               // Remove, if present and not still selected anywhere else!
-              if (!is_field_value_still_selected(update_field_id, field_type, $(value_ele).val())) {
+              if (
+                !is_field_value_still_selected(
+                  update_field_id,
+                  field_type,
+                  $(value_ele).val(),
+                )
+              ) {
                 $(value_ele).remove();
 
                 // Keep deleted items in sync
-                if ($(value_ele).attr('id') && ($(value_ele).attr('id').length > 0) && ($(value_ele).attr('id').indexOf('-') >= 0)) {
-                  let id = $(value_ele).attr('id').substring($(value_ele).attr('id').indexOf('-') + 1);
+                if (
+                  $(value_ele).attr('id') &&
+                  $(value_ele).attr('id').length > 0 &&
+                  $(value_ele).attr('id').indexOf('-') >= 0
+                ) {
+                  let id = $(value_ele)
+                    .attr('id')
+                    .substring($(value_ele).attr('id').indexOf('-') + 1);
                   if (!window.lodash.includes(deleted_items, id)) {
                     deleted_items.push(id);
                     $(update_field_meta).val(JSON.stringify(deleted_items));
@@ -1269,9 +1559,7 @@ jQuery(function ($) {
                 }
               }
             }
-
           });
-
         }
 
         break;
@@ -1279,29 +1567,41 @@ jQuery(function ($) {
 
       case 'connection':
       case 'location': {
-
         // Determine values to be updated
         let source_typeahead = window.Typeahead['.js-typeahead-' + field_id];
-        let update_typeahead = window.Typeahead['.js-typeahead-' + update_field_id];
+        let update_typeahead =
+          window.Typeahead['.js-typeahead-' + update_field_id];
 
         // Update values accordingly
         if (source_typeahead && update_typeahead) {
-
           // Obtain handle onto update field meta - deletion array
-          let update_field_meta = $('#main_updated_fields_div').find('#merge_field_id[value="' + update_field_id + '"]').parent().find('#field_meta');
-          let deleted_items = (update_field_meta && ($(update_field_meta).length > 0) && $(update_field_meta).val()) ? JSON.parse($(update_field_meta).val()) : [];
+          let update_field_meta = $('#main_updated_fields_div')
+            .find('#merge_field_id[value="' + update_field_id + '"]')
+            .parent()
+            .find('#field_meta');
+          let deleted_items =
+            update_field_meta &&
+            $(update_field_meta).length > 0 &&
+            $(update_field_meta).val()
+              ? JSON.parse($(update_field_meta).val())
+              : [];
 
           // Iterate source tags, updating accordingly
           $.each(source_typeahead.items, function (idx, source) {
+            if (is_selected) {
+              // Add, if not already present
 
-            if (is_selected) { // Add, if not already present
-
-              if (!window.lodash.includes(update_typeahead.items, source['ID'])) {
+              if (
+                !window.lodash.includes(update_typeahead.items, source['ID'])
+              ) {
                 update_typeahead.addMultiselectItemLayout(source);
 
                 // Keep deleted items in sync
                 let found = window.lodash.find(deleted_items, function (item) {
-                  return new String(item['ID']).valueOf() == new String(source['ID'].valueOf());
+                  return (
+                    new String(item['ID']).valueOf() ==
+                    new String(source['ID'].valueOf())
+                  );
                 });
 
                 if (found) {
@@ -1309,95 +1609,123 @@ jQuery(function ($) {
                   $(update_field_meta).val(JSON.stringify(deleted_items));
                 }
               }
+            } else {
+              // Remove, if present and not still selected anywhere else!
 
-            } else { // Remove, if present and not still selected anywhere else!
-
-              if (!is_field_value_still_selected(update_field_id, field_type, source)) {
-
+              if (
+                !is_field_value_still_selected(
+                  update_field_id,
+                  field_type,
+                  source,
+                )
+              ) {
                 // Remove item object
                 window.lodash.remove(update_typeahead.items, function (value) {
                   return value['name'] === source['name'];
                 });
 
                 // Remove compared item string
-                window.lodash.remove(update_typeahead.comparedItems, function (value) {
-                  return new String(value).valueOf() == new String(source['ID'].valueOf());
-                });
+                window.lodash.remove(
+                  update_typeahead.comparedItems,
+                  function (value) {
+                    return (
+                      new String(value).valueOf() ==
+                      new String(source['ID'].valueOf())
+                    );
+                  },
+                );
 
                 // Remove matching label container
-                $(update_typeahead.label.container).find('.typeahead__label').each(function (idx, label) {
-                  if ($(label).find('span').not('span.typeahead__cancel-button').text() === source['name']) {
-                    $(label).remove();
-                  }
-                });
+                $(update_typeahead.label.container)
+                  .find('.typeahead__label')
+                  .each(function (idx, label) {
+                    if (
+                      $(label)
+                        .find('span')
+                        .not('span.typeahead__cancel-button')
+                        .text() === source['name']
+                    ) {
+                      $(label).remove();
+                    }
+                  });
 
                 // Keep deleted items in sync
                 let found = window.lodash.find(deleted_items, function (item) {
-                  return new String(item['ID']).valueOf() == new String(source['ID'].valueOf());
+                  return (
+                    new String(item['ID']).valueOf() ==
+                    new String(source['ID'].valueOf())
+                  );
                 });
 
                 if (!found) {
                   deleted_items.push(source);
                   $(update_field_meta).val(JSON.stringify(deleted_items));
                 }
-
               }
             }
           });
 
           update_typeahead.adjustInputSize();
-
         }
 
         break;
       }
 
       case 'user_select': {
-
         // Determine values to be updated
-        let source_user_select_typeahead_field_input = '.js-typeahead-' + field_id;
-        let update_user_select_typeahead_field_input = '.js-typeahead-' + update_field_id;
-        let source_typeahead_user_select = window.Typeahead[source_user_select_typeahead_field_input];
-        let update_typeahead_user_select = window.Typeahead[update_user_select_typeahead_field_input];
+        let source_user_select_typeahead_field_input =
+          '.js-typeahead-' + field_id;
+        let update_user_select_typeahead_field_input =
+          '.js-typeahead-' + update_field_id;
+        let source_typeahead_user_select =
+          window.Typeahead[source_user_select_typeahead_field_input];
+        let update_typeahead_user_select =
+          window.Typeahead[update_user_select_typeahead_field_input];
 
         // Update values accordingly
         if (source_typeahead_user_select && update_typeahead_user_select) {
           if (is_selected) {
-            $(update_user_select_typeahead_field_input).val($(source_user_select_typeahead_field_input).val());
-            update_typeahead_user_select.item = source_typeahead_user_select.item;
+            $(update_user_select_typeahead_field_input).val(
+              $(source_user_select_typeahead_field_input).val(),
+            );
+            update_typeahead_user_select.item =
+              source_typeahead_user_select.item;
           }
         }
 
         break;
       }
     }
-
   }
 
   function is_field_value_still_selected(field_id, field_type, field_value) {
-
     let still_selected = false;
 
     // Determine current merge state post ids + supporting meta info
     let merging_objs = [
       {
-        'post_id': $('#main_archiving_current_post_id').val(),
-        'fields_div': 'main_archiving_fields_div'
+        post_id: $('#main_archiving_current_post_id').val(),
+        fields_div: 'main_archiving_fields_div',
       },
       {
-        'post_id': $('#main_primary_current_post_id').val(),
-        'fields_div': 'main_primary_fields_div'
-      }];
+        post_id: $('#main_primary_current_post_id').val(),
+        fields_div: 'main_primary_fields_div',
+      },
+    ];
 
     // Iterate over both ids, in search of matching field values
     $.each(merging_objs, function (idx, merge_obj) {
-
       // Obtain handle on td field select input widget
-      let td_field_select_input = $('#' + merge_obj['fields_div']).find('.td-field-select input[data-merge_field_id="' + merge_obj['post_id'] + "_" + field_id + '"]');
+      let td_field_select_input = $('#' + merge_obj['fields_div']).find(
+        '.td-field-select input[data-merge_field_id="' +
+          merge_obj['post_id'] +
+          '_' +
+          field_id +
+          '"]',
+      );
 
       // Only proceed if input is selected
       if (td_field_select_input && $(td_field_select_input).is(':checked')) {
-
         // Compare values (by field type) to determine if there is still a match
         switch (field_type) {
           case 'textarea':
@@ -1408,15 +1736,23 @@ jQuery(function ($) {
             break;
           }
 
-
           case 'key_select': {
             break;
           }
 
           case 'multi_select': {
-            $(td_field_select_input).parent().parent().find('button.selected-select-button')
+            $(td_field_select_input)
+              .parent()
+              .parent()
+              .find('button.selected-select-button')
               .each(function (idx, button) {
-                if (button && ($(button).length > 0) && field_value && $(button).attr('id').valueOf() == $(field_value).attr('id').valueOf()) {
+                if (
+                  button &&
+                  $(button).length > 0 &&
+                  field_value &&
+                  $(button).attr('id').valueOf() ==
+                    $(field_value).attr('id').valueOf()
+                ) {
                   still_selected = true;
                 }
               });
@@ -1426,11 +1762,20 @@ jQuery(function ($) {
 
           case 'tags':
           case 'location': {
-            let typeahead = window.Typeahead['.js-typeahead-' + merge_obj['post_id'] + "_" + field_id];
+            let typeahead =
+              window.Typeahead[
+                '.js-typeahead-' + merge_obj['post_id'] + '_' + field_id
+              ];
             if (typeahead) {
-              let matched_value = window.lodash.find(typeahead.items, function (item) {
-                return new String(item['name']).valueOf() == new String(field_value['name'].valueOf());
-              });
+              let matched_value = window.lodash.find(
+                typeahead.items,
+                function (item) {
+                  return (
+                    new String(item['name']).valueOf() ==
+                    new String(field_value['name'].valueOf())
+                  );
+                },
+              );
 
               if (matched_value && $(matched_value).length > 0) {
                 still_selected = true;
@@ -1442,7 +1787,10 @@ jQuery(function ($) {
 
           case 'communication_channel':
           case 'location_meta': {
-            let matched_value = $(td_field_select_input).parent().parent().find('input.input-group-field[value="' + field_value + '"]');
+            let matched_value = $(td_field_select_input)
+              .parent()
+              .parent()
+              .find('input.input-group-field[value="' + field_value + '"]');
             if (matched_value && $(matched_value).length > 0) {
               still_selected = true;
             }
@@ -1455,11 +1803,20 @@ jQuery(function ($) {
           }
 
           case 'connection': {
-            let connection_typeahead = window.Typeahead['.js-typeahead-' + merge_obj['post_id'] + "_" + field_id];
+            let connection_typeahead =
+              window.Typeahead[
+                '.js-typeahead-' + merge_obj['post_id'] + '_' + field_id
+              ];
             if (connection_typeahead) {
-              let matched_value = window.lodash.find(connection_typeahead.items, function (item) {
-                return new String(item['ID']).valueOf() == new String(field_value['ID'].valueOf());
-              });
+              let matched_value = window.lodash.find(
+                connection_typeahead.items,
+                function (item) {
+                  return (
+                    new String(item['ID']).valueOf() ==
+                    new String(field_value['ID'].valueOf())
+                  );
+                },
+              );
 
               if (matched_value && $(matched_value).length > 0) {
                 still_selected = true;
@@ -1470,13 +1827,16 @@ jQuery(function ($) {
           }
         }
       }
-
     });
 
     return still_selected;
   }
 
-  function is_field_value_already_in_primary(field_id, field_type, field_value) {
+  function is_field_value_already_in_primary(
+    field_id,
+    field_type,
+    field_value,
+  ) {
     let is_already_in_primary = false;
 
     // First, obtain handle onto current primary post
@@ -1484,12 +1844,10 @@ jQuery(function ($) {
 
     // Ensure primary post contains field in question
     if (primary_post && primary_post[field_id]) {
-
       // Parse value accordingly, based on field type
       switch (field_type) {
         case 'link':
         case 'communication_channel': {
-
           $.each(primary_post[field_id], function (idx, value) {
             if (window.lodash.includes(value, field_value)) {
               is_already_in_primary = true;
@@ -1499,13 +1857,18 @@ jQuery(function ($) {
           break;
         }
       }
-
     }
 
     return is_already_in_primary;
   }
 
-  function is_link_field_value_already_in_primary(field_id, link_type, link_meta_id, link_value, check_by_value) {
+  function is_link_field_value_already_in_primary(
+    field_id,
+    link_type,
+    link_meta_id,
+    link_value,
+    check_by_value,
+  ) {
     let is_already_in_primary = false;
 
     // First, obtain handle onto current primary post
@@ -1513,17 +1876,20 @@ jQuery(function ($) {
 
     // Ensure primary post contains field in question
     if (primary_post && primary_post[field_id]) {
-
       // Parse value accordingly, based on link type, meta_id & value.
       $.each(primary_post[field_id], function (idx, value) {
         if (value['type'] && value['meta_id'] && value['value']) {
           if (value['type'] === link_type) {
-
             // Accommodate both checks by meta_id (in the event of value changes) and existing unchanged values.
-            if (!check_by_value && (String(value['meta_id']) === String(link_meta_id))) {
+            if (
+              !check_by_value &&
+              String(value['meta_id']) === String(link_meta_id)
+            ) {
               is_already_in_primary = true;
-
-            } else if (check_by_value && (String(value['value']) === String(link_value))) {
+            } else if (
+              check_by_value &&
+              String(value['value']) === String(link_value)
+            ) {
               is_already_in_primary = true;
             }
           }
@@ -1535,214 +1901,246 @@ jQuery(function ($) {
   }
 
   function handle_merge() {
-
     // Disable submit button
-    $('.submit-merge').toggleClass('loading').attr("disabled", true);
+    $('.submit-merge').toggleClass('loading').attr('disabled', true);
 
     // Start packaging updated fields
     let values = {};
-    $('#main_updated_fields_div').find('.td-field-input').each(function (idx, td) {
+    $('#main_updated_fields_div')
+      .find('.td-field-input')
+      .each(function (idx, td) {
+        let field_id = $(td).find('#merge_field_id').val();
+        let field_type = $(td).find('#merge_field_type').val();
+        let post_field_id = $(td).find('#post_field_id').val();
+        let field_meta = $(td).find('#field_meta');
 
-      let field_id = $(td).find('#merge_field_id').val();
-      let field_type = $(td).find('#merge_field_type').val();
-      let post_field_id = $(td).find('#post_field_id').val();
-      let field_meta = $(td).find('#field_meta');
+        switch (field_type) {
+          case 'textarea':
+          case 'number':
+          case 'boolean':
+          case 'text':
+          case 'key_select':
+            values[post_field_id] = $(td)
+              .find('#' + field_id)
+              .val();
+            break;
 
-      switch (field_type) {
+          case 'date':
+            values[post_field_id] = $(field_meta).val();
+            break;
 
-        case 'textarea':
-        case 'number':
-        case 'boolean':
-        case 'text':
-        case 'key_select':
-          values[post_field_id] = $(td).find('#' + field_id).val();
-          break;
+          case 'multi_select': {
+            let options = [];
+            $(td)
+              .find('button')
+              .each(function () {
+                options.push({
+                  value: $(this).attr('id'),
+                  delete: !$(this).hasClass('selected-select-button'),
+                });
+              });
 
-        case 'date':
-          values[post_field_id] = $(field_meta).val();
-          break;
-
-        case 'multi_select': {
-          let options = [];
-          $(td).find('button').each(function () {
-            options.push({
-              'value': $(this).attr('id'),
-              'delete': !$(this).hasClass('selected-select-button')
-            });
-          });
-
-          if (options) {
-            values[post_field_id] = {
-              'values': options
-            };
+            if (options) {
+              values[post_field_id] = {
+                values: options,
+              };
+            }
+            break;
           }
-          break;
-        }
 
-        case 'tags':
-        case 'location':
-        case 'connection': {
-          let typeahead = window.Typeahead['.js-typeahead-' + field_id];
-          if (typeahead) {
+          case 'tags':
+          case 'location':
+          case 'connection': {
+            let typeahead = window.Typeahead['.js-typeahead-' + field_id];
+            if (typeahead) {
+              // Determine values to be processed
+              let key = field_type === 'tags' ? 'name' : 'ID';
+              let items = typeahead.items;
+              let deletions = field_meta.val()
+                ? JSON.parse(field_meta.val())
+                : [];
 
+              // Package values and any deletions
+              let entries = [];
+              $.each(items, function (idx, item) {
+                entries.push({
+                  value: item[key],
+                });
+              });
+              $.each(deletions, function (idx, item) {
+                entries.push({
+                  value: item[key],
+                  delete: true,
+                });
+              });
+
+              // If present, capture entries
+              if (entries) {
+                values[post_field_id] = {
+                  values: entries,
+                };
+              }
+            }
+            break;
+          }
+
+          case 'location_meta': {
             // Determine values to be processed
-            let key = (field_type === 'tags') ? 'name' : 'ID';
-            let items = typeahead.items;
-            let deletions = field_meta.val() ? JSON.parse(field_meta.val()) : [];
+            let location_meta_entries = [];
+            let location_meta_deletions = field_meta.val()
+              ? JSON.parse(field_meta.val())
+              : [];
 
             // Package values and any deletions
-            let entries = [];
-            $.each(items, function (idx, item) {
-              entries.push({
-                'value': item[key]
+            $(td)
+              .find('input.input-group-field')
+              .each(function (idx, input) {
+                if ($(input).val()) {
+                  location_meta_entries.push({
+                    value: $(input).val(),
+                  });
+                }
               });
-            });
-            $.each(deletions, function (idx, item) {
-              entries.push({
-                'value': item[key],
-                'delete': true
+
+            if (window.selected_location_grid_meta !== undefined) {
+              location_meta_entries.push({
+                value: window.selected_location_grid_meta,
+              });
+            }
+
+            $.each(location_meta_deletions, function (idx, id) {
+              location_meta_entries.push({
+                grid_meta_id: id,
+                delete: true,
               });
             });
 
             // If present, capture entries
-            if (entries) {
+            if (location_meta_entries) {
               values[post_field_id] = {
-                'values': entries
+                values: location_meta_entries,
               };
             }
+            break;
           }
-          break;
-        }
 
-        case 'location_meta': {
+          case 'link': {
+            // Determine values to be processed
+            let link_entries = [];
+            let link_deletions = field_meta.val()
+              ? JSON.parse(field_meta.val())
+              : [];
 
-          // Determine values to be processed
-          let location_meta_entries = [];
-          let location_meta_deletions = field_meta.val() ? JSON.parse(field_meta.val()) : [];
+            // Package values and any deletions
+            $(td)
+              .find('.input-group input.link-input')
+              .each(function (idx, input) {
+                let link_type = $(input).data('type');
+                let link_meta_id = $(input).data('meta-id');
+                let link_val = $(input).val();
 
-          // Package values and any deletions
-          $(td).find('input.input-group-field').each(function (idx, input) {
-            if ($(input).val()) {
-              location_meta_entries.push({
-                'value': $(input).val()
+                let has_value = is_link_field_value_already_in_primary(
+                  post_field_id,
+                  link_type,
+                  link_meta_id,
+                  link_val,
+                  true,
+                );
+                let matched_meta_id = is_link_field_value_already_in_primary(
+                  post_field_id,
+                  link_type,
+                  link_meta_id,
+                  link_val,
+                  false,
+                );
+
+                if (link_val && !has_value) {
+                  link_entries.push({
+                    value: link_val,
+                    type: link_type,
+                    meta_id: matched_meta_id ? link_meta_id : '',
+                  });
+                }
               });
-            }
-          });
 
-          if (window.selected_location_grid_meta !== undefined) {
-            location_meta_entries.push({
-              'value': window.selected_location_grid_meta
-            });
-          }
-
-          $.each(location_meta_deletions, function (idx, id) {
-            location_meta_entries.push({
-              'grid_meta_id': id,
-              'delete': true
-            });
-          });
-
-          // If present, capture entries
-          if (location_meta_entries) {
-            values[post_field_id] = {
-              'values': location_meta_entries
-            };
-          }
-          break;
-        }
-
-        case 'link': {
-
-          // Determine values to be processed
-          let link_entries = [];
-          let link_deletions = field_meta.val() ? JSON.parse(field_meta.val()) : [];
-
-          // Package values and any deletions
-          $(td).find('.input-group input.link-input').each(function (idx, input) {
-            let link_type = $(input).data('type');
-            let link_meta_id = $(input).data('meta-id');
-            let link_val = $(input).val();
-
-            let has_value = is_link_field_value_already_in_primary(post_field_id, link_type, link_meta_id, link_val, true);
-            let matched_meta_id = is_link_field_value_already_in_primary(post_field_id, link_type, link_meta_id, link_val, false);
-
-            if (link_val && !has_value) {
+            $.each(link_deletions, function (idx, deleted_meta_id) {
               link_entries.push({
-                'value': link_val,
-                'type': link_type,
-                'meta_id': matched_meta_id ? link_meta_id : ''
+                meta_id: deleted_meta_id,
+                delete: true,
               });
-            }
-          });
-
-          $.each(link_deletions, function (idx, deleted_meta_id) {
-            link_entries.push({
-              'meta_id': deleted_meta_id,
-              'delete': true
             });
-          });
 
-          // If present, capture entries
-          if (link_entries) {
-            values[post_field_id] = {
-              'values': link_entries
-            };
-          }
-          break;
-        }
-
-        case 'communication_channel': {
-
-          // Determine values to be processed
-          let comm_entries = [];
-          let comm_deletions = field_meta.val() ? JSON.parse(field_meta.val()) : [];
-
-          // Package values and any deletions
-          $(td).find('.input-group').each(function () {
-            let comm_key = $(this).find('button').data('key');
-            let comm_val = $(this).find('input').val();
-
-            if (comm_val && !is_field_value_already_in_primary(post_field_id, field_type, comm_val)) {
-              let comm_entry = {
-                'value': comm_val
+            // If present, capture entries
+            if (link_entries) {
+              values[post_field_id] = {
+                values: link_entries,
               };
-
-              if (comm_key && comm_key !== 'new') {
-                comm_entry['key'] = comm_key;
-              }
-
-              comm_entries.push(comm_entry);
             }
-          });
+            break;
+          }
 
-          $.each(comm_deletions, function (idx, deleted) {
-            comm_entries.push({
-              'key': deleted['key'],
-              'delete': true
+          case 'communication_channel': {
+            // Determine values to be processed
+            let comm_entries = [];
+            let comm_deletions = field_meta.val()
+              ? JSON.parse(field_meta.val())
+              : [];
+
+            // Package values and any deletions
+            $(td)
+              .find('.input-group')
+              .each(function () {
+                let comm_key = $(this).find('button').data('key');
+                let comm_val = $(this).find('input').val();
+
+                if (
+                  comm_val &&
+                  !is_field_value_already_in_primary(
+                    post_field_id,
+                    field_type,
+                    comm_val,
+                  )
+                ) {
+                  let comm_entry = {
+                    value: comm_val,
+                  };
+
+                  if (comm_key && comm_key !== 'new') {
+                    comm_entry['key'] = comm_key;
+                  }
+
+                  comm_entries.push(comm_entry);
+                }
+              });
+
+            $.each(comm_deletions, function (idx, deleted) {
+              comm_entries.push({
+                key: deleted['key'],
+                delete: true,
+              });
             });
-          });
 
-          // If present, capture entries
-          if (comm_entries) {
-            values[post_field_id] = comm_entries;
+            // If present, capture entries
+            if (comm_entries) {
+              values[post_field_id] = comm_entries;
+            }
+            break;
           }
-          break;
-        }
 
-        case 'user_select': {
-          let user_select_typeahead = window.Typeahead['.js-typeahead-' + field_id];
-          if (user_select_typeahead && user_select_typeahead.item) {
-            values[post_field_id] = 'user-' + user_select_typeahead.item['ID'];
+          case 'user_select': {
+            let user_select_typeahead =
+              window.Typeahead['.js-typeahead-' + field_id];
+            if (user_select_typeahead && user_select_typeahead.item) {
+              values[post_field_id] =
+                'user-' + user_select_typeahead.item['ID'];
+            }
+            break;
           }
-          break;
         }
-      }
-
-    });
+      });
 
     // Submit packaged fields to backend for further processing
     if (values) {
-
       // Determine current primary & archiving post records, + others
       let post_type = window.merge_post_details['post_settings']['post_type'];
       let primary_post = fetch_post_by_merge_type(true);
@@ -1750,29 +2148,40 @@ jQuery(function ($) {
 
       // Build payload accordingly, based on updated values
       let payload = {
-        'post_type': post_type,
-        'primary_post_id': primary_post['record']['ID'],
-        'archiving_post_id': archiving_post['record']['ID'],
-        'merge_comments': $('#merge_comments').is(':checked'),
-        'values': values
+        post_type: post_type,
+        primary_post_id: primary_post['record']['ID'],
+        archiving_post_id: archiving_post['record']['ID'],
+        merge_comments: $('#merge_comments').is(':checked'),
+        values: values,
       };
 
       console.log(payload);
 
       // Finally dispatch payload to corresponding post type merge endpoint
-      window.makeRequestOnPosts("POST", window.SHAREDFUNCTIONS.escapeHTML(post_type) + '/merge', payload).then(resp => {
-        window.location = primary_post['record']['ID'];
-
-      }).catch(err => {
-        console.error(err);
-        $('.submit-merge').toggleClass('loading').attr("disabled", false);
-        $('.merge_errors').html(window.SHAREDFUNCTIONS.escapeHTML(window.merge_post_details['translations']['error_msg']) + ' : ' + window.SHAREDFUNCTIONS.escapeHTML(window.lodash.get(err, 'responseJSON.message', err)));
-      });
-
+      window
+        .makeRequestOnPosts(
+          'POST',
+          window.SHAREDFUNCTIONS.escapeHTML(post_type) + '/merge',
+          payload,
+        )
+        .then((resp) => {
+          window.location = primary_post['record']['ID'];
+        })
+        .catch((err) => {
+          console.error(err);
+          $('.submit-merge').toggleClass('loading').attr('disabled', false);
+          $('.merge_errors').html(
+            window.SHAREDFUNCTIONS.escapeHTML(
+              window.merge_post_details['translations']['error_msg'],
+            ) +
+              ' : ' +
+              window.SHAREDFUNCTIONS.escapeHTML(
+                window.lodash.get(err, 'responseJSON.message', err),
+              ),
+          );
+        });
     } else {
-      $('.submit-merge').toggleClass('loading').attr("disabled", false);
+      $('.submit-merge').toggleClass('loading').attr('disabled', false);
     }
-
   }
-
 });

--- a/dt-assets/js/modular-list.js
+++ b/dt-assets/js/modular-list.js
@@ -1,74 +1,94 @@
-"use strict";
-(function($, list_settings, Foundation) {
-  let selected_filters = $("#selected-filters")
-  let new_filter_labels = []
-  let custom_filters = []
-  let filter_to_save = "";
-  let filter_to_delete = "";
-  let filterToEdit = "";
-  let filter_accordions = $('#list-filter-tabs')
-  let currentFilters = $("#current-filters")
-  let cookie = window.SHAREDFUNCTIONS.get_json_from_local_storage("last_view", {}, list_settings.post_type);
-  let cached_filter
-  let get_records_promise = null
-  let loading_spinner = $("#list-loading-spinner")
-  let old_filters = JSON.stringify(list_settings.filters)
-  let table_header_row = $('.js-list thead .sortable th')
-  let fields_to_show_in_table = window.SHAREDFUNCTIONS.get_json_cookie( 'fields_to_show_in_table', [] );
-  let fields_to_search = window.SHAREDFUNCTIONS.get_json_cookie( 'fields_to_search', [] );
+'use strict';
+(function ($, list_settings, Foundation) {
+  let selected_filters = $('#selected-filters');
+  let new_filter_labels = [];
+  let custom_filters = [];
+  let filter_to_save = '';
+  let filter_to_delete = '';
+  let filterToEdit = '';
+  let filter_accordions = $('#list-filter-tabs');
+  let currentFilters = $('#current-filters');
+  let cookie = window.SHAREDFUNCTIONS.get_json_from_local_storage(
+    'last_view',
+    {},
+    list_settings.post_type,
+  );
+  let cached_filter;
+  let get_records_promise = null;
+  let loading_spinner = $('#list-loading-spinner');
+  let old_filters = JSON.stringify(list_settings.filters);
+  let table_header_row = $('.js-list thead .sortable th');
+  let fields_to_show_in_table = window.SHAREDFUNCTIONS.get_json_cookie(
+    'fields_to_show_in_table',
+    [],
+  );
+  let fields_to_search = window.SHAREDFUNCTIONS.get_json_cookie(
+    'fields_to_search',
+    [],
+  );
   let current_user_id = window.wpApiNotifications.current_user_id;
-  let mobile_breakpoint = 1024
-  let clearSearchButton = $('.search-input__clear-button')
-  let getFilterCountsPromise = null
-  const { status_field } = list_settings.post_type_settings
-  const { status_key, archived_key } = status_field ? status_field : {}
-  const filterOutArchivedItemsKey = `-${archived_key}`
-  const archivedSwitch = $('#archivedToggle')
-  let archivedSwitchStatus = window.SHAREDFUNCTIONS.get_json_from_local_storage( 'list_archived_switch_status', false, list_settings.post_type );
-  window.post_type_fields = list_settings.post_type_settings.fields
-  window.records_list = { posts:[], total:0 }
-  const esc = window.SHAREDFUNCTIONS.escapeHTML
+  let mobile_breakpoint = 1024;
+  let clearSearchButton = $('.search-input__clear-button');
+  let getFilterCountsPromise = null;
+  const { status_field } = list_settings.post_type_settings;
+  const { status_key, archived_key } = status_field ? status_field : {};
+  const filterOutArchivedItemsKey = `-${archived_key}`;
+  const archivedSwitch = $('#archivedToggle');
+  let archivedSwitchStatus = window.SHAREDFUNCTIONS.get_json_from_local_storage(
+    'list_archived_switch_status',
+    false,
+    list_settings.post_type,
+  );
+  window.post_type_fields = list_settings.post_type_settings.fields;
+  window.records_list = { posts: [], total: 0 };
+  const esc = window.SHAREDFUNCTIONS.escapeHTML;
 
-  const ALL_ID = '*'
-  const ALL_WITHOUT_ID = '-*'
+  const ALL_ID = '*';
+  const ALL_WITHOUT_ID = '-*';
 
-  let items = []
-  let current_filter
+  let items = [];
+  let current_filter;
 
-  on_load()
+  on_load();
 
   function on_load() {
     let cached_filter = cookie;
 
-    const query_param_custom_filter = create_custom_filter_from_query_params()
+    const query_param_custom_filter = create_custom_filter_from_query_params();
 
-    setup_archived_switch_position(archivedSwitchStatus)
+    setup_archived_switch_position(archivedSwitchStatus);
 
-    current_filter = get_current_filter(query_param_custom_filter, cached_filter);
+    current_filter = get_current_filter(
+      query_param_custom_filter,
+      cached_filter,
+    );
 
-    setup_filters()
+    setup_filters();
 
-    setup_custom_cached_filter(query_param_custom_filter, cached_filter, current_filter);
+    setup_custom_cached_filter(
+      query_param_custom_filter,
+      cached_filter,
+      current_filter,
+    );
 
     determine_list_columns(fields_to_show_in_table);
 
-    get_records_for_current_filter()
+    get_records_for_current_filter();
 
-    collapse_filters()
+    collapse_filters();
 
-    get_filter_counts(old_filters)
+    get_filter_counts(old_filters);
 
-    reset_sorting_in_table_header(current_filter)
+    reset_sorting_in_table_header(current_filter);
   }
 
   function get_current_filter(urlCustomFilter, cachedFilter) {
+    const { filterID, filterTab, query } = get_url_query_params();
 
-    const { filterID, filterTab, query } = get_url_query_params()
-
-    if (filterID && is_in_filter_list(filterID) ) {
-      const currentFilter = { ID: filterID, query: query || {} }
-      if (filterTab) currentFilter.tab = filterTab
-      return currentFilter
+    if (filterID && is_in_filter_list(filterID)) {
+      const currentFilter = { ID: filterID, query: query || {} };
+      if (filterTab) currentFilter.tab = filterTab;
+      return currentFilter;
     } else if (urlCustomFilter && !window.lodash.isEmpty(urlCustomFilter)) {
       return urlCustomFilter;
     } else if (cachedFilter && !window.lodash.isEmpty(cachedFilter)) {
@@ -77,21 +97,51 @@
     return { query: {} };
   }
 
-  function setup_custom_cached_filter(urlCustomFilter, cachedFilter, currentFilter) {
-    const { filterID } = get_url_query_params()
+  function setup_custom_cached_filter(
+    urlCustomFilter,
+    cachedFilter,
+    currentFilter,
+  ) {
+    const { filterID } = get_url_query_params();
 
-    if (!is_in_filter_list(filterID) && urlCustomFilter && !window.lodash.isEmpty(urlCustomFilter) && urlCustomFilter.type === "custom_filter") {
+    if (
+      !is_in_filter_list(filterID) &&
+      urlCustomFilter &&
+      !window.lodash.isEmpty(urlCustomFilter) &&
+      urlCustomFilter.type === 'custom_filter'
+    ) {
       urlCustomFilter.query.offset = 0;
-      add_custom_filter(urlCustomFilter.name, "default", urlCustomFilter.query, urlCustomFilter.labels, false);
-    } else if (!is_in_filter_list(filterID) && cachedFilter && !window.lodash.isEmpty(cachedFilter) && cachedFilter.type === "custom_filter") {
+      add_custom_filter(
+        urlCustomFilter.name,
+        'default',
+        urlCustomFilter.query,
+        urlCustomFilter.labels,
+        false,
+      );
+    } else if (
+      !is_in_filter_list(filterID) &&
+      cachedFilter &&
+      !window.lodash.isEmpty(cachedFilter) &&
+      cachedFilter.type === 'custom_filter'
+    ) {
       cachedFilter.query.offset = 0;
-      add_custom_filter(cachedFilter.name, "default", cachedFilter.query, cachedFilter.labels, false);
+      add_custom_filter(
+        cachedFilter.name,
+        'default',
+        cachedFilter.query,
+        cachedFilter.labels,
+        false,
+      );
     } else {
       //check select filter
       if (currentFilter.ID) {
         //open the filter tabs
-        $(`#list-filter-tabs [data-id='${window.SHAREDFUNCTIONS.escapeHTML(currentFilter.tab)}'] a`).click();
-        let filter_element = $(`input[name=view][data-id="${window.SHAREDFUNCTIONS.escapeHTML(currentFilter.ID)}"].js-list-view`);
+        $(
+          `#list-filter-tabs [data-id='${window.SHAREDFUNCTIONS.escapeHTML(currentFilter.tab)}'] a`,
+        ).click();
+        let filter_element = $(
+          `input[name=view][data-id="${window.SHAREDFUNCTIONS.escapeHTML(currentFilter.ID)}"].js-list-view`,
+        );
         if (filter_element.length) {
           filter_element.prop('checked', true);
         } else {
@@ -103,14 +153,14 @@
     }
   }
 
-  function check_first_filter (){
-    $('#list-filter-tabs .accordion-item a')[0].click()
-    $($('.js-list-view')[0]).prop('checked', true)
+  function check_first_filter() {
+    $('#list-filter-tabs .accordion-item a')[0].click();
+    $($('.js-list-view')[0]).prop('checked', true);
   }
 
   function determine_list_columns(fieldsToShowInTable) {
-    if ( window.lodash.isEmpty(fieldsToShowInTable)){
-      fields_to_show_in_table = list_settings.fields_to_show_in_table
+    if (window.lodash.isEmpty(fieldsToShowInTable)) {
+      fields_to_show_in_table = list_settings.fields_to_show_in_table;
     }
   }
 
@@ -121,26 +171,30 @@
   });
 
   //load record for the first filter when a tile is clicked
-  $(document).on('click', '.accordion-title', function(){
-    let selected_filter = $(".js-list-view:checked").data('id')
+  $(document).on('click', '.accordion-title', function () {
+    let selected_filter = $('.js-list-view:checked').data('id');
     let tab = $(this).data('id');
-    if ( selected_filter ){
-      $(`.accordion-item[data-id='${tab}'] .js-list-view`).first().prop('checked', true);
-      get_records_for_current_filter()
+    if (selected_filter) {
+      $(`.accordion-item[data-id='${tab}'] .js-list-view`)
+        .first()
+        .prop('checked', true);
+      get_records_for_current_filter();
     }
-  })
+  });
 
   // Support field name filtering
   let searchable_filter_field_objects = build_searchable_filter_field_objects();
   function build_searchable_filter_field_objects() {
     let searchable_objs = [];
 
-    $('#filter-tabs').children().each(function (idx, li) {
-      searchable_objs.push({
-        id: $(li).find('a').attr('id'),
-        name: $(li).find('a').text().trim()
+    $('#filter-tabs')
+      .children()
+      .each(function (idx, li) {
+        searchable_objs.push({
+          id: $(li).find('a').attr('id'),
+          name: $(li).find('a').text().trim(),
+        });
       });
-    });
 
     return searchable_objs;
   }
@@ -154,11 +208,16 @@
   });
 
   function execute_searchable_filter_field_query(query) {
-
     // Search across field objects...
-    let hits = window.lodash.filter(searchable_filter_field_objects, function (field) {
-      return window.lodash.includes(field.name.trim().toLowerCase(), query.trim().toLowerCase());
-    });
+    let hits = window.lodash.filter(
+      searchable_filter_field_objects,
+      function (field) {
+        return window.lodash.includes(
+          field.name.trim().toLowerCase(),
+          query.trim().toLowerCase(),
+        );
+      },
+    );
 
     // Refresh filter fields list
     refresh_searchable_filter_field_objects(hits);
@@ -166,22 +225,20 @@
 
   function refresh_searchable_filter_field_objects(fields) {
     $('#filter-tabs').fadeOut('fast', function () {
-
       // Iterate over filter tab element's children
-      $('#filter-tabs').children().each(function (idx, li) {
+      $('#filter-tabs')
+        .children()
+        .each(function (idx, li) {
+          let id = $(li).find('a').attr('id');
+          let name = $(li).find('a').text().trim();
 
-        let id = $(li).find('a').attr('id');
-        let name = $(li).find('a').text().trim();
-
-        // Determine visibility state to adopt
-        if (window.lodash.find(fields, {'id': id, 'name': name})) {
-          $(li).show();
-
-        } else {
-          $(li).hide();
-        }
-
-      });
+          // Determine visibility state to adopt
+          if (window.lodash.find(fields, { id: id, name: name })) {
+            $(li).show();
+          } else {
+            $(li).hide();
+          }
+        });
 
       // Default to selecting first field within refreshed list
       let selected_li = $('#filter-tabs li').not('[style*="display"]').first();
@@ -195,21 +252,24 @@
   // Remove filter labels
   $(document).on('click', '.current-filter-list-close', function () {
     let label = $(this).parent();
-    remove_current_filter_label(label, get_current_filter_label_field_details(label));
+    remove_current_filter_label(
+      label,
+      get_current_filter_label_field_details(label),
+    );
   });
 
   // Collapse filter tile for mobile view
   function collapse_filters() {
-    if (window.Foundation.MediaQuery.only("small")) {
-      $('#list-filters .bordered-box').addClass('collapsed')
+    if (window.Foundation.MediaQuery.only('small')) {
+      $('#list-filters .bordered-box').addClass('collapsed');
     } else {
-      $('#list-filters .bordered-box').removeClass('collapsed')
+      $('#list-filters .bordered-box').removeClass('collapsed');
     }
   }
 
-  $(window).resize(function(){
-    collapse_filters()
-  })
+  $(window).resize(function () {
+    collapse_filters();
+  });
 
   function get_current_filter_label_field_details(label) {
     let field_id = null;
@@ -223,45 +283,40 @@
     });
 
     return {
-      'id': field_id,
-      'name': field_name
+      id: field_id,
+      name: field_name,
     };
   }
 
   function remove_current_filter_label(label, field_details) {
     if (current_filter && current_filter.labels) {
       if (field_details && field_details.id && field_details.name) {
-
         // Update current filter's labels
         let id = null;
         let labels = [];
         $.each(current_filter.labels, function (idx, val) {
-          if ((field_details.id === val.field) && (field_details.name === val.name)) {
+          if (
+            field_details.id === val.field &&
+            field_details.name === val.name
+          ) {
             id = val.id;
-
           } else {
             labels.push(val);
           }
         });
         current_filter.labels = labels;
 
-
         // Update current filter's query object
         if (id) {
-
           // Determine query object shape
           if (current_filter.query['fields']) {
-
             let fields = [];
             $.each(current_filter.query['fields'], function (idx, val) {
-
               // Do we have a match...?
               let field = val[field_details.id];
               if (field) {
-
                 let field_values = [];
                 $.each(field, function (field_idx, field_val) {
-
                   if (id !== field_val) {
                     field_values.push(field_val);
                   }
@@ -273,44 +328,40 @@
                   updated_field[field_details.id] = field_values;
                   fields.push(updated_field);
                 }
-
               } else {
                 fields.push(val);
               }
-
             });
             current_filter.query['fields'] = fields;
-
           } else if (current_filter.query[field_details.id]) {
-
             let field_values = [];
             $.each(current_filter.query[field_details.id], function (idx, val) {
-
               if (id !== val) {
                 field_values.push(val);
               }
-
             });
 
             // Update query field, if still populated
             if (field_values.length > 0) {
               current_filter.query[field_details.id] = field_values;
-
             } else {
               delete current_filter.query[field_details.id];
             }
-
           } else if (current_filter.query['text']) {
-
             // Remove text property, to force a return to all filtered view
             delete current_filter.query['text'];
 
             // Locate and select corresponding all radio button
-            $('.list-views').find('.js-list-view').each(function (idx, input) {
-              if ($.inArray($(input).data('id'), ['all_my_contacts', 'all']) !== -1) {
-                $(input).prop('checked', true);
-              }
-            });
+            $('.list-views')
+              .find('.js-list-view')
+              .each(function (idx, input) {
+                if (
+                  $.inArray($(input).data('id'), ['all_my_contacts', 'all']) !==
+                  -1
+                ) {
+                  $(input).prop('checked', true);
+                }
+              });
           }
         }
       }
@@ -321,270 +372,321 @@
 
     // Refresh view records
     get_records_for_current_filter(current_filter);
-
   }
 
   /**
    * Creates a custom filter from the query and labels in the encoded url
    */
   function create_custom_filter_from_query_params() {
-    const { query, labels, filterName } = get_url_query_params()
+    const { query, labels, filterName } = get_url_query_params();
 
-    if (!query) return {}
+    if (!query) return {};
 
     /* Creating object the same shape as cached_filter */
     let query_custom_filter = {
       ID: Date.now() / 1000,
-      name: (filterName) ? filterName : 'Custom Filter',
+      name: filterName ? filterName : 'Custom Filter',
       type: 'custom_filter',
       labels: [],
       query: {},
-    }
+    };
 
     if (Object.prototype.hasOwnProperty.call(query, 'offset')) {
-      query.offset = 0
+      query.offset = 0;
     }
     if (Object.prototype.hasOwnProperty.call(query, 'sort')) {
-      query.sort = 'name'
+      query.sort = 'name';
     }
 
     if (query) {
-      query_custom_filter.query = query
+      query_custom_filter.query = query;
     }
 
     if (labels) {
-      query_custom_filter.labels = labels
+      query_custom_filter.labels = labels;
     }
 
-    return query_custom_filter
+    return query_custom_filter;
   }
 
   function get_url_query_params() {
-    const url = new URL(window.location)
-    const encodedQuery = url.searchParams.get('query')
-    const encodedLabels = url.searchParams.get('labels')
-    const filterID = url.searchParams.get('filter_id')
-    const filterTab = url.searchParams.get('filter_tab')
-    const filterName = url.searchParams.get('filter_name')
-    const query = encodedQuery && window.SHAREDFUNCTIONS.decodeJSON(encodedQuery)
-    const labels = encodedLabels && window.SHAREDFUNCTIONS.decodeJSON(encodedLabels)
-    return ({
+    const url = new URL(window.location);
+    const encodedQuery = url.searchParams.get('query');
+    const encodedLabels = url.searchParams.get('labels');
+    const filterID = url.searchParams.get('filter_id');
+    const filterTab = url.searchParams.get('filter_tab');
+    const filterName = url.searchParams.get('filter_name');
+    const query =
+      encodedQuery && window.SHAREDFUNCTIONS.decodeJSON(encodedQuery);
+    const labels =
+      encodedLabels && window.SHAREDFUNCTIONS.decodeJSON(encodedLabels);
+    return {
       query,
       labels,
       filterID,
       filterTab,
-      filterName
-    })
+      filterName,
+    };
   }
 
   function is_in_filter_list(filterID) {
-    if (list_settings.filters.filters.some((filter) => filterID === filter.ID)) {
-      return true
+    if (
+      list_settings.filters.filters.some((filter) => filterID === filter.ID)
+    ) {
+      return true;
     }
 
-    return false
+    return false;
   }
 
   function update_url_query(currentFilter) {
-    const encodedQuery = window.SHAREDFUNCTIONS.encodeJSON(currentFilter.query)
-    const encodedLabels = window.SHAREDFUNCTIONS.encodeJSON(currentFilter.labels)
+    const encodedQuery = window.SHAREDFUNCTIONS.encodeJSON(currentFilter.query);
+    const encodedLabels = window.SHAREDFUNCTIONS.encodeJSON(
+      currentFilter.labels,
+    );
 
-    const url = new URL(window.location)
+    const url = new URL(window.location);
 
-    url.searchParams.set('query', encodedQuery)
-    url.searchParams.set('labels', encodedLabels)
-    url.searchParams.set('filter_id', currentFilter.ID)
-    url.searchParams.set('filter_tab', currentFilter.tab || '')
-    url.searchParams.set('filter_name', currentFilter.name || '')
+    url.searchParams.set('query', encodedQuery);
+    url.searchParams.set('labels', encodedLabels);
+    url.searchParams.set('filter_id', currentFilter.ID);
+    url.searchParams.set('filter_tab', currentFilter.tab || '');
+    url.searchParams.set('filter_name', currentFilter.name || '');
 
-    window.history.pushState(null, document.title, url.search)
+    window.history.pushState(null, document.title, url.search);
   }
 
-  function get_records_for_current_filter(custom_filter = null){
-    let checked = $(".js-list-view:checked")
-    let current_view = checked.val()
-    let filter_id = checked.data("id") || current_view || ""
+  function get_records_for_current_filter(custom_filter = null) {
+    let checked = $('.js-list-view:checked');
+    let current_view = checked.val();
+    let filter_id = checked.data('id') || current_view || '';
     let sort = current_filter.query.sort || null;
 
     // Determine if default resets are required?
-    if ( custom_filter ) {
-      current_filter = custom_filter
+    if (custom_filter) {
+      current_filter = custom_filter;
 
       // Ensure to uncheck all split by option filters, to avoid infinity loops!
-      $(".js-list-view-split-by").prop('checked', false);
-
-    } else if (current_view === "custom_filter") {
-      let filterId = checked.data("id")
-      current_filter = window.lodash.find(custom_filters, {ID: filterId})
-      current_filter.type = current_view
+      $('.js-list-view-split-by').prop('checked', false);
+    } else if (current_view === 'custom_filter') {
+      let filterId = checked.data('id');
+      current_filter = window.lodash.find(custom_filters, { ID: filterId });
+      current_filter.type = current_view;
     } else {
-      current_filter = window.lodash.find(list_settings.filters.filters, {ID: filter_id}) || window.lodash.find(list_settings.filters.filters, {ID: filter_id.toString()}) || current_filter
-      current_filter.type = 'default'
-      current_filter.labels = current_filter.labels || [{id: filter_id, name: current_filter.name}]
+      current_filter =
+        window.lodash.find(list_settings.filters.filters, { ID: filter_id }) ||
+        window.lodash.find(list_settings.filters.filters, {
+          ID: filter_id.toString(),
+        }) ||
+        current_filter;
+      current_filter.type = 'default';
+      current_filter.labels = current_filter.labels || [
+        { id: filter_id, name: current_filter.name },
+      ];
     }
-    if ( current_filter.query === undefined ) {
-      current_filter.query = {}
+    if (current_filter.query === undefined) {
+      current_filter.query = {};
     }
     sort = sort || current_filter.query.sort;
-    current_filter.query.sort = (typeof sort === "string") ? sort : "-post_date"
+    current_filter.query.sort = typeof sort === 'string' ? sort : '-post_date';
 
     // Conduct a deep copy (clone) of filter, to support future returns to default
     current_filter = $.extend(true, {}, current_filter);
 
     // Determine if any split by filters are to be applied.
-    let checked_split_by = $(".js-list-view-split-by:checked");
+    let checked_split_by = $('.js-list-view-split-by:checked');
     if (checked_split_by && checked_split_by.length > 0) {
-      current_filter = apply_split_by_filters(current_filter, checked_split_by.data('field_id'), checked_split_by.data('field_option_id'), checked_split_by.data('field_option_label'));
+      current_filter = apply_split_by_filters(
+        current_filter,
+        checked_split_by.data('field_id'),
+        checked_split_by.data('field_option_id'),
+        checked_split_by.data('field_option_label'),
+      );
     }
 
-    clear_search_query()
+    clear_search_query();
 
-    get_records()
+    get_records();
   }
 
   function clear_search_query() {
     // clear query if the current_filter is not a search query with the same text as the search-query
-    const searchLabel = current_filter.labels.find((label) => label.id === 'search')
-    if ( searchLabel && ( searchLabel.name === $("#search-query").val() || searchLabel.name === $("#search-query-mobile").val() ) ) {
-      return
+    const searchLabel = current_filter.labels.find(
+      (label) => label.id === 'search',
+    );
+    if (
+      searchLabel &&
+      (searchLabel.name === $('#search-query').val() ||
+        searchLabel.name === $('#search-query-mobile').val())
+    ) {
+      return;
     }
-    if ($("#search-query").val() !== ""){
-      $("#search-query").val("")
+    if ($('#search-query').val() !== '') {
+      $('#search-query').val('');
     }
-    if ($("#search-query-mobile").val() !== "") {
-      $("#search-query-mobile").val("")
+    if ($('#search-query-mobile').val() !== '') {
+      $('#search-query-mobile').val('');
     }
   }
 
-  function setup_filters(){
-    if ( !list_settings.filters.tabs) {
+  function setup_filters() {
+    if (!list_settings.filters.tabs) {
       return;
     }
     let selected_tab = $('.accordion-item.is-active').data('id');
-    let selected_filter = $(".js-list-view:checked").data('id')
+    let selected_filter = $('.js-list-view:checked').data('id');
     let html = ``;
-    list_settings.filters.tabs.forEach( tab =>{
+    list_settings.filters.tabs.forEach((tab) => {
       html += `
       <li class="accordion-item" data-accordion-item data-id="${window.SHAREDFUNCTIONS.escapeHTML(tab.key)}">
         <a href="#" class="accordion-title" data-id="${window.SHAREDFUNCTIONS.escapeHTML(tab.key)}">
           ${window.SHAREDFUNCTIONS.escapeHTML(tab.label)}
           <span class="tab-count-span" data-tab="${window.SHAREDFUNCTIONS.escapeHTML(tab.key)}">
-              ${Number.isInteger(tab.count) ? `(${window.SHAREDFUNCTIONS.escapeHTML(tab.count)})`: ``}
+              ${Number.isInteger(tab.count) ? `(${window.SHAREDFUNCTIONS.escapeHTML(tab.count)})` : ``}
           </span>
         </a>
         <div class="accordion-content" data-tab-content>
           <div class="list-views">
-            ${ list_settings.filters.filters.map( filter =>{
-              if (filter.tab === tab.key && filter.tab !== 'custom') {
-                let indent = filter.subfilter && Number.isInteger(filter.subfilter) ? 15 * filter.subfilter : 15;
-                return `
-                        <label class="list-view" style="${ filter.subfilter ? `margin-left:${indent}px` : ''}">
+            ${list_settings.filters.filters
+              .map((filter) => {
+                if (filter.tab === tab.key && filter.tab !== 'custom') {
+                  let indent =
+                    filter.subfilter && Number.isInteger(filter.subfilter)
+                      ? 15 * filter.subfilter
+                      : 15;
+                  return `
+                        <label class="list-view" style="${filter.subfilter ? `margin-left:${indent}px` : ''}">
                           <input type="radio" name="view" value="${window.SHAREDFUNCTIONS.escapeHTML(filter.ID)}" data-id="${window.SHAREDFUNCTIONS.escapeHTML(filter.ID)}" class="js-list-view" autocomplete="off">
                           <span class="list-view__text" id="total_filter_label" title="${window.SHAREDFUNCTIONS.escapeHTML(filter.name)}">${window.SHAREDFUNCTIONS.escapeHTML(filter.name)}</span>
-                          <span class="list-view__count js-list-view-count" data-value="${window.SHAREDFUNCTIONS.escapeHTML(filter.ID)}">${window.SHAREDFUNCTIONS.escapeHTML(filter.count )}</span>
+                          <span class="list-view__count js-list-view-count" data-value="${window.SHAREDFUNCTIONS.escapeHTML(filter.ID)}">${window.SHAREDFUNCTIONS.escapeHTML(filter.count)}</span>
                         </label>
-                        `
-              }
-            }).join('')}
+                        `;
+                }
+              })
+              .join('')}
           </div>
         </div>
       </li>
-      `
-    } )
-    filter_accordions.html(html)
+      `;
+    });
+    filter_accordions.html(html);
 
-    let saved_filters_list = $(`#list-filter-tabs [data-id='custom'] .list-views`)
-    saved_filters_list.empty()
-    if ( list_settings.filters.filters.filter(t=>t.tab === 'custom').length === 0 ) {
-      saved_filters_list.html(`<span>${window.SHAREDFUNCTIONS.escapeHTML(list_settings.translations.empty_custom_filters)}</span>`)
+    let saved_filters_list = $(
+      `#list-filter-tabs [data-id='custom'] .list-views`,
+    );
+    saved_filters_list.empty();
+    if (
+      list_settings.filters.filters.filter((t) => t.tab === 'custom').length ===
+      0
+    ) {
+      saved_filters_list.html(
+        `<span>${window.SHAREDFUNCTIONS.escapeHTML(list_settings.translations.empty_custom_filters)}</span>`,
+      );
     }
-    list_settings.filters.filters.filter(t=>t.tab === 'custom').forEach(filter=>{
-      if ( filter && filter.visible === '') {
-        return
-      }
-      let delete_filter = $(`<span style="float:right" data-filter="${window.SHAREDFUNCTIONS.escapeHTML( filter.ID )}">
+    list_settings.filters.filters
+      .filter((t) => t.tab === 'custom')
+      .forEach((filter) => {
+        if (filter && filter.visible === '') {
+          return;
+        }
+        let delete_filter =
+          $(`<span style="float:right" data-filter="${window.SHAREDFUNCTIONS.escapeHTML(filter.ID)}">
         <img style="padding: 0 4px" src="${window.wpApiShare.template_dir}/dt-assets/images/trash.svg">
-      </span>`)
-      delete_filter.on("click", function () {
-        $(`.delete-filter-name`).html(filter.name)
-        $('#delete-filter-modal').foundation('open');
-        filter_to_delete = filter.ID;
-      })
-      let edit_filter = $(`<span style="float:right" data-filter="${window.SHAREDFUNCTIONS.escapeHTML( filter.ID )}">
+      </span>`);
+        delete_filter.on('click', function () {
+          $(`.delete-filter-name`).html(filter.name);
+          $('#delete-filter-modal').foundation('open');
+          filter_to_delete = filter.ID;
+        });
+        let edit_filter =
+          $(`<span style="float:right" data-filter="${window.SHAREDFUNCTIONS.escapeHTML(filter.ID)}">
           <img style="padding: 0 4px" src="${window.wpApiShare.template_dir}/dt-assets/images/edit.svg">
-      </span>`)
-      edit_filter.on("click", function () {
-        edit_saved_filter( filter )
-        filterToEdit = filter.ID;
-      })
-      let filterName = `<span class="filter-list-name" data-filter="${window.SHAREDFUNCTIONS.escapeHTML(filter.ID)}">${window.SHAREDFUNCTIONS.escapeHTML(filter.name)}</span>`
-      const radio = $(`<input name='view' class='js-list-view' autocomplete='off' data-id="${window.SHAREDFUNCTIONS.escapeHTML(filter.ID)}" >`)
-      .attr("type", "radio")
-      .val("saved-filters")
-      .on("change", function() {
-      });
-      saved_filters_list.append(
-        $("<div>").append(
-          $("<label>")
-          .css("cursor", "pointer")
-          .addClass("js-filter-checkbox-label")
-          .data("filter-value", status)
-          .append(radio)
-          .append(filterName)
-          .append(delete_filter)
-          .append(edit_filter)
+      </span>`);
+        edit_filter.on('click', function () {
+          edit_saved_filter(filter);
+          filterToEdit = filter.ID;
+        });
+        let filterName = `<span class="filter-list-name" data-filter="${window.SHAREDFUNCTIONS.escapeHTML(filter.ID)}">${window.SHAREDFUNCTIONS.escapeHTML(filter.name)}</span>`;
+        const radio = $(
+          `<input name='view' class='js-list-view' autocomplete='off' data-id="${window.SHAREDFUNCTIONS.escapeHTML(filter.ID)}" >`,
         )
-      )
-    })
+          .attr('type', 'radio')
+          .val('saved-filters')
+          .on('change', function () {});
+        saved_filters_list.append(
+          $('<div>').append(
+            $('<label>')
+              .css('cursor', 'pointer')
+              .addClass('js-filter-checkbox-label')
+              .data('filter-value', status)
+              .append(radio)
+              .append(filterName)
+              .append(delete_filter)
+              .append(edit_filter),
+          ),
+        );
+      });
     new window.Foundation.Accordion(filter_accordions, {
       slideSpeed: 100,
-      allowAllClosed: true
+      allowAllClosed: true,
     });
-    if ( selected_tab ){
-      $(`#list-filter-tabs [data-id='${window.SHAREDFUNCTIONS.escapeHTML( selected_tab )}'] a`).click()
+    if (selected_tab) {
+      $(
+        `#list-filter-tabs [data-id='${window.SHAREDFUNCTIONS.escapeHTML(selected_tab)}'] a`,
+      ).click();
     }
-    if ( selected_filter ){
-      $(`[data-id="${window.SHAREDFUNCTIONS.escapeHTML( selected_filter )}"].js-list-view`).prop('checked', true);
+    if (selected_filter) {
+      $(
+        `[data-id="${window.SHAREDFUNCTIONS.escapeHTML(selected_filter)}"].js-list-view`,
+      ).prop('checked', true);
     }
   }
 
   function get_filter_counts(oldFilters) {
-    if ( getFilterCountsPromise && window.lodash.get( getFilterCountsPromise, "readyState") !== 4 ) {
-      getFilterCountsPromise.abort()
+    if (
+      getFilterCountsPromise &&
+      window.lodash.get(getFilterCountsPromise, 'readyState') !== 4
+    ) {
+      getFilterCountsPromise.abort();
     }
     getFilterCountsPromise = $.ajax({
       url: `${window.wpApiShare.root}dt/v1/users/get_filters?post_type=${list_settings.post_type}&force_refresh=1`,
       beforeSend: function (xhr) {
         xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce);
-      }
-    })
-    getFilterCountsPromise.then(filters=>{
-      if (oldFilters !== JSON.stringify(filters)){
-        list_settings.filters = filters
-        setup_filters()
-      }
-    }).catch(err => {
-      if ( window.lodash.get( err, "statusText" ) !== "abort" ){
-        console.error(err)
-      }
-    })
+      },
+    });
+    getFilterCountsPromise
+      .then((filters) => {
+        if (oldFilters !== JSON.stringify(filters)) {
+          list_settings.filters = filters;
+          setup_filters();
+        }
+      })
+      .catch((err) => {
+        if (window.lodash.get(err, 'statusText') !== 'abort') {
+          console.error(err);
+        }
+      });
   }
 
   function setup_current_filter_labels() {
-    let html = ""
-    let filter = current_filter
-    if (filter && filter.labels){
-      filter.labels.forEach(label=>{
-
+    let html = '';
+    let filter = current_filter;
+    if (filter && filter.labels) {
+      filter.labels.forEach((label) => {
         // Determine exclusion status
-        let excluded_class = is_search_query_filter_label_excluded(filter, label) ? 'current-filter-list-excluded' : '';
+        let excluded_class = is_search_query_filter_label_excluded(
+          filter,
+          label,
+        )
+          ? 'current-filter-list-excluded'
+          : '';
 
         // Proceed with displaying of filter label
         html += `<span class="current-filter-list ${excluded_class} ${window.SHAREDFUNCTIONS.escapeHTML(label.field)}">${window.SHAREDFUNCTIONS.escapeHTML(label.name)}`;
 
         if (label.id && label.field && label.name) {
           html += `<span class="current-filter-list-close">x</span>`;
-
         } else {
           html += `&nbsp;`;
         }
@@ -592,290 +694,362 @@
         html += `</span>`;
       });
     } else {
-      let query = filter.query
-      window.lodash.forOwn( query, query_key=> {
+      let query = filter.query;
+      window.lodash.forOwn(query, (query_key) => {
         if (Array.isArray(query[query_key])) {
-
-          query[query_key].forEach(q => {
-
-            html += `<span class="current-filter-list ${window.SHAREDFUNCTIONS.escapeHTML( query_key )}">${window.SHAREDFUNCTIONS.escapeHTML( q )}&nbsp;</span>`
-          })
+          query[query_key].forEach((q) => {
+            html += `<span class="current-filter-list ${window.SHAREDFUNCTIONS.escapeHTML(query_key)}">${window.SHAREDFUNCTIONS.escapeHTML(q)}&nbsp;</span>`;
+          });
         } else {
-          html += `<span class="current-filter-list search">${window.SHAREDFUNCTIONS.escapeHTML( query[query_key] )}&nbsp;</span>`
+          html += `<span class="current-filter-list search">${window.SHAREDFUNCTIONS.escapeHTML(query[query_key])}&nbsp;</span>`;
         }
-      })
+      });
     }
 
-    if ( filter.query.sort ){
-      let sortLabel = filter.query.sort
-      if ( sortLabel.includes('last_modified') ){
-        sortLabel = list_settings.translations.date_modified
-      } else if ( sortLabel.includes('post_date') ) {
-        sortLabel = list_settings.translations.creation_date
+    if (filter.query.sort) {
+      let sortLabel = filter.query.sort;
+      if (sortLabel.includes('last_modified')) {
+        sortLabel = list_settings.translations.date_modified;
+      } else if (sortLabel.includes('post_date')) {
+        sortLabel = list_settings.translations.creation_date;
       } else {
-
         // remove leading dash from sort filter key when reverse sorting
-        const leadingDashSearch = new RegExp('^-')
-        const querySortKey = (sortLabel.search(leadingDashSearch) > -1) ? sortLabel.replace(leadingDashSearch, '') : sortLabel
-        sortLabel = window.lodash.get( list_settings, `post_type_settings.fields[${querySortKey}].name`, sortLabel)
+        const leadingDashSearch = new RegExp('^-');
+        const querySortKey =
+          sortLabel.search(leadingDashSearch) > -1
+            ? sortLabel.replace(leadingDashSearch, '')
+            : sortLabel;
+        sortLabel = window.lodash.get(
+          list_settings,
+          `post_type_settings.fields[${querySortKey}].name`,
+          sortLabel,
+        );
       }
       html += `<span class="current-filter-list" data-id="sort">
-          ${window.SHAREDFUNCTIONS.escapeHTML( list_settings.translations.sorting_by )}: ${window.SHAREDFUNCTIONS.escapeHTML( sortLabel )}
-      &nbsp;</span>`
+          ${window.SHAREDFUNCTIONS.escapeHTML(list_settings.translations.sorting_by)}: ${window.SHAREDFUNCTIONS.escapeHTML(sortLabel)}
+      &nbsp;</span>`;
     }
-    currentFilters.html(html)
+    currentFilters.html(html);
   }
 
   function reset_sorting_in_table_header(currentFilter) {
-    let sort_field = window.lodash.get(currentFilter, "query.sort", "-post_date");
+    let sort_field = window.lodash.get(
+      currentFilter,
+      'query.sort',
+      '-post_date',
+    );
     //reset sorting in table header
-    table_header_row.removeClass("sorting_asc");
-    table_header_row.removeClass("sorting_desc");
-    let header_cell = $(`.js-list thead .sortable th[data-id="${window.SHAREDFUNCTIONS.escapeHTML(sort_field.replace("-", ""))}"]`);
-    header_cell.addClass(`sorting_${sort_field.startsWith('-') ? 'desc' : 'asc'}`);
-    table_header_row.data("sort", '');
-    header_cell.data("sort", 'asc');
+    table_header_row.removeClass('sorting_asc');
+    table_header_row.removeClass('sorting_desc');
+    let header_cell = $(
+      `.js-list thead .sortable th[data-id="${window.SHAREDFUNCTIONS.escapeHTML(sort_field.replace('-', ''))}"]`,
+    );
+    header_cell.addClass(
+      `sorting_${sort_field.startsWith('-') ? 'desc' : 'asc'}`,
+    );
+    table_header_row.data('sort', '');
+    header_cell.data('sort', 'asc');
   }
 
-  $('.js-sort-by').on("click", function () {
-    table_header_row.removeClass("sorting_asc")
-    table_header_row.removeClass("sorting_desc")
-    let dir = $(this).data('order')
-    let field = $(this).data('field')
-    get_records( 0, (dir === "asc" ? "" : '-') + field )
-  })
+  $('.js-sort-by').on('click', function () {
+    table_header_row.removeClass('sorting_asc');
+    table_header_row.removeClass('sorting_desc');
+    let dir = $(this).data('order');
+    let field = $(this).data('field');
+    get_records(0, (dir === 'asc' ? '' : '-') + field);
+  });
 
   //sort the table by clicking the header
-  $('.js-list th').on("click", function () {
+  $('.js-list th').on('click', function () {
     //check is this is the bulk_edit_master checkbox
-    if ( this.id == "bulk_edit_master") {
+    if (this.id == 'bulk_edit_master') {
       return;
     }
     let id = $(this).data('id');
-    let sort = $(this).data('sort')
-    table_header_row.removeClass("sorting_asc")
-    table_header_row.removeClass("sorting_desc")
-    table_header_row.data("sort", '')
-    if ( !sort || sort === 'desc' ){
-      $(this).data('sort', 'asc')
-      $(this).addClass("sorting_asc")
-      $(this).removeClass("sorting_desc")
+    let sort = $(this).data('sort');
+    table_header_row.removeClass('sorting_asc');
+    table_header_row.removeClass('sorting_desc');
+    table_header_row.data('sort', '');
+    if (!sort || sort === 'desc') {
+      $(this).data('sort', 'asc');
+      $(this).addClass('sorting_asc');
+      $(this).removeClass('sorting_desc');
     } else {
-      $(this).data('sort', 'desc')
-      $(this).removeClass("sorting_asc")
-      $(this).addClass("sorting_desc")
-      id = `-${id}`
+      $(this).data('sort', 'desc');
+      $(this).removeClass('sorting_asc');
+      $(this).addClass('sorting_desc');
+      id = `-${id}`;
     }
-    get_records(0, id)
-  })
+    get_records(0, id);
+  });
 
-  $('#choose_fields_to_show_in_table').on('click', function(){
-    $('#list_column_picker').toggle()
-  })
-  $('#save_column_choices').on('click', function(){
+  $('#choose_fields_to_show_in_table').on('click', function () {
+    $('#list_column_picker').toggle();
+  });
+  $('#save_column_choices').on('click', function () {
     let new_selected = [];
-    $('#list_column_picker input:checked').each((index, elem)=>{
-      new_selected.push($(elem).val())
-    })
-    fields_to_show_in_table = window.lodash.intersection( fields_to_show_in_table, new_selected ) // remove unchecked
-    fields_to_show_in_table = window.lodash.uniq(window.lodash.union( fields_to_show_in_table, new_selected ))
-    window.SHAREDFUNCTIONS.save_json_cookie('fields_to_show_in_table', fields_to_show_in_table, list_settings.post_type )
-    window.location.reload()
-  })
-  $('#reset_column_choices').on('click', function(){
-    fields_to_show_in_table = []
-    window.SHAREDFUNCTIONS.save_json_cookie('fields_to_show_in_table', fields_to_show_in_table, list_settings.post_type )
-    window.location.reload()
-  })
+    $('#list_column_picker input:checked').each((index, elem) => {
+      new_selected.push($(elem).val());
+    });
+    fields_to_show_in_table = window.lodash.intersection(
+      fields_to_show_in_table,
+      new_selected,
+    ); // remove unchecked
+    fields_to_show_in_table = window.lodash.uniq(
+      window.lodash.union(fields_to_show_in_table, new_selected),
+    );
+    window.SHAREDFUNCTIONS.save_json_cookie(
+      'fields_to_show_in_table',
+      fields_to_show_in_table,
+      list_settings.post_type,
+    );
+    window.location.reload();
+  });
+  $('#reset_column_choices').on('click', function () {
+    fields_to_show_in_table = [];
+    window.SHAREDFUNCTIONS.save_json_cookie(
+      'fields_to_show_in_table',
+      fields_to_show_in_table,
+      list_settings.post_type,
+    );
+    window.location.reload();
+  });
 
-  archivedSwitch.on('click', function() {
-    const showArchived = this.checked
+  archivedSwitch.on('click', function () {
+    const showArchived = this.checked;
 
-    archivedSwitchStatus = showArchived
-    window.SHAREDFUNCTIONS.save_json_to_local_storage('list_archived_switch_status', showArchived, list_settings.post_type)
+    archivedSwitchStatus = showArchived;
+    window.SHAREDFUNCTIONS.save_json_to_local_storage(
+      'list_archived_switch_status',
+      showArchived,
+      list_settings.post_type,
+    );
 
-    get_records()
-  })
+    get_records();
+  });
 
   function setup_archived_switch_position(switchStatus) {
-    archivedSwitch.prop('checked', switchStatus)
+    archivedSwitch.prop('checked', switchStatus);
   }
 
   function apply_archived_toggle_to_current_filter() {
-    if ( !list_settings?.post_type_settings?.status_field ) return
-    const showArchived = archivedSwitchStatus
+    if (!list_settings?.post_type_settings?.status_field) return;
+    const showArchived = archivedSwitchStatus;
     let status = get_filtered_status();
 
     if (showArchived && status && status.includes(filterOutArchivedItemsKey)) {
-      const index = status.indexOf(filterOutArchivedItemsKey)
-      status.splice(index, 1)
+      const index = status.indexOf(filterOutArchivedItemsKey);
+      status.splice(index, 1);
 
       // Remove status property from query if empty.
-      if ( status.length === 0 ) {
-        if ( is_custom_filter() ){
-          current_filter.query.fields = current_filter.query.fields.filter((item) => !Object.prototype.hasOwnProperty.call(item, status_key))
+      if (status.length === 0) {
+        if (is_custom_filter()) {
+          current_filter.query.fields = current_filter.query.fields.filter(
+            (item) => !Object.prototype.hasOwnProperty.call(item, status_key),
+          );
         } else {
-          delete current_filter.query[status_key]
+          delete current_filter.query[status_key];
         }
       }
     }
 
     if (!showArchived && (!status || status.length === 0)) {
-      set_filtered_status([filterOutArchivedItemsKey])
+      set_filtered_status([filterOutArchivedItemsKey]);
     }
   }
 
   function is_custom_filter() {
-    return !!current_filter.query.fields
+    return !!current_filter.query.fields;
   }
 
   function get_filtered_status() {
-    return is_custom_filter() ? get_status_field_in_custom_filter() : current_filter.query[status_key];
+    return is_custom_filter()
+      ? get_status_field_in_custom_filter()
+      : current_filter.query[status_key];
   }
 
   function set_filtered_status(newStatus) {
     if (is_custom_filter()) {
-      set_status_field_in_custom_filter(newStatus)
+      set_status_field_in_custom_filter(newStatus);
     } else {
-      current_filter.query[status_key] = newStatus
+      current_filter.query[status_key] = newStatus;
     }
   }
 
   function get_status_field_in_custom_filter() {
-    const query = current_filter.query
-    const fields = query.fields
+    const query = current_filter.query;
+    const fields = query.fields;
 
-    if (!fields || !Array.isArray(fields)) return []
+    if (!fields || !Array.isArray(fields)) return [];
 
-    const filterItem = fields.find((item) => Object.prototype.hasOwnProperty.call(item, status_key))
-    return filterItem && filterItem[status_key]
+    const filterItem = fields.find((item) =>
+      Object.prototype.hasOwnProperty.call(item, status_key),
+    );
+    return filterItem && filterItem[status_key];
   }
 
   function set_status_field_in_custom_filter(newStatus) {
     const fields = current_filter.query.fields;
-    if (!fields || !Array.isArray(fields)) return
+    if (!fields || !Array.isArray(fields)) return;
 
-    const index = fields.findIndex((item) => Object.prototype.hasOwnProperty.call(item, status_key))
+    const index = fields.findIndex((item) =>
+      Object.prototype.hasOwnProperty.call(item, status_key),
+    );
     if (index === -1) {
-      fields.push({[status_key]: newStatus})
+      fields.push({ [status_key]: newStatus });
     } else {
-      fields[index][status_key] = newStatus
+      fields[index][status_key] = newStatus;
     }
   }
 
-  $('#records-table').dragableColumns({
-    drag: true,
-    dragClass: 'drag',
-    overClass: 'over',
-    movedContainerSelector: '.dnd-moved',
-    onDragEnd: ()=>{
-      fields_to_show_in_table = []
-      $('.table-headers th').each((i, e)=>{
-        let field = $(e).data('id')
-        if ( field ){
-          fields_to_show_in_table.push(field)
-        }
-      })
-      window.SHAREDFUNCTIONS.save_json_cookie('fields_to_show_in_table', fields_to_show_in_table, list_settings.post_type )
-    }
-  }).on('click', 'tbody tr', function(event){
-    //open the record if the row is clicked. Give priority to normal browser behavior with links.
-    if(!event.target.href) {
-      window.location = $(this).data('link')
-    }
-  })
+  $('#records-table')
+    .dragableColumns({
+      drag: true,
+      dragClass: 'drag',
+      overClass: 'over',
+      movedContainerSelector: '.dnd-moved',
+      onDragEnd: () => {
+        fields_to_show_in_table = [];
+        $('.table-headers th').each((i, e) => {
+          let field = $(e).data('id');
+          if (field) {
+            fields_to_show_in_table.push(field);
+          }
+        });
+        window.SHAREDFUNCTIONS.save_json_cookie(
+          'fields_to_show_in_table',
+          fields_to_show_in_table,
+          list_settings.post_type,
+        );
+      },
+    })
+    .on('click', 'tbody tr', function (event) {
+      //open the record if the row is clicked. Give priority to normal browser behavior with links.
+      if (!event.target.href) {
+        window.location = $(this).data('link');
+      }
+    });
 
-  let build_table = (records)=>{
-    let table_rows = ``
-    let mobile = $(window).width() < mobile_breakpoint
-    records.forEach( ( record, index )=>{
-      let row_fields_html = ''
-      fields_to_show_in_table.forEach(field_key=>{
+  let build_table = (records) => {
+    let table_rows = ``;
+    let mobile = $(window).width() < mobile_breakpoint;
+    records.forEach((record, index) => {
+      let row_fields_html = '';
+      fields_to_show_in_table.forEach((field_key) => {
         let values_html = '';
         let values = [];
-        if (field_key === "name"){
+        if (field_key === 'name') {
           if (mobile) {
-            return
+            return;
           }
-          values_html = `<a href="${window.SHAREDFUNCTIONS.escapeHTML(record.permalink)}" title="${window.SHAREDFUNCTIONS.escapeHTML(record.post_title)}">${window.SHAREDFUNCTIONS.escapeHTML(record.post_title)}</a>`
+          values_html = `<a href="${window.SHAREDFUNCTIONS.escapeHTML(record.permalink)}" title="${window.SHAREDFUNCTIONS.escapeHTML(record.post_title)}">${window.SHAREDFUNCTIONS.escapeHTML(record.post_title)}</a>`;
         } else if (list_settings.post_type_settings.fields[field_key]) {
-          let field_settings = list_settings.post_type_settings.fields[field_key]
-          let field_value = window.lodash.get( record, field_key, false )
-          if ( field_key !== "favorite" && field_settings.type === "boolean" ) {
-            field_value = window.lodash.get( record, field_key )
+          let field_settings =
+            list_settings.post_type_settings.fields[field_key];
+          let field_value = window.lodash.get(record, field_key, false);
+          if (field_key !== 'favorite' && field_settings.type === 'boolean') {
+            field_value = window.lodash.get(record, field_key);
           }
 
           /* breadcrumb: new-field-type Display field in table */
-          if ( field_value !== false ) {
+          if (field_value !== false) {
             if (['text', 'textarea', 'number'].includes(field_settings.type)) {
-              values = [window.SHAREDFUNCTIONS.escapeHTML(field_value)]
+              values = [window.SHAREDFUNCTIONS.escapeHTML(field_value)];
             } else if (field_settings.type === 'date') {
-              values = [window.SHAREDFUNCTIONS.escapeHTML(window.SHAREDFUNCTIONS.formatDate(field_value.timestamp))]
+              values = [
+                window.SHAREDFUNCTIONS.escapeHTML(
+                  window.SHAREDFUNCTIONS.formatDate(field_value.timestamp),
+                ),
+              ];
             } else if (field_settings.type === 'datetime') {
-              values = [window.SHAREDFUNCTIONS.escapeHTML(window.SHAREDFUNCTIONS.formatDate(field_value.timestamp, true))]
+              values = [
+                window.SHAREDFUNCTIONS.escapeHTML(
+                  window.SHAREDFUNCTIONS.formatDate(
+                    field_value.timestamp,
+                    true,
+                  ),
+                ),
+              ];
             } else if (field_settings.type === 'user_select') {
-              values = [window.SHAREDFUNCTIONS.escapeHTML(field_value.display)]
+              values = [window.SHAREDFUNCTIONS.escapeHTML(field_value.display)];
             } else if (field_settings.type === 'key_select') {
-              values = [window.SHAREDFUNCTIONS.escapeHTML(field_value.label)]
+              values = [window.SHAREDFUNCTIONS.escapeHTML(field_value.label)];
             } else if (field_settings.type === 'multi_select') {
-              values = field_value.map(v => {
+              values = field_value.map((v) => {
                 return `${window.SHAREDFUNCTIONS.escapeHTML(window.lodash.get(field_settings, `default[${v}].label`, v))}`;
-              })
+              });
             } else if (field_settings.type === 'link') {
               values = field_value.map((link) => {
-                return window.SHAREDFUNCTIONS.escapeHTML(link.value)
-              })
-            } else if (field_settings.type === 'tags') {
-              values = field_value.map(v => {
-                return `${window.SHAREDFUNCTIONS.escapeHTML(window.lodash.get(field_settings, `default[${v}].label`, v))}`;
-              })
-            } else if ( field_settings.type === "location" || field_settings.type === "location_meta" ){
-              values = field_value.map(v => {
-                return `${window.SHAREDFUNCTIONS.escapeHTML( v.label )}`;
-              })
-            } else if ( field_settings.type === "communication_channel" ){
-              values = field_value.map(v => {
-                return `${window.SHAREDFUNCTIONS.escapeHTML( v.value )}`;
-              })
-            } else if ( field_settings.type === "connection" ){
-              values = field_value.map(v => {
-                let meta = []
-                if ( field_settings.meta_fields ){
-                  Object.keys(field_settings.meta_fields).forEach(key=>{
-                    if ( v.meta && v.meta[key] ){
-                      meta.push(v.meta[key])
-                    }
-                  })
-                }
-                return `${window.SHAREDFUNCTIONS.escapeHTML( v.post_title )}${meta.length ? ` (${meta.join(',')})` : ''}`;
-              })
-            } else if ( field_settings.type === "boolean" ){
-              if (field_key === "favorite") {
-                values = [`<svg class='icon-star${field_value === true ? ' selected' : ''}' viewBox="0 0 32 32" data-id=${record.ID}><use xlink:href="${window.wpApiShare.template_dir}/dt-assets/images/star.svg#star"></use></svg>`]
-              } else if ( field_value === true ) {
-                values = ['&check;']
-              }
-            } else if ( field_settings.type === 'task' ) {
-              values = field_value
-              .filter(v => {
-                return (v.value && v.value.note && v.value.note !== '');
-              })
-              .map(v => {
-                return `${window.SHAREDFUNCTIONS.escapeHTML(v.value.note)}`;
+                return window.SHAREDFUNCTIONS.escapeHTML(link.value);
               });
+            } else if (field_settings.type === 'tags') {
+              values = field_value.map((v) => {
+                return `${window.SHAREDFUNCTIONS.escapeHTML(window.lodash.get(field_settings, `default[${v}].label`, v))}`;
+              });
+            } else if (
+              field_settings.type === 'location' ||
+              field_settings.type === 'location_meta'
+            ) {
+              values = field_value.map((v) => {
+                return `${window.SHAREDFUNCTIONS.escapeHTML(v.label)}`;
+              });
+            } else if (field_settings.type === 'communication_channel') {
+              values = field_value.map((v) => {
+                return `${window.SHAREDFUNCTIONS.escapeHTML(v.value)}`;
+              });
+            } else if (field_settings.type === 'connection') {
+              values = field_value.map((v) => {
+                let meta = [];
+                if (field_settings.meta_fields) {
+                  Object.keys(field_settings.meta_fields).forEach((key) => {
+                    if (v.meta && v.meta[key]) {
+                      meta.push(v.meta[key]);
+                    }
+                  });
+                }
+                return `${window.SHAREDFUNCTIONS.escapeHTML(v.post_title)}${meta.length ? ` (${meta.join(',')})` : ''}`;
+              });
+            } else if (field_settings.type === 'boolean') {
+              if (field_key === 'favorite') {
+                values = [
+                  `<svg class='icon-star${field_value === true ? ' selected' : ''}' viewBox="0 0 32 32" data-id=${record.ID}><use xlink:href="${window.wpApiShare.template_dir}/dt-assets/images/star.svg#star"></use></svg>`,
+                ];
+              } else if (field_value === true) {
+                values = ['&check;'];
+              }
+            } else if (field_settings.type === 'task') {
+              values = field_value
+                .filter((v) => {
+                  return v.value && v.value.note && v.value.note !== '';
+                })
+                .map((v) => {
+                  return `${window.SHAREDFUNCTIONS.escapeHTML(v.value.note)}`;
+                });
             }
-          } else if ( !field_value && field_settings.type === "boolean" && field_key === "favorite") {
-            values = [`<svg class='icon-star' viewBox="0 0 32 32" data-id=${record.ID}><use xlink:href="${window.wpApiShare.template_dir}/dt-assets/images/star.svg#star"></use></svg>`]
-          } else if ( field_value === undefined && field_settings.type === "boolean" && field_settings.default === true) {
-            values = ['&check;']
+          } else if (
+            !field_value &&
+            field_settings.type === 'boolean' &&
+            field_key === 'favorite'
+          ) {
+            values = [
+              `<svg class='icon-star' viewBox="0 0 32 32" data-id=${record.ID}><use xlink:href="${window.wpApiShare.template_dir}/dt-assets/images/star.svg#star"></use></svg>`,
+            ];
+          } else if (
+            field_value === undefined &&
+            field_settings.type === 'boolean' &&
+            field_settings.default === true
+          ) {
+            values = ['&check;'];
           }
         } else {
           return;
         }
-        values_html += values.map( (v, index)=>{
-          return `<li>${v}</li>`
-        }).join('')
-        if ( $(window).width() < mobile_breakpoint ){
+        values_html += values
+          .map((v, index) => {
+            return `<li>${v}</li>`;
+          })
+          .join('');
+        if ($(window).width() < mobile_breakpoint) {
           row_fields_html += `
             <td>
               <div class="mobile-list-field-name">
@@ -890,14 +1064,20 @@
               </div>
 
             </td>
-          `
+          `;
         } else {
           //this looks for the star SVG from the favorited fields and changes the value to a checkmark like other boolean fields to be used in the title element on desktop lists.
-          if (values[0] === `<svg class='icon-star selected' viewBox="0 0 32 32" data-id=${record.ID}><use xlink:href="${window.wpApiShare.template_dir}/dt-assets/images/star.svg#star"></use></svg>` ) {
-            values[0] = '&#9734;'
+          if (
+            values[0] ===
+            `<svg class='icon-star selected' viewBox="0 0 32 32" data-id=${record.ID}><use xlink:href="${window.wpApiShare.template_dir}/dt-assets/images/star.svg#star"></use></svg>`
+          ) {
+            values[0] = '&#9734;';
           }
-          if (values[0] === `<svg class='icon-star' viewBox="0 0 32 32" data-id=${record.ID}><use xlink:href="${window.wpApiShare.template_dir}/dt-assets/images/star.svg#star"></use></svg>`) {
-            values[0] = '&#9733;'
+          if (
+            values[0] ===
+            `<svg class='icon-star' viewBox="0 0 32 32" data-id=${record.ID}><use xlink:href="${window.wpApiShare.template_dir}/dt-assets/images/star.svg#star"></use></svg>`
+          ) {
+            values[0] = '&#9733;';
           }
           let tmp_html = `
             <td dir="auto" data-id="${field_key}" title="${values.join(', ')}">
@@ -905,193 +1085,287 @@
                 ${values_html}
               </ul>
             </td>
-          `
+          `;
 
-          if (field_key === "favorite") {
+          if (field_key === 'favorite') {
             row_fields_html = tmp_html + row_fields_html;
           } else {
             row_fields_html += tmp_html;
           }
         }
-      })
+      });
 
-      if ( mobile ){
+      if (mobile) {
         table_rows += `<tr data-link="${window.SHAREDFUNCTIONS.escapeHTML(record.permalink)}">
           <td class="bulk_edit_checkbox">
               <input class="bulk_edit_checkbox" type="checkbox" name="bulk_edit_id" value="${record.ID}">
           </td>
           <td>
               <div class="mobile-list-field-name">
-                ${index+1}.
+                ${index + 1}.
               </div>
               <div class="mobile-list-field-value">
-                  <a href="${ window.SHAREDFUNCTIONS.escapeHTML( record.permalink ) }">${ window.SHAREDFUNCTIONS.escapeHTML( record.post_title ) }</a>
+                  <a href="${window.SHAREDFUNCTIONS.escapeHTML(record.permalink)}">${window.SHAREDFUNCTIONS.escapeHTML(record.post_title)}</a>
               </div>
           </td>
-          ${ row_fields_html }
-        `
+          ${row_fields_html}
+        `;
       } else {
         table_rows += `<tr class="dnd-moved" data-link="${window.SHAREDFUNCTIONS.escapeHTML(record.permalink)}">
           <td class="bulk_edit_checkbox" ><input type="checkbox" name="bulk_edit_id" value="${record.ID}"></td>
-          <td style="white-space: nowrap" data-id="index" >${index+1}.</td>
-          ${ row_fields_html }
-        `
+          <td style="white-space: nowrap" data-id="index" >${index + 1}.</td>
+          ${row_fields_html}
+        `;
       }
-    })
-    if ( records.length === 0 ) {
-      table_rows = `<tr><td colspan="10">${window.SHAREDFUNCTIONS.escapeHTML(list_settings.translations.empty_list)}</td></tr>`
+    });
+    if (records.length === 0) {
+      table_rows = `<tr><td colspan="10">${window.SHAREDFUNCTIONS.escapeHTML(list_settings.translations.empty_list)}</td></tr>`;
     }
 
     let table_html = `
       ${table_rows}
-    `
-    $('#table-content').html(table_html)
+    `;
+    $('#table-content').html(table_html);
     bulk_edit_checkbox_event();
     favorite_edit_event();
-  }
+  };
 
-  function get_records( offset = 0, sort = null ){
-    loading_spinner.addClass("active");
-    let query = current_filter.query
-    if ( offset ){
-      query.offset = offset
-      query.limit = 500
+  function get_records(offset = 0, sort = null) {
+    loading_spinner.addClass('active');
+    let query = current_filter.query;
+    if (offset) {
+      query.offset = offset;
+      query.limit = 500;
     }
-    if ( sort ){
-      query.sort = sort
-      query.offset = 0
+    if (sort) {
+      query.sort = sort;
+      query.offset = 0;
     }
 
-    update_url_query(current_filter)
-    apply_archived_toggle_to_current_filter()
+    update_url_query(current_filter);
+    apply_archived_toggle_to_current_filter();
 
-    window.SHAREDFUNCTIONS.save_json_to_local_storage(`last_view`, current_filter, list_settings.post_type )
-    if ( get_records_promise && window.lodash.get(get_records_promise, "readyState") !== 4){
-      get_records_promise.abort()
+    window.SHAREDFUNCTIONS.save_json_to_local_storage(
+      `last_view`,
+      current_filter,
+      list_settings.post_type,
+    );
+    if (
+      get_records_promise &&
+      window.lodash.get(get_records_promise, 'readyState') !== 4
+    ) {
+      get_records_promise.abort();
     }
-    query.fields_to_return = fields_to_show_in_table
-    get_records_promise = window.makeRequestOnPosts( 'POST', `${list_settings.post_type}/list`, JSON.parse(JSON.stringify(query)))
-    return get_records_promise.then(response=>{
-      if (offset){
-        items = window.lodash.unionBy(items, response.posts || [], "ID")
-      } else {
-        items = response.posts || []
-      }
-      window.records_list.posts = items // adds global access to current list for plugins
-      window.records_list.total = response.total
+    query.fields_to_return = fields_to_show_in_table;
+    get_records_promise = window.makeRequestOnPosts(
+      'POST',
+      `${list_settings.post_type}/list`,
+      JSON.parse(JSON.stringify(query)),
+    );
+    return get_records_promise
+      .then((response) => {
+        if (offset) {
+          items = window.lodash.unionBy(items, response.posts || [], 'ID');
+        } else {
+          items = response.posts || [];
+        }
+        window.records_list.posts = items; // adds global access to current list for plugins
+        window.records_list.total = response.total;
 
-      // save
-      if (Object.prototype.hasOwnProperty.call(response, 'posts') && response.posts.length > 0) {
-        let records_list_ids_and_type = [];
+        // save
+        if (
+          Object.prototype.hasOwnProperty.call(response, 'posts') &&
+          response.posts.length > 0
+        ) {
+          let records_list_ids_and_type = [];
 
-        $.each(items, function(id, post_object ) {
-          records_list_ids_and_type.push({ ID: post_object.ID });
-        });
+          $.each(items, function (id, post_object) {
+            records_list_ids_and_type.push({ ID: post_object.ID });
+          });
 
-        window.SHAREDFUNCTIONS.save_json_cookie(`records_list`, records_list_ids_and_type, list_settings.post_type);
+          window.SHAREDFUNCTIONS.save_json_cookie(
+            `records_list`,
+            records_list_ids_and_type,
+            list_settings.post_type,
+          );
+        }
 
-      }
+        $('#bulk_edit_master_checkbox').prop('checked', false); //unchecks the bulk edit master checkbox when the list reloads.
 
-
-      $('#bulk_edit_master_checkbox').prop("checked", false); //unchecks the bulk edit master checkbox when the list reloads.
-
-      $('#load-more').toggle(items.length !== parseInt( response.total ))
-      let result_text = list_settings.translations.txt_info.replace("_START_", items.length).replace("_TOTAL_", response.total)
-      $('.filter-result-text').html(result_text)
-      build_table(items)
-      setup_current_filter_labels()
-      loading_spinner.removeClass("active")
-    }).catch(err => {
-      loading_spinner.removeClass("active")
-      if ( window.lodash.get( err, "statusText" ) !== "abort" ) {
-        console.error(err)
-      }
-    })
+        $('#load-more').toggle(items.length !== parseInt(response.total));
+        let result_text = list_settings.translations.txt_info
+          .replace('_START_', items.length)
+          .replace('_TOTAL_', response.total);
+        $('.filter-result-text').html(result_text);
+        build_table(items);
+        setup_current_filter_labels();
+        loading_spinner.removeClass('active');
+      })
+      .catch((err) => {
+        loading_spinner.removeClass('active');
+        if (window.lodash.get(err, 'statusText') !== 'abort') {
+          console.error(err);
+        }
+      });
   }
 
   $('#load-more').on('click', function () {
-    $(this).addClass('loading')
-    get_records( items.length ).then(()=>{
-      $(this).removeClass('loading')
-    })
-  })
-
+    $(this).addClass('loading');
+    get_records(items.length).then(() => {
+      $(this).removeClass('loading');
+    });
+  });
 
   /**
    * Modal options
    */
 
-
   //add the new filter in the filters list
   function add_custom_filter(name, type, query, labels, load_records = true) {
-    query = query || current_filter.query
+    query = query || current_filter.query;
     let ID = new Date().getTime() / 1000;
     current_filter = {
       ID,
       type,
       name: window.SHAREDFUNCTIONS.escapeHTML(name),
       query: JSON.parse(JSON.stringify(query)),
-      labels: labels
-    }
-    custom_filters.push(JSON.parse(JSON.stringify(current_filter)))
+      labels: labels,
+    };
+    custom_filters.push(JSON.parse(JSON.stringify(current_filter)));
 
-    let save_filter = $(`<a style="float:right" data-filter="${window.SHAREDFUNCTIONS.escapeHTML( ID.toString() )}">
-        ${window.SHAREDFUNCTIONS.escapeHTML( list_settings.translations.save )}
-    </a>`).on("click", function () {
-      $("#filter-name").val(name)
-      $('#save-filter-modal').foundation('open');
-      filter_to_save = ID;
-    })
-    let filterRow = $(`<label class='list-view ${window.SHAREDFUNCTIONS.escapeHTML( ID.toString() )}'>`).append(`
-      <input type="radio" name="view" value="custom_filter" data-id="${window.SHAREDFUNCTIONS.escapeHTML( ID.toString() )}" class="js-list-view" checked autocomplete="off">
+    let save_filter =
+      $(`<a style="float:right" data-filter="${window.SHAREDFUNCTIONS.escapeHTML(ID.toString())}">
+        ${window.SHAREDFUNCTIONS.escapeHTML(list_settings.translations.save)}
+    </a>`).on('click', function () {
+        $('#filter-name').val(name);
+        $('#save-filter-modal').foundation('open');
+        filter_to_save = ID;
+      });
+    let filterRow = $(
+      `<label class='list-view ${window.SHAREDFUNCTIONS.escapeHTML(ID.toString())}'>`,
+    )
+      .append(
+        `
+      <input type="radio" name="view" value="custom_filter" data-id="${window.SHAREDFUNCTIONS.escapeHTML(ID.toString())}" class="js-list-view" checked autocomplete="off">
         ${window.SHAREDFUNCTIONS.escapeHTML(name)}
-    `).append(save_filter)
-    $(".custom-filters").append(filterRow)
-    if ( load_records ){
-      get_records_for_current_filter()
+    `,
+      )
+      .append(save_filter);
+    $('.custom-filters').append(filterRow);
+    if (load_records) {
+      get_records_for_current_filter();
     }
   }
 
-  let get_custom_filter_search_query = ()=>{
-    let search_query = []
-    let fields_filtered = window.lodash.uniq(new_filter_labels.map(f=>f.field))
-    fields_filtered.forEach(field=>{
-      let type = window.lodash.get(list_settings, `post_type_settings.fields.${field}.type` )
-        if (type === "connection") {
-          const allConnections = $(`#${field} .all-connections`)
-          const withoutConnections = $(`#${field} .all-without-connections`)
-          if (allConnections.prop('checked') === true) {
-            search_query.push( { [field] : [ALL_ID] } )
-          } else if (withoutConnections.prop('checked') === true) {
-            search_query.push( { [field] : [ALL_WITHOUT_ID] } )
-          } else {
-            search_query.push({[field]: adjust_search_query_filter_states(field, type, window.lodash.map(window.lodash.get(window.Typeahead[`.js-typeahead-${field}`], "items"), "ID"))});
-          }
+  let get_custom_filter_search_query = () => {
+    let search_query = [];
+    let fields_filtered = window.lodash.uniq(
+      new_filter_labels.map((f) => f.field),
+    );
+    fields_filtered.forEach((field) => {
+      let type = window.lodash.get(
+        list_settings,
+        `post_type_settings.fields.${field}.type`,
+      );
+      if (type === 'connection') {
+        const allConnections = $(`#${field} .all-connections`);
+        const withoutConnections = $(`#${field} .all-without-connections`);
+        if (allConnections.prop('checked') === true) {
+          search_query.push({ [field]: [ALL_ID] });
+        } else if (withoutConnections.prop('checked') === true) {
+          search_query.push({ [field]: [ALL_WITHOUT_ID] });
+        } else {
+          search_query.push({
+            [field]: adjust_search_query_filter_states(
+              field,
+              type,
+              window.lodash.map(
+                window.lodash.get(
+                  window.Typeahead[`.js-typeahead-${field}`],
+                  'items',
+                ),
+                'ID',
+              ),
+            ),
+          });
         }
-      if ( type === "user_select" ){
-        search_query.push({[field]: adjust_search_query_filter_states(field, type, window.lodash.map(window.lodash.get(window.Typeahead[`.js-typeahead-${field}`], "items"), "ID"))});
-      } else if ( type === "multi_select" ){
-        search_query.push({[field]: adjust_search_query_filter_states(field, type, window.lodash.map(window.lodash.get(window.Typeahead[`.js-typeahead-${field}`], "items"), "key"))});
-      } else if ( type === "tags" ){
-        search_query.push({[field]: adjust_search_query_filter_states(field, type, window.lodash.map(window.lodash.get(window.Typeahead[`.js-typeahead-${field}`], "items"), "key"))});
-      } else if ( type === "location" || type === "location_meta" ){
-        search_query.push({'location_grid': adjust_search_query_filter_states('location_grid', type, window.lodash.map(window.lodash.get(window.Typeahead[`.js-typeahead-${field}`], "items"), 'ID'))});
-      } else if ( type === "date" || type === "datetime" ){
-        let date = {}
-        let start = $(`.dt_date_picker[data-field="${field}"][data-delimit="start"]`).val()
-        if ( start ){
-          date.start = start
+      }
+      if (type === 'user_select') {
+        search_query.push({
+          [field]: adjust_search_query_filter_states(
+            field,
+            type,
+            window.lodash.map(
+              window.lodash.get(
+                window.Typeahead[`.js-typeahead-${field}`],
+                'items',
+              ),
+              'ID',
+            ),
+          ),
+        });
+      } else if (type === 'multi_select') {
+        search_query.push({
+          [field]: adjust_search_query_filter_states(
+            field,
+            type,
+            window.lodash.map(
+              window.lodash.get(
+                window.Typeahead[`.js-typeahead-${field}`],
+                'items',
+              ),
+              'key',
+            ),
+          ),
+        });
+      } else if (type === 'tags') {
+        search_query.push({
+          [field]: adjust_search_query_filter_states(
+            field,
+            type,
+            window.lodash.map(
+              window.lodash.get(
+                window.Typeahead[`.js-typeahead-${field}`],
+                'items',
+              ),
+              'key',
+            ),
+          ),
+        });
+      } else if (type === 'location' || type === 'location_meta') {
+        search_query.push({
+          location_grid: adjust_search_query_filter_states(
+            'location_grid',
+            type,
+            window.lodash.map(
+              window.lodash.get(
+                window.Typeahead[`.js-typeahead-${field}`],
+                'items',
+              ),
+              'ID',
+            ),
+          ),
+        });
+      } else if (type === 'date' || type === 'datetime') {
+        let date = {};
+        let start = $(
+          `.dt_date_picker[data-field="${field}"][data-delimit="start"]`,
+        ).val();
+        if (start) {
+          date.start = start;
         }
-        let end = $(`.dt_date_picker[data-field="${field}"][data-delimit="end"]`).val()
-        if ( end ){
-          date.end = end
+        let end = $(
+          `.dt_date_picker[data-field="${field}"][data-delimit="end"]`,
+        ).val();
+        if (end) {
+          date.end = end;
         }
-        search_query.push({[field]: date})
-      } else if ( type === "text" || type === "communication_channel" ){
+        search_query.push({ [field]: date });
+      } else if (type === 'text' || type === 'communication_channel') {
         let filter = $('#' + field + '_text_comms_filter').val();
         let value = filter;
 
-        switch ( $('.filter-by-text-comms-option:checked').val() ) {
+        switch ($('.filter-by-text-comms-option:checked').val()) {
           case 'all-with-set-value': {
             value = '*';
             break;
@@ -1111,72 +1385,88 @@
         }
 
         // Package accordingly based on field type.
-        switch ( type ) {
+        switch (type) {
           case 'text':
           case 'communication_channel': {
-            search_query.push({[field]: (value !== null) ? [value] : []});
+            search_query.push({ [field]: value !== null ? [value] : [] });
             break;
           }
         }
-
       } else {
-        let options = []
-        $(`#${field}-options input:checked`).each(function(){
-          options.push( $(this).val() )
-        })
-        if ( options.length ){
-          search_query.push({[field]: adjust_search_query_filter_states(field, type, options)});
+        let options = [];
+        $(`#${field}-options input:checked`).each(function () {
+          options.push($(this).val());
+        });
+        if (options.length) {
+          search_query.push({
+            [field]: adjust_search_query_filter_states(field, type, options),
+          });
         }
       }
-    })
+    });
     search_query = {
-      fields: search_query
-    }
-    if (list_settings.post_type === "contacts") {
-      if ($("#combine_subassigned").is(":checked")) {
-        let assigned_to = search_query.fields.filter(a => a.assigned_to)
-        let subassigned = search_query.fields.filter(a => a.subassigned)
-        search_query.fields = search_query.fields.filter(a => {
-          return !a.assigned_to && !a.subassigned
-        })
-        search_query.fields.push([assigned_to[0], subassigned[0]])
-        search_query.combine = [ "subassigned" ] // to select checkbox in filter modal
+      fields: search_query,
+    };
+    if (list_settings.post_type === 'contacts') {
+      if ($('#combine_subassigned').is(':checked')) {
+        let assigned_to = search_query.fields.filter((a) => a.assigned_to);
+        let subassigned = search_query.fields.filter((a) => a.subassigned);
+        search_query.fields = search_query.fields.filter((a) => {
+          return !a.assigned_to && !a.subassigned;
+        });
+        search_query.fields.push([assigned_to[0], subassigned[0]]);
+        search_query.combine = ['subassigned']; // to select checkbox in filter modal
       }
     }
 
-    return search_query
-  }
-  $("#confirm-filter-records").on("click", function () {
-    let search_query = get_custom_filter_search_query()
-    let filterName = $('#new-filter-name').val()
+    return search_query;
+  };
+  $('#confirm-filter-records').on('click', function () {
+    let search_query = get_custom_filter_search_query();
+    let filterName = $('#new-filter-name').val();
     reset_split_by_filters();
-    add_custom_filter( filterName || "Custom Filter", "custom-filter", search_query, new_filter_labels)
-  })
+    add_custom_filter(
+      filterName || 'Custom Filter',
+      'custom-filter',
+      search_query,
+      new_filter_labels,
+    );
+  });
 
   $(document).on('click', '.current-filter-label-button', function () {
     if (is_custom_filter_modal_visible()) {
       $(this).parent().toggleClass('current-filter-excluded');
     }
-  })
+  });
 
   // Detect selected custom filter additions and alter shape accordingly
   new MutationObserver(function (mutation_list, observer) {
-    if (is_custom_filter_modal_visible() && mutation_list[0] && $(mutation_list[0].target).attr('id') == 'selected-filters') {
-
+    if (
+      is_custom_filter_modal_visible() &&
+      mutation_list[0] &&
+      $(mutation_list[0].target).attr('id') == 'selected-filters'
+    ) {
       // Iterate over latest selected filters list
-      $(mutation_list[0].target).find('.current-filter').each(function () {
-        let filter_label = $(this);
+      $(mutation_list[0].target)
+        .find('.current-filter')
+        .each(function () {
+          let filter_label = $(this);
 
-        // Only add exclusion button, if required
-        if (($(filter_label).find('.current-filter-label-button').length == 0) && is_custom_filter_field_type_supported_for_exclusion(filter_label)) {
-          $(filter_label).append(`<span title="${window.SHAREDFUNCTIONS.escapeHTML(list_settings.translations.exclude_item)}" class="current-filter-label-button mdi mdi-minus-circle-multiple-outline"></span>`);
-        }
-      });
+          // Only add exclusion button, if required
+          if (
+            $(filter_label).find('.current-filter-label-button').length == 0 &&
+            is_custom_filter_field_type_supported_for_exclusion(filter_label)
+          ) {
+            $(filter_label).append(
+              `<span title="${window.SHAREDFUNCTIONS.escapeHTML(list_settings.translations.exclude_item)}" class="current-filter-label-button mdi mdi-minus-circle-multiple-outline"></span>`,
+            );
+          }
+        });
     }
   }).observe($('#selected-filters').get(0), {
     attributes: true,
     childList: true,
-    subtree: true
+    subtree: true,
   });
 
   function is_custom_filter_modal_visible() {
@@ -1189,9 +1479,19 @@
     // Attempt to locate corresponding field settings
     $.each(list_settings.post_type_settings.fields, function (id, field) {
       if (window.lodash.includes($(filter_label).attr('class'), id)) {
-
         // Determine if identified setting has supported field type
-        is_supported = window.lodash.includes(['connection', 'user_select', 'multi_select', 'tags', 'location', 'location_meta', 'key_select'], field.type);
+        is_supported = window.lodash.includes(
+          [
+            'connection',
+            'user_select',
+            'multi_select',
+            'tags',
+            'location',
+            'location_meta',
+            'key_select',
+          ],
+          field.type,
+        );
       }
     });
 
@@ -1204,25 +1504,49 @@
   }
 
   function adjust_search_query_filter_states(field_id, field_type, filters) {
-
     // Adjust accordingly, by field type
-    if (window.lodash.includes(['connection', 'user_select', 'multi_select', 'tags', 'location', 'location_meta', 'key_select'], field_type) ||
-      !window.lodash.includes(['date', 'datetime', 'boolean', 'communication_channel', 'text', 'textarea', 'array', 'number', 'task'], field_type)) {
-
+    if (
+      window.lodash.includes(
+        [
+          'connection',
+          'user_select',
+          'multi_select',
+          'tags',
+          'location',
+          'location_meta',
+          'key_select',
+        ],
+        field_type,
+      ) ||
+      !window.lodash.includes(
+        [
+          'date',
+          'datetime',
+          'boolean',
+          'communication_channel',
+          'text',
+          'textarea',
+          'array',
+          'number',
+          'task',
+        ],
+        field_type,
+      )
+    ) {
       // Start adjustment of sarch query filters
       let adjusted_filters = window.lodash.map(filters, function (value) {
-
         // Determine it's current exclusion state
-        let excluded = $('.current-filter.current-filter-excluded.' + field_id).filter(function () {
+        let excluded = $(
+          '.current-filter.current-filter-excluded.' + field_id,
+        ).filter(function () {
           return $(this).data('id') == value;
         });
 
         // Prefix exclusion flag, accordingly
-        return ((excluded.length > 0) ? '-' : '') + value;
+        return (excluded.length > 0 ? '-' : '') + value;
       });
 
       return adjusted_filters;
-
     }
 
     // By default, return filters untouched!
@@ -1231,8 +1555,11 @@
 
   function is_search_query_filter_label_excluded(filter, label) {
     let excluded = false;
-    if (window.lodash.has(filter, 'query.fields') && Array.isArray( filter.query.fields ) ) {
-      filter.query.fields.forEach(field => {
+    if (
+      window.lodash.has(filter, 'query.fields') &&
+      Array.isArray(filter.query.fields)
+    ) {
+      filter.query.fields.forEach((field) => {
         if (field[label.field]) {
           excluded = window.lodash.includes(field[label.field], '-' + label.id);
         }
@@ -1243,118 +1570,154 @@
   }
 
   function toggle_all_connection_option(tabsPanel, without) {
-    const allConnectionsElement = tabsPanel.find('.all-connections')
-    const withoutConnectionsElement = tabsPanel.find('.all-without-connections')
+    const allConnectionsElement = tabsPanel.find('.all-connections');
+    const withoutConnectionsElement = tabsPanel.find(
+      '.all-without-connections',
+    );
 
-    without ? allConnectionsElement.prop('checked', false) : withoutConnectionsElement.prop('checked', false)
+    without
+      ? allConnectionsElement.prop('checked', false)
+      : withoutConnectionsElement.prop('checked', false);
   }
 
   function all_connections_click_handler(options) {
-    const { without } = options || { without: false}
-    const id = without ? ALL_WITHOUT_ID : ALL_ID
-    const tabsPanel = $(this).closest('.tabs-panel')
-    const field = tabsPanel.length === 1 ? tabsPanel[0].id : ''
-    const typeaheadQueryElement = tabsPanel.find('.typeahead__query')
-    const typeaheadCancelButtons = tabsPanel.find('.typeahead__cancel-button')
-    const typeahead = tabsPanel.find(`.js-typeahead-${field}`)
+    const { without } = options || { without: false };
+    const id = without ? ALL_WITHOUT_ID : ALL_ID;
+    const tabsPanel = $(this).closest('.tabs-panel');
+    const field = tabsPanel.length === 1 ? tabsPanel[0].id : '';
+    const typeaheadQueryElement = tabsPanel.find('.typeahead__query');
+    const typeaheadCancelButtons = tabsPanel.find('.typeahead__cancel-button');
+    const typeahead = tabsPanel.find(`.js-typeahead-${field}`);
 
-    toggle_all_connection_option(tabsPanel, without)
+    toggle_all_connection_option(tabsPanel, without);
 
     if ($(this).prop('checked') === true) {
-      typeahead.prop('disabled', true)
-      typeaheadQueryElement.addClass('disabled')
+      typeahead.prop('disabled', true);
+      typeaheadQueryElement.addClass('disabled');
       // remove the current filters and leave anything in the typeahead as it is
-      remove_all_filter_labels(field)
-      const {newLabel, filterName } = create_label_all(field, without, id, list_settings)
-      selected_filters.append(`<span class="current-filter ${esc( field )}" data-id="${id}">${filterName}</span>`)
-      new_filter_labels.push(newLabel)
+      remove_all_filter_labels(field);
+      const { newLabel, filterName } = create_label_all(
+        field,
+        without,
+        id,
+        list_settings,
+      );
+      selected_filters.append(
+        `<span class="current-filter ${esc(field)}" data-id="${id}">${filterName}</span>`,
+      );
+      new_filter_labels.push(newLabel);
     } else {
-      typeahead.prop('disabled', false)
-      typeaheadQueryElement.removeClass('disabled')
-      remove_filter_labels(id, field)
+      typeahead.prop('disabled', false);
+      typeaheadQueryElement.removeClass('disabled');
+      remove_filter_labels(id, field);
       // clear the typeahead by manually clicking each selected item.
       // This is done at this point as it triggers the typeahead to open which we don't want just after we have disabled it.
       typeaheadCancelButtons.each(function () {
-        $(this).trigger('click', { botClick: true })
-      })
+        $(this).trigger('click', { botClick: true });
+      });
     }
   }
-
 
   /* Label creation */
 
-  function create_label_all(field, without, id, listSettings ) {
-    const fieldLabel = listSettings.post_type_settings.fields[field] ? listSettings.post_type_settings.fields[field].name : ''
-    const allLabel = without ? esc(listSettings.translations.without) : esc( listSettings.translations.all )
-    const filterName = `${esc( fieldLabel )}: ${allLabel}`
+  function create_label_all(field, without, id, listSettings) {
+    const fieldLabel = listSettings.post_type_settings.fields[field]
+      ? listSettings.post_type_settings.fields[field].name
+      : '';
+    const allLabel = without
+      ? esc(listSettings.translations.without)
+      : esc(listSettings.translations.all);
+    const filterName = `${esc(fieldLabel)}: ${allLabel}`;
 
-    return ({
+    return {
       newLabel: {
         id: id,
         name: filterName,
-        field: field
+        field: field,
       },
       filterName,
-    })
+    };
   }
 
   function create_value_label(field, key, value) {
-    return ({ newLabel: { id: key, name: value, field}})
+    return { newLabel: { id: key, name: value, field } };
   }
 
   function create_name_value_label(field, id, value, listSettings) {
-    let name = window.lodash.get(listSettings, `post_type_settings.fields.${field}.name`, field)
+    let name = window.lodash.get(
+      listSettings,
+      `post_type_settings.fields.${field}.name`,
+      field,
+    );
     const filterName = `${name}: ${value}`;
-    return ({
+    return {
       newLabel: { id, name: filterName, field },
       name,
-    })
+    };
   }
 
   function create_location_label(field, id, value, listSettings) {
-    let name = window.lodash.get(listSettings, `post_type_settings.fields.location_grid.name`, 'location_grid')
-    return ({
+    let name = window.lodash.get(
+      listSettings,
+      `post_type_settings.fields.location_grid.name`,
+      'location_grid',
+    );
+    return {
       newLabel: { id, name: `${name}: ${value}`, field, type: 'location_grid' },
       name,
-    })
+    };
   }
 
   function create_date_label(field, date, delimiter) {
-    let field_name = window.lodash.get( list_settings, `post_type_settings.fields.${field}.name` , field)
-    let delimiter_label = list_settings.translations[`range_${delimiter}`]
+    let field_name = window.lodash.get(
+      list_settings,
+      `post_type_settings.fields.${field}.name`,
+      field,
+    );
+    let delimiter_label = list_settings.translations[`range_${delimiter}`];
 
     return {
-      newLabel: { id: `${field}_${delimiter}`, name: `${field_name} ${delimiter_label}: ${date}`, field, date: date },
+      newLabel: {
+        id: `${field}_${delimiter}`,
+        name: `${field_name} ${delimiter_label}: ${date}`,
+        field,
+        date: date,
+      },
       field_name,
       delimiter_label,
-    }
+    };
   }
 
-  $('.all-connections').on("click", all_connections_click_handler)
+  $('.all-connections').on('click', all_connections_click_handler);
 
   function without_connections_handler() {
-    all_connections_click_handler.call(this, { without: true })
+    all_connections_click_handler.call(this, { without: true });
   }
 
-  $('.all-without-connections').on("click", without_connections_handler)
+  $('.all-without-connections').on('click', without_connections_handler);
 
-  $('.text-comms-filter-input').on("keyup", function (e) {
-
+  $('.text-comms-filter-input').on('keyup', function (e) {
     // Ensure to assign default settings accordingly.
     const field = $(e.target).data('field');
     const panel = $(`#${field}.tabs-panel`);
     const field_settings = list_settings?.post_type_settings?.fields[field];
-    if ( panel && field_settings && field_settings['type'] ) {
-      switch ( field_settings['type'] ) {
+    if (panel && field_settings && field_settings['type']) {
+      switch (field_settings['type']) {
         case 'text':
         case 'communication_channel': {
-          const checked_options = $(panel).find(`.filter-by-text-comms-option:checked`);
-          const existing_label = new_filter_labels.find((label) => ( label['field'] === field ) );
+          const checked_options = $(panel).find(
+            `.filter-by-text-comms-option:checked`,
+          );
+          const existing_label = new_filter_labels.find(
+            (label) => label['field'] === field,
+          );
 
           // Only apply default settings if unable to detect and previous selections.
-          if ( ( checked_options.length === 0 ) && ( existing_label === undefined ) ) {
-            const default_option = $(panel).find(`.filter-by-text-comms-option[value="all-with-filtered-value"]`);
-            if ( default_option ) {
+          if (checked_options.length === 0 && existing_label === undefined) {
+            const default_option = $(panel).find(
+              `.filter-by-text-comms-option[value="all-with-filtered-value"]`,
+            );
+            if (default_option) {
               $(default_option).prop('checked', true);
               $(default_option).trigger('click');
             }
@@ -1362,14 +1725,30 @@
 
           // Update label with latest filtered value.
           const filtered_value = $(e.target).val();
-          const latest_checked_option = $(panel).find(`.filter-by-text-comms-option:checked`);
-          const latest_existing_label = new_filter_labels.find( (label) => ( label['field'] === field ) );
-          if ( ( latest_checked_option.length === 1 ) && ( latest_existing_label !== undefined ) && ['all-with-filtered-value', 'all-without-filtered-value'].includes( $(latest_checked_option).val() ) ) {
-            const updated_label_text = `${esc( list_settings.post_type_settings.fields[field] ? list_settings.post_type_settings.fields[field].name : '' )}: ${esc(filtered_value)}`;
-            $(selected_filters).find(`.current-filter[data-id="${$(latest_checked_option).val()}"].${field}`).text( updated_label_text );
+          const latest_checked_option = $(panel).find(
+            `.filter-by-text-comms-option:checked`,
+          );
+          const latest_existing_label = new_filter_labels.find(
+            (label) => label['field'] === field,
+          );
+          if (
+            latest_checked_option.length === 1 &&
+            latest_existing_label !== undefined &&
+            ['all-with-filtered-value', 'all-without-filtered-value'].includes(
+              $(latest_checked_option).val(),
+            )
+          ) {
+            const updated_label_text = `${esc(list_settings.post_type_settings.fields[field] ? list_settings.post_type_settings.fields[field].name : '')}: ${esc(filtered_value)}`;
+            $(selected_filters)
+              .find(
+                `.current-filter[data-id="${$(latest_checked_option).val()}"].${field}`,
+              )
+              .text(updated_label_text);
 
             // Update global filter labels array.
-            const label_idx = new_filter_labels.findIndex( (label) => ( label['field'] === field ) );
+            const label_idx = new_filter_labels.findIndex(
+              (label) => label['field'] === field,
+            );
             new_filter_labels[label_idx]['name'] = updated_label_text;
           }
           break;
@@ -1378,31 +1757,34 @@
     }
   });
 
-  $('.filter-by-text-comms-option').on("click", function (e) {
-    handle_filter_by_text_comms( {
+  $('.filter-by-text-comms-option').on('click', function (e) {
+    handle_filter_by_text_comms({
       id: $(this).val(),
-      field: $(this).data('field')
-    } );
+      field: $(this).data('field'),
+    });
   });
 
   function handle_filter_by_text_comms(options) {
-    const {id, field} = options || {id: null, field: null};
+    const { id, field } = options || { id: null, field: null };
     if (id && field) {
-
       // Adjust filter text field state accordingly, based on option selection.
       let filter_text_field = $('#' + field + '_text_comms_filter');
-      $(filter_text_field).prop('disabled', ['all-with-set-value', 'all-without-set-value'].includes(id));
+      $(filter_text_field).prop(
+        'disabled',
+        ['all-with-set-value', 'all-without-set-value'].includes(id),
+      );
 
       // Ensure duplicates are avoided.
-      const existing_label = new_filter_labels.find((label) => ( label['id'] === id ) && ( label['field'] === field ) );
-      if ( existing_label === undefined ) {
-
+      const existing_label = new_filter_labels.find(
+        (label) => label['id'] === id && label['field'] === field,
+      );
+      if (existing_label === undefined) {
         // Identify stale labels to be deleted.
         let removed_old_filter_labels = [];
         new_filter_labels.forEach((label) => {
-          if ( label['field'] === field ) {
-            if ( !( label['id'] === id ) ) {
-              removed_old_filter_labels.push( label );
+          if (label['field'] === field) {
+            if (!(label['id'] === id)) {
+              removed_old_filter_labels.push(label);
             }
           }
         });
@@ -1412,7 +1794,11 @@
           new_filter_labels = new_filter_labels.filter((existing_label) => {
             let filtered = false;
             removed_old_filter_labels.forEach((stale_label) => {
-              if ( (existing_label['id'] !== stale_label['id']) && (existing_label['name'] !== stale_label['name']) && (existing_label['field'] !== stale_label['field']) ) {
+              if (
+                existing_label['id'] !== stale_label['id'] &&
+                existing_label['name'] !== stale_label['name'] &&
+                existing_label['field'] !== stale_label['field']
+              ) {
                 filtered = true;
               }
             });
@@ -1422,351 +1808,462 @@
 
           // Remove associated ui labels.
           removed_old_filter_labels.forEach((label) => {
-            $(selected_filters).find(`.current-filter[data-id="${label['id']}"].${label['field']}`).remove();
+            $(selected_filters)
+              .find(
+                `.current-filter[data-id="${label['id']}"].${label['field']}`,
+              )
+              .remove();
           });
         }
 
         // Create new generic filter label.
-        let {newLabel, filterName} = create_label_all(field, ['all-without-set-value', 'all-without-filtered-value'].includes(id), id, list_settings);
+        let { newLabel, filterName } = create_label_all(
+          field,
+          ['all-without-set-value', 'all-without-filtered-value'].includes(id),
+          id,
+          list_settings,
+        );
 
         // Adjust label to reflect filtered text.
-        if ( ['all-with-filtered-value', 'all-without-filtered-value'].includes(id) ) {
+        if (
+          ['all-with-filtered-value', 'all-without-filtered-value'].includes(id)
+        ) {
           let filtered_value = $(`#${field}_text_comms_filter`).val();
-          newLabel['name'] = filterName = `${esc( list_settings.post_type_settings.fields[field] ? list_settings.post_type_settings.fields[field].name : '' )}: ${esc(filtered_value)}`;
+          newLabel['name'] =
+            filterName = `${esc(list_settings.post_type_settings.fields[field] ? list_settings.post_type_settings.fields[field].name : '')}: ${esc(filtered_value)}`;
         }
 
-        selected_filters.append(`<span class="current-filter ${esc(field)}" data-id="${id}">${filterName}</span>`);
+        selected_filters.append(
+          `<span class="current-filter ${esc(field)}" data-id="${id}">${filterName}</span>`,
+        );
         new_filter_labels.push(newLabel);
       }
     }
   }
 
-  let load_multi_select_typeaheads = async function load_multi_select_typeaheads() {
-    for (let input of $("#filter-modal .multi_select .typeahead__query input")) {
-      let field = $(input).data('field')
-      let typeahead_name = `.js-typeahead-${field}`
+  let load_multi_select_typeaheads =
+    async function load_multi_select_typeaheads() {
+      for (let input of $(
+        '#filter-modal .multi_select .typeahead__query input',
+      )) {
+        let field = $(input).data('field');
+        let typeahead_name = `.js-typeahead-${field}`;
 
-      if (window.Typeahead[typeahead_name]) {
-        return
-      }
-
-      let source_data = { data: [] }
-      let field_options = window.lodash.get(list_settings, `post_type_settings.fields.${field}.default`, {})
-      if ( Object.keys(field_options).length > 0 ){
-        window.lodash.forOwn(field_options, (val, key)=>{
-          if ( !val.deleted ){
-            source_data.data.push({
-              key: key,
-              name: key,
-              value: val.label || key
-            })
-          }
-        })
-      } else {
-        source_data = {
-          [field]: {
-            display: ["value"],
-            ajax: {
-              url: window.wpApiShare.root + `dt-posts/v2/${list_settings.post_type}/multi-select-values`,
-              data: {
-                s: "{{query}}",
-                field
-              },
-              beforeSend: function (xhr) {
-                xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce);
-              },
-              callback: {
-                done: function (data) {
-                  return (data || []).map(tag => {
-                    let label = window.lodash.get(field_options, tag + ".label", tag)
-                    return {value: label, key: tag}
-                  })
-                }
-              }
-            }
-          }
+        if (window.Typeahead[typeahead_name]) {
+          return;
         }
-      }
-      $.typeahead({
-        input: `.js-typeahead-${field}`,
-        minLength: 0,
-        maxItem: 20,
-        searchOnFocus: true,
-        template: function (query, item) {
-          return `<span>${window.SHAREDFUNCTIONS.escapeHTML(item.value)}</span>`
-        },
-        source: source_data,
-        display: "value",
-        templateValue: "{{value}}",
-        dynamic: true,
-        multiselect: {
-          matchOn: ["key"],
-          data: [],
-          callback: {
-            onCancel: function (node, item) {
-              $(`.current-filter[data-id="${item.key}"].${field}`).remove()
-              window.lodash.pullAllBy(new_filter_labels, [{id:item.key}], "id")
+
+        let source_data = { data: [] };
+        let field_options = window.lodash.get(
+          list_settings,
+          `post_type_settings.fields.${field}.default`,
+          {},
+        );
+        if (Object.keys(field_options).length > 0) {
+          window.lodash.forOwn(field_options, (val, key) => {
+            if (!val.deleted) {
+              source_data.data.push({
+                key: key,
+                name: key,
+                value: val.label || key,
+              });
             }
-          }
-        },
-        callback: {
-          onClick: function(node, a, item) {
-            const { newLabel, name } = create_name_value_label(field, item.key, item.value, list_settings)
-            selected_filters.append(`<span class="current-filter ${window.SHAREDFUNCTIONS.escapeHTML( field )}" data-id="${window.SHAREDFUNCTIONS.escapeHTML( item.key )}">${window.SHAREDFUNCTIONS.escapeHTML( name )}:${window.SHAREDFUNCTIONS.escapeHTML( item.value )}</span>`)
-            new_filter_labels.push(newLabel)
-          },
-          onResult: function (node, query, result, resultCount) {
-            let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
-            $(`#${field}-result-container`).html(text);
-          },
-          onHideLayout: function () {
-            $(`#${field}-result-container`).html("");
-          }
-        }
-      });
-    }
-  }
-
-  let load_post_type_typeaheads = ()=>{
-    $(".typeahead__query [data-type='connection']").each((key, el)=>{
-      let field_key = $(el).data('field')
-      let post_type = window.lodash.get( list_settings, `post_type_settings.fields.${field_key}.post_type`, field_key)
-      if (!window.Typeahead[`.js-typeahead-${field_key}`]) {
-        $.typeahead({
-          input: `.js-typeahead-${field_key}`,
-          minLength: 0,
-          accent: true,
-          searchOnFocus: true,
-          maxItem: 20,
-          template: function (query, item) {
-            return `<span dir="auto">${window.SHAREDFUNCTIONS.escapeHTML(item.name)} (#${window.SHAREDFUNCTIONS.escapeHTML( item.ID )})</span>`
-          },
-          source: window.TYPEAHEADS.typeaheadPostsSource(post_type),
-          display: "name",
-          templateValue: "{{name}}",
-          dynamic: true,
-          multiselect: {
-            matchOn: ["ID"],
-            data: [],
-            callback: {
-              onCancel: function (node, item, event) {
-                remove_filter_labels(item.ID, field_key)
-              }
-            }
-          },
-          callback: {
-            onResult: function (node, query, result, resultCount) {
-              let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
-              $(`#${field_key}-result-container`).html(text);
-            },
-            onHideLayout: function () {
-              $(`#${field_key}-result-container`).html("");
-            },
-            onClick: function (node, a, item) {
-              const { newLabel } = create_value_label(field_key, item.ID, item.name)
-              new_filter_labels.push(newLabel)
-              selected_filters.append(`<span class="current-filter ${field_key}" data-id="${window.SHAREDFUNCTIONS.escapeHTML( item.ID )}">${window.SHAREDFUNCTIONS.escapeHTML( item.name )}</span>`)
-            }
-          }
-        });
-      }
-    })
-  }
-
-  const remove_filter_labels = (id, field_key) => {
-    $(`.current-filter[data-id="${id}"].${field_key}`).remove()
-    window.lodash.pullAllBy(new_filter_labels, [{id: id}], "id")
-  }
-
-  const remove_all_filter_labels = (field_key) => {
-    // get all id's for this field_key
-    let ids = []
-    document.querySelectorAll(`.current-filter.${field_key}`).forEach((element) => {
-      ids.push(element.dataset.id)
-    })
-    ids.forEach((id) => remove_filter_labels(id, field_key))
-  }
-
-  let load_user_select_typeaheads = ()=>{
-    $(".typeahead__query [data-type='user_select']").each((key, el)=>{
-      let field_key = $(el).data('field')
-      if (!window.Typeahead[`.js-typeahead-${field_key}`]) {
-        $.typeahead({
-          input: `.js-typeahead-${field_key}`,
-          minLength: 0,
-          accent: true,
-          searchOnFocus: true,
-          maxItem: 20,
-          template: function (query, item) {
-            return `<span dir="auto">${window.SHAREDFUNCTIONS.escapeHTML(item.name)} (#${window.SHAREDFUNCTIONS.escapeHTML( item.ID )})</span>`
-          },
-          source: window.TYPEAHEADS.typeaheadUserSource(),
-          display: "name",
-          templateValue: "{{name}}",
-          dynamic: true,
-          multiselect: {
-            matchOn: ["ID"],
-            data: [],
-            callback: {
-              onCancel: function (node, item) {
-                $(`.current-filter[data-id="${item.ID}"].${field_key}`).remove()
-                window.lodash.pullAllBy(new_filter_labels, [{id: item.ID}], "id")
-              }
-            }
-          },
-          callback: {
-            onResult: function (node, query, result, resultCount) {
-              let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
-              $(`#${field_key}-result-container`).html(text);
-            },
-            onHideLayout: function () {
-              $(`#${field_key}-result-container`).html("");
-            },
-            onClick: function (node, a, item) {
-              const { newLabel } = create_value_label(field_key, item.ID, item.name)
-              new_filter_labels.push(newLabel)
-              selected_filters.append(`<span class="current-filter ${field_key}" data-id="${window.SHAREDFUNCTIONS.escapeHTML( item.ID )}">${window.SHAREDFUNCTIONS.escapeHTML( item.name )}</span>`)
-            }
-          }
-        });
-      }
-    })
-  }
-
-  /**
-   * Location
-   */
-  $('#mapbox-clear-autocomplete').click("input", function(){
-    delete window.location_data;
-  });
-
-  let load_location_typeahead = ()=> {
-    let key = 'location_grid'
-    if ( $('.js-typeahead-location_grid_meta').length){
-      key = 'location_grid_meta';
-    }
-    if ( !window.Typeahead[`.js-typeahead-${key}`]) {
-
-      // Ensure element is present before proceeding!
-      if ($('.js-typeahead-' + window.SHAREDFUNCTIONS.escapeHTML(key)).length > 0) {
-        $.typeahead({
-          input: `.js-typeahead-${window.SHAREDFUNCTIONS.escapeHTML(key)}`,
-          minLength: 0,
-          accent: true,
-          searchOnFocus: true,
-          maxItem: 20,
-          dropdownFilter: [{
-            key: 'group',
-            value: 'used',
-            template: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.used_locations),
-            all: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.all_locations)
-          }],
-          source: {
-            used: {
-              display: "name",
+          });
+        } else {
+          source_data = {
+            [field]: {
+              display: ['value'],
               ajax: {
-                url: window.wpApiShare.root + 'dt/v1/mapping_module/search_location_grid_by_name',
+                url:
+                  window.wpApiShare.root +
+                  `dt-posts/v2/${list_settings.post_type}/multi-select-values`,
                 data: {
-                  s: "{{query}}",
-                  filter: function () {
-                    return window.lodash.get(window.Typeahead[`.js-typeahead-${key}`].filters.dropdown, 'value', 'all')
-                  }
+                  s: '{{query}}',
+                  field,
                 },
                 beforeSend: function (xhr) {
                   xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce);
                 },
                 callback: {
                   done: function (data) {
-                    if (typeof window.typeaheadTotals!=="undefined") {
-                      window.typeaheadTotals.field = data.total
-                    }
-                    return data.location_grid
-                  }
-                }
-              }
-            }
+                    return (data || []).map((tag) => {
+                      let label = window.lodash.get(
+                        field_options,
+                        tag + '.label',
+                        tag,
+                      );
+                      return { value: label, key: tag };
+                    });
+                  },
+                },
+              },
+            },
+          };
+        }
+        $.typeahead({
+          input: `.js-typeahead-${field}`,
+          minLength: 0,
+          maxItem: 20,
+          searchOnFocus: true,
+          template: function (query, item) {
+            return `<span>${window.SHAREDFUNCTIONS.escapeHTML(item.value)}</span>`;
           },
-          display: "name",
-          templateValue: "{{name}}",
+          source: source_data,
+          display: 'value',
+          templateValue: '{{value}}',
           dynamic: true,
           multiselect: {
-            matchOn: ["ID"],
+            matchOn: ['key'],
             data: [],
             callback: {
               onCancel: function (node, item) {
-                $(`.current-filter[data-id="${item.ID}"].location_grid`).remove()
-                window.lodash.pullAllBy(new_filter_labels, [{id: item.ID}], "id")
-              }
-            }
+                $(`.current-filter[data-id="${item.key}"].${field}`).remove();
+                window.lodash.pullAllBy(
+                  new_filter_labels,
+                  [{ id: item.key }],
+                  'id',
+                );
+              },
+            },
+          },
+          callback: {
+            onClick: function (node, a, item) {
+              const { newLabel, name } = create_name_value_label(
+                field,
+                item.key,
+                item.value,
+                list_settings,
+              );
+              selected_filters.append(
+                `<span class="current-filter ${window.SHAREDFUNCTIONS.escapeHTML(field)}" data-id="${window.SHAREDFUNCTIONS.escapeHTML(item.key)}">${window.SHAREDFUNCTIONS.escapeHTML(name)}:${window.SHAREDFUNCTIONS.escapeHTML(item.value)}</span>`,
+              );
+              new_filter_labels.push(newLabel);
+            },
+            onResult: function (node, query, result, resultCount) {
+              let text = window.TYPEAHEADS.typeaheadHelpText(
+                resultCount,
+                query,
+                result,
+              );
+              $(`#${field}-result-container`).html(text);
+            },
+            onHideLayout: function () {
+              $(`#${field}-result-container`).html('');
+            },
+          },
+        });
+      }
+    };
+
+  let load_post_type_typeaheads = () => {
+    $(".typeahead__query [data-type='connection']").each((key, el) => {
+      let field_key = $(el).data('field');
+      let post_type = window.lodash.get(
+        list_settings,
+        `post_type_settings.fields.${field_key}.post_type`,
+        field_key,
+      );
+      if (!window.Typeahead[`.js-typeahead-${field_key}`]) {
+        $.typeahead({
+          input: `.js-typeahead-${field_key}`,
+          minLength: 0,
+          accent: true,
+          searchOnFocus: true,
+          maxItem: 20,
+          template: function (query, item) {
+            return `<span dir="auto">${window.SHAREDFUNCTIONS.escapeHTML(item.name)} (#${window.SHAREDFUNCTIONS.escapeHTML(item.ID)})</span>`;
+          },
+          source: window.TYPEAHEADS.typeaheadPostsSource(post_type),
+          display: 'name',
+          templateValue: '{{name}}',
+          dynamic: true,
+          multiselect: {
+            matchOn: ['ID'],
+            data: [],
+            callback: {
+              onCancel: function (node, item, event) {
+                remove_filter_labels(item.ID, field_key);
+              },
+            },
           },
           callback: {
             onResult: function (node, query, result, resultCount) {
-              let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+              let text = window.TYPEAHEADS.typeaheadHelpText(
+                resultCount,
+                query,
+                result,
+              );
+              $(`#${field_key}-result-container`).html(text);
+            },
+            onHideLayout: function () {
+              $(`#${field_key}-result-container`).html('');
+            },
+            onClick: function (node, a, item) {
+              const { newLabel } = create_value_label(
+                field_key,
+                item.ID,
+                item.name,
+              );
+              new_filter_labels.push(newLabel);
+              selected_filters.append(
+                `<span class="current-filter ${field_key}" data-id="${window.SHAREDFUNCTIONS.escapeHTML(item.ID)}">${window.SHAREDFUNCTIONS.escapeHTML(item.name)}</span>`,
+              );
+            },
+          },
+        });
+      }
+    });
+  };
+
+  const remove_filter_labels = (id, field_key) => {
+    $(`.current-filter[data-id="${id}"].${field_key}`).remove();
+    window.lodash.pullAllBy(new_filter_labels, [{ id: id }], 'id');
+  };
+
+  const remove_all_filter_labels = (field_key) => {
+    // get all id's for this field_key
+    let ids = [];
+    document
+      .querySelectorAll(`.current-filter.${field_key}`)
+      .forEach((element) => {
+        ids.push(element.dataset.id);
+      });
+    ids.forEach((id) => remove_filter_labels(id, field_key));
+  };
+
+  let load_user_select_typeaheads = () => {
+    $(".typeahead__query [data-type='user_select']").each((key, el) => {
+      let field_key = $(el).data('field');
+      if (!window.Typeahead[`.js-typeahead-${field_key}`]) {
+        $.typeahead({
+          input: `.js-typeahead-${field_key}`,
+          minLength: 0,
+          accent: true,
+          searchOnFocus: true,
+          maxItem: 20,
+          template: function (query, item) {
+            return `<span dir="auto">${window.SHAREDFUNCTIONS.escapeHTML(item.name)} (#${window.SHAREDFUNCTIONS.escapeHTML(item.ID)})</span>`;
+          },
+          source: window.TYPEAHEADS.typeaheadUserSource(),
+          display: 'name',
+          templateValue: '{{name}}',
+          dynamic: true,
+          multiselect: {
+            matchOn: ['ID'],
+            data: [],
+            callback: {
+              onCancel: function (node, item) {
+                $(
+                  `.current-filter[data-id="${item.ID}"].${field_key}`,
+                ).remove();
+                window.lodash.pullAllBy(
+                  new_filter_labels,
+                  [{ id: item.ID }],
+                  'id',
+                );
+              },
+            },
+          },
+          callback: {
+            onResult: function (node, query, result, resultCount) {
+              let text = window.TYPEAHEADS.typeaheadHelpText(
+                resultCount,
+                query,
+                result,
+              );
+              $(`#${field_key}-result-container`).html(text);
+            },
+            onHideLayout: function () {
+              $(`#${field_key}-result-container`).html('');
+            },
+            onClick: function (node, a, item) {
+              const { newLabel } = create_value_label(
+                field_key,
+                item.ID,
+                item.name,
+              );
+              new_filter_labels.push(newLabel);
+              selected_filters.append(
+                `<span class="current-filter ${field_key}" data-id="${window.SHAREDFUNCTIONS.escapeHTML(item.ID)}">${window.SHAREDFUNCTIONS.escapeHTML(item.name)}</span>`,
+              );
+            },
+          },
+        });
+      }
+    });
+  };
+
+  /**
+   * Location
+   */
+  $('#mapbox-clear-autocomplete').click('input', function () {
+    delete window.location_data;
+  });
+
+  let load_location_typeahead = () => {
+    let key = 'location_grid';
+    if ($('.js-typeahead-location_grid_meta').length) {
+      key = 'location_grid_meta';
+    }
+    if (!window.Typeahead[`.js-typeahead-${key}`]) {
+      // Ensure element is present before proceeding!
+      if (
+        $('.js-typeahead-' + window.SHAREDFUNCTIONS.escapeHTML(key)).length > 0
+      ) {
+        $.typeahead({
+          input: `.js-typeahead-${window.SHAREDFUNCTIONS.escapeHTML(key)}`,
+          minLength: 0,
+          accent: true,
+          searchOnFocus: true,
+          maxItem: 20,
+          dropdownFilter: [
+            {
+              key: 'group',
+              value: 'used',
+              template: window.SHAREDFUNCTIONS.escapeHTML(
+                window.wpApiShare.translations.used_locations,
+              ),
+              all: window.SHAREDFUNCTIONS.escapeHTML(
+                window.wpApiShare.translations.all_locations,
+              ),
+            },
+          ],
+          source: {
+            used: {
+              display: 'name',
+              ajax: {
+                url:
+                  window.wpApiShare.root +
+                  'dt/v1/mapping_module/search_location_grid_by_name',
+                data: {
+                  s: '{{query}}',
+                  filter: function () {
+                    return window.lodash.get(
+                      window.Typeahead[`.js-typeahead-${key}`].filters.dropdown,
+                      'value',
+                      'all',
+                    );
+                  },
+                },
+                beforeSend: function (xhr) {
+                  xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce);
+                },
+                callback: {
+                  done: function (data) {
+                    if (typeof window.typeaheadTotals !== 'undefined') {
+                      window.typeaheadTotals.field = data.total;
+                    }
+                    return data.location_grid;
+                  },
+                },
+              },
+            },
+          },
+          display: 'name',
+          templateValue: '{{name}}',
+          dynamic: true,
+          multiselect: {
+            matchOn: ['ID'],
+            data: [],
+            callback: {
+              onCancel: function (node, item) {
+                $(
+                  `.current-filter[data-id="${item.ID}"].location_grid`,
+                ).remove();
+                window.lodash.pullAllBy(
+                  new_filter_labels,
+                  [{ id: item.ID }],
+                  'id',
+                );
+              },
+            },
+          },
+          callback: {
+            onResult: function (node, query, result, resultCount) {
+              let text = window.TYPEAHEADS.typeaheadHelpText(
+                resultCount,
+                query,
+                result,
+              );
               $('#location_grid-result-container').html(text);
             },
             onReady() {
               this.filters.dropdown = {
-                key: "group",
-                value: "used",
-                template: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.used_locations)
-              }
+                key: 'group',
+                value: 'used',
+                template: window.SHAREDFUNCTIONS.escapeHTML(
+                  window.wpApiShare.translations.used_locations,
+                ),
+              };
               this.container
-              .removeClass("filter")
-              .find("." + this.options.selector.filterButton)
-              .html(window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.used_locations));
+                .removeClass('filter')
+                .find('.' + this.options.selector.filterButton)
+                .html(
+                  window.SHAREDFUNCTIONS.escapeHTML(
+                    window.wpApiShare.translations.used_locations,
+                  ),
+                );
             },
             onHideLayout: function () {
-              $('#location_grid-result-container').html("");
+              $('#location_grid-result-container').html('');
             },
             onClick: function (node, a, item) {
-              const {name, newLabel} = create_location_label(key, item.ID, item.name, list_settings)
-              new_filter_labels.push(newLabel)
-              selected_filters.append(`<span class="current-filter location_grid" data-id="${window.SHAREDFUNCTIONS.escapeHTML(item.ID)}">${window.SHAREDFUNCTIONS.escapeHTML(name)}:${window.SHAREDFUNCTIONS.escapeHTML(item.name)}</span>`)
-            }
-          }
+              const { name, newLabel } = create_location_label(
+                key,
+                item.ID,
+                item.name,
+                list_settings,
+              );
+              new_filter_labels.push(newLabel);
+              selected_filters.append(
+                `<span class="current-filter location_grid" data-id="${window.SHAREDFUNCTIONS.escapeHTML(item.ID)}">${window.SHAREDFUNCTIONS.escapeHTML(name)}:${window.SHAREDFUNCTIONS.escapeHTML(item.name)}</span>`,
+              );
+            },
+          },
         });
       }
     }
-  }
+  };
 
   /*
    * Setup filter box
    */
-  let typeaheads_loaded = null
-  $('#filter-modal').on("open.zf.reveal", function () {
-    new_filter_labels=[]
-    load_location_typeahead()
-    load_post_type_typeaheads()
-    load_user_select_typeaheads()
-    typeaheads_loaded = load_multi_select_typeaheads().catch(err => {
-      console.error(err)
-    })
-    $('#new-filter-name').val('')
-    $("#filter-modal input.dt_date_picker").each(function () {
-      $(this).val('')
-    })
-    $("#filter-modal input:checked").each(function () {
-      $(this).prop('checked', false)
-    })
-    $("#filter-modal input:disabled").each(function () {
-      $(this).prop('disabled', false)
-    })
+  let typeaheads_loaded = null;
+  $('#filter-modal').on('open.zf.reveal', function () {
+    new_filter_labels = [];
+    load_location_typeahead();
+    load_post_type_typeaheads();
+    load_user_select_typeaheads();
+    typeaheads_loaded = load_multi_select_typeaheads().catch((err) => {
+      console.error(err);
+    });
+    $('#new-filter-name').val('');
+    $('#filter-modal input.dt_date_picker').each(function () {
+      $(this).val('');
+    });
+    $('#filter-modal input:checked').each(function () {
+      $(this).prop('checked', false);
+    });
+    $('#filter-modal input:disabled').each(function () {
+      $(this).prop('disabled', false);
+    });
     $('#filter-modal .typeahead__query.disabled').each(function () {
-      $(this).removeClass('disabled')
-    })
+      $(this).removeClass('disabled');
+    });
     selected_filters.empty();
-    $(".typeahead__query input").each(function () {
-      let typeahead = window.Typeahead['.'+$(this).attr("class").split(/\s+/)[0]]
-      if ( typeahead && typeahead.items ){
-        for (let i = 0; i < typeahead.items.length; i ){
-          typeahead.cancelMultiselectItem(0)
+    $('.typeahead__query input').each(function () {
+      let typeahead =
+        window.Typeahead['.' + $(this).attr('class').split(/\s+/)[0]];
+      if (typeahead && typeahead.items) {
+        for (let i = 0; i < typeahead.items.length; i) {
+          typeahead.cancelMultiselectItem(0);
         }
-        typeahead.node.trigger('propertychange.typeahead')
+        typeahead.node.trigger('propertychange.typeahead');
       }
     });
-    $('#confirm-filter-records').show()
-    $('#save-filter-edits').hide()
-  })
+    $('#confirm-filter-records').show();
+    $('#save-filter-edits').hide();
+  });
 
   var clicked;
   $(document).mousedown(function (e) {
@@ -1778,384 +2275,490 @@
   $(document).mouseup(function (e) {
     clicked = null;
   });
-  $("#filter-modal input.dt_date_picker").on('blur', function (e) {
-    if (clicked && clicked.closest( '.ui-datepicker' ).length === 1 ) {
+  $('#filter-modal input.dt_date_picker').on('blur', function (e) {
+    if (clicked && clicked.closest('.ui-datepicker').length === 1) {
       // we have clicked in the datepicker, so don't run the blur
-      return
+      return;
     }
     // delay the blur so that if the user has clicked we get the correct date from the input
     setTimeout(() => {
       if (!e.target.value) {
-        const clearButton = $(this).prev('.clear-date-picker')
-        clearButton.click()
-        return
+        const clearButton = $(this).prev('.clear-date-picker');
+        clearButton.click();
+        return;
       }
-      $(this).datepicker('setDate', e.target.value)
-      $('.ui-datepicker-current-day').click()
+      $(this).datepicker('setDate', e.target.value);
+      $('.ui-datepicker-current-day').click();
     }, 100);
-  })
+  });
 
-  function edit_saved_filter( filter ){
+  function edit_saved_filter(filter) {
     $('#filter-modal').foundation('open');
-    typeaheads_loaded.then(()=>{
-      let connectionTypeKeys = list_settings.post_type_settings.connection_types
-      connectionTypeKeys.push("location_grid")
-      filter.labels.forEach(label=>{
-
+    typeaheads_loaded.then(() => {
+      let connectionTypeKeys =
+        list_settings.post_type_settings.connection_types;
+      connectionTypeKeys.push('location_grid');
+      filter.labels.forEach((label) => {
         // Determine exclusion status
-        let excluded_class = is_search_query_filter_label_excluded(filter, label) ? 'current-filter-excluded' : '';
+        let excluded_class = is_search_query_filter_label_excluded(
+          filter,
+          label,
+        )
+          ? 'current-filter-excluded'
+          : '';
 
         // Proceed with displaying of filter modal
-        selected_filters.append(`<span class="current-filter ${excluded_class} ${window.SHAREDFUNCTIONS.escapeHTML( label.field )}" data-id="${window.SHAREDFUNCTIONS.escapeHTML( label.id )}">${window.SHAREDFUNCTIONS.escapeHTML( label.name )}</span>`)
-        let type = window.lodash.get(list_settings, `post_type_settings.fields.${label.field}.type`)
-        if ( type === "key_select" || type === "boolean" ){
-          $(`#filter-modal #${label.field}-options input[value="${label.id}"]`).prop('checked', true)
-        } else if ( type === "date" || type === "datetime" ){
-          $(`#filter-modal #${label.field}-options #${label.id}`).datepicker('setDate', label.date)
-        } else if ( connectionTypeKeys.includes( label.field ) ){
+        selected_filters.append(
+          `<span class="current-filter ${excluded_class} ${window.SHAREDFUNCTIONS.escapeHTML(label.field)}" data-id="${window.SHAREDFUNCTIONS.escapeHTML(label.id)}">${window.SHAREDFUNCTIONS.escapeHTML(label.name)}</span>`,
+        );
+        let type = window.lodash.get(
+          list_settings,
+          `post_type_settings.fields.${label.field}.type`,
+        );
+        if (type === 'key_select' || type === 'boolean') {
+          $(
+            `#filter-modal #${label.field}-options input[value="${label.id}"]`,
+          ).prop('checked', true);
+        } else if (type === 'date' || type === 'datetime') {
+          $(`#filter-modal #${label.field}-options #${label.id}`).datepicker(
+            'setDate',
+            label.date,
+          );
+        } else if (connectionTypeKeys.includes(label.field)) {
           if (label.id === '*') {
-            const fieldAllConnectionsElement = document.querySelector(`#filter-modal #${label.field} .all-connections`)
-            const boundAllConnectionsClickHandler = all_connections_click_handler.bind(fieldAllConnectionsElement)
-            $(fieldAllConnectionsElement).prop('checked', true)
-            boundAllConnectionsClickHandler()
+            const fieldAllConnectionsElement = document.querySelector(
+              `#filter-modal #${label.field} .all-connections`,
+            );
+            const boundAllConnectionsClickHandler =
+              all_connections_click_handler.bind(fieldAllConnectionsElement);
+            $(fieldAllConnectionsElement).prop('checked', true);
+            boundAllConnectionsClickHandler();
           } else {
-            window.Typeahead[`.js-typeahead-${label.field}`].addMultiselectItemLayout({ID:label.id, name:label.name})
+            window.Typeahead[
+              `.js-typeahead-${label.field}`
+            ].addMultiselectItemLayout({ ID: label.id, name: label.name });
           }
-        } else if ( type === "multi_select" ){
-          window.Typeahead[`.js-typeahead-${label.field}`].addMultiselectItemLayout({key:label.id, value:label.name})
-        } else if ( type === "tags" ){
-          window.Typeahead[`.js-typeahead-${label.field}`].addMultiselectItemLayout({key:label.id, value:label.id})
-        } else if ( type === "user_select" ){
-          window.Typeahead[`.js-typeahead-${label.field}`].addMultiselectItemLayout({name:label.name, ID:label.id})
+        } else if (type === 'multi_select') {
+          window.Typeahead[
+            `.js-typeahead-${label.field}`
+          ].addMultiselectItemLayout({ key: label.id, value: label.name });
+        } else if (type === 'tags') {
+          window.Typeahead[
+            `.js-typeahead-${label.field}`
+          ].addMultiselectItemLayout({ key: label.id, value: label.id });
+        } else if (type === 'user_select') {
+          window.Typeahead[
+            `.js-typeahead-${label.field}`
+          ].addMultiselectItemLayout({ name: label.name, ID: label.id });
         }
-      })
+      });
       // moved this below the forEach as the global new_filter_labels was messing with the loop.
-      new_filter_labels = filter.labels
-      ;(filter.query.combine || []).forEach(c=>{
-        $(`#combine_${c}`).prop('checked', true)
-      })
-      $('#new-filter-name').val(filter.name)
-      $('#confirm-filter-records').hide()
-      $('#save-filter-edits').data("filter-id", filter.ID).show()
-    })
+      new_filter_labels = filter.labels;
+      (filter.query.combine || []).forEach((c) => {
+        $(`#combine_${c}`).prop('checked', true);
+      });
+      $('#new-filter-name').val(filter.name);
+      $('#confirm-filter-records').hide();
+      $('#save-filter-edits').data('filter-id', filter.ID).show();
+    });
   }
 
   $('#save-filter-edits').on('click', function () {
-    let search_query = get_custom_filter_search_query()
-    let filter_id = $('#save-filter-edits').data("filter-id")
-    let filter = window.lodash.find(list_settings.filters.filters, {ID:filter_id})
-    filter.name = $('#new-filter-name').val()
-    $(`.filter-list-name[data-filter="${filter_id}"]`).text(filter.name)
-    filter.query = search_query
-    filter.labels = new_filter_labels
-    window.API.save_filters( list_settings.post_type, filter )
-    get_records_for_current_filter()
-  })
+    let search_query = get_custom_filter_search_query();
+    let filter_id = $('#save-filter-edits').data('filter-id');
+    let filter = window.lodash.find(list_settings.filters.filters, {
+      ID: filter_id,
+    });
+    filter.name = $('#new-filter-name').val();
+    $(`.filter-list-name[data-filter="${filter_id}"]`).text(filter.name);
+    filter.query = search_query;
+    filter.labels = new_filter_labels;
+    window.API.save_filters(list_settings.post_type, filter);
+    get_records_for_current_filter();
+  });
 
   $('#filter-tabs').on('change.zf.tabs', function (a, b) {
-    let field = $(b).data("field")
+    let field = $(b).data('field');
     const panel = $(`#${field}.tabs-panel`);
-    $(`.tabs-panel`).removeClass('is-active')
-    $(panel).addClass('is-active')
+    $(`.tabs-panel`).removeClass('is-active');
+    $(panel).addClass('is-active');
     if (field && window.Typeahead[`.js-typeahead-${field}`]) {
-      window.Typeahead[`.js-typeahead-${field}`].adjustInputSize()
+      window.Typeahead[`.js-typeahead-${field}`].adjustInputSize();
     }
-  })
+  });
 
   //watch all other checkboxes
-  $('#filter-modal .key_select_options input').on("change", function() {
+  $('#filter-modal .key_select_options input').on('change', function () {
     let field_key = $(this).data('field');
-    let option_id = $(this).val()
-    if ($(this).is(":checked")){
-      let field_options = window.lodash.get( list_settings, `post_type_settings.fields.${field_key}.default` )
-      let option_name = field_options[option_id] ? field_options[option_id]["label"] : '';
-      const { name, newLabel } = create_name_value_label(field_key, $(this).val(), option_name, list_settings)
-      new_filter_labels.push(newLabel)
-      selected_filters.append(`<span class="current-filter ${window.SHAREDFUNCTIONS.escapeHTML( field_key )}" data-id="${window.SHAREDFUNCTIONS.escapeHTML( option_id )}">${window.SHAREDFUNCTIONS.escapeHTML( name )}:${window.SHAREDFUNCTIONS.escapeHTML( option_name )}</span>`)
+    let option_id = $(this).val();
+    if ($(this).is(':checked')) {
+      let field_options = window.lodash.get(
+        list_settings,
+        `post_type_settings.fields.${field_key}.default`,
+      );
+      let option_name = field_options[option_id]
+        ? field_options[option_id]['label']
+        : '';
+      const { name, newLabel } = create_name_value_label(
+        field_key,
+        $(this).val(),
+        option_name,
+        list_settings,
+      );
+      new_filter_labels.push(newLabel);
+      selected_filters.append(
+        `<span class="current-filter ${window.SHAREDFUNCTIONS.escapeHTML(field_key)}" data-id="${window.SHAREDFUNCTIONS.escapeHTML(option_id)}">${window.SHAREDFUNCTIONS.escapeHTML(name)}:${window.SHAREDFUNCTIONS.escapeHTML(option_name)}</span>`,
+      );
     } else {
-      $(`.current-filter[data-id="${$(this).val()}"].${field_key}`).remove()
-      window.lodash.pullAllBy(new_filter_labels, [{id:option_id}], "id")
+      $(`.current-filter[data-id="${$(this).val()}"].${field_key}`).remove();
+      window.lodash.pullAllBy(new_filter_labels, [{ id: option_id }], 'id');
     }
-  })
+  });
   //watch bool checkboxes
-  $('#filter-modal .boolean_options input').on("change", function() {
+  $('#filter-modal .boolean_options input').on('change', function () {
     let field_key = $(this).data('field');
-    let option_id = $(this).val()
+    let option_id = $(this).val();
     let label = $(this).data('label');
-    if ($(this).is(":checked")){
-      const { name, newLabel } = create_name_value_label(field_key, $(this).val(), label, list_settings)
-      new_filter_labels.push(newLabel)
-      selected_filters.append(`<span class="current-filter ${window.SHAREDFUNCTIONS.escapeHTML( field_key )}" data-id="${window.SHAREDFUNCTIONS.escapeHTML( option_id )}">${window.SHAREDFUNCTIONS.escapeHTML( name )}:${window.SHAREDFUNCTIONS.escapeHTML( label )}</span>`)
+    if ($(this).is(':checked')) {
+      const { name, newLabel } = create_name_value_label(
+        field_key,
+        $(this).val(),
+        label,
+        list_settings,
+      );
+      new_filter_labels.push(newLabel);
+      selected_filters.append(
+        `<span class="current-filter ${window.SHAREDFUNCTIONS.escapeHTML(field_key)}" data-id="${window.SHAREDFUNCTIONS.escapeHTML(option_id)}">${window.SHAREDFUNCTIONS.escapeHTML(name)}:${window.SHAREDFUNCTIONS.escapeHTML(label)}</span>`,
+      );
     } else {
-      $(`.current-filter[data-id="${$(this).val()}"].${field_key}`).remove()
-      window.lodash.pullAllBy(new_filter_labels, [{id:option_id}], "id")
+      $(`.current-filter[data-id="${$(this).val()}"].${field_key}`).remove();
+      window.lodash.pullAllBy(new_filter_labels, [{ id: option_id }], 'id');
     }
-  })
+  });
 
   $('#filter-modal .dt_date_picker').datepicker({
     constrainInput: false,
     dateFormat: 'yy-mm-dd',
     onSelect: function (date) {
-      let id = $(this).data('field')
-      let delimiter = $(this).data('delimit')
+      let id = $(this).data('field');
+      let delimiter = $(this).data('delimit');
       //remove existing filters
-      window.lodash.pullAllBy(new_filter_labels, [{id:`${id}_${delimiter}`}], "id")
-      $(`.current-filter[data-id="${id}_${delimiter}"]`).remove()
-      const { newLabel, field_name, delimiter_label } = create_date_label(id, date, delimiter)
+      window.lodash.pullAllBy(
+        new_filter_labels,
+        [{ id: `${id}_${delimiter}` }],
+        'id',
+      );
+      $(`.current-filter[data-id="${id}_${delimiter}"]`).remove();
+      const { newLabel, field_name, delimiter_label } = create_date_label(
+        id,
+        date,
+        delimiter,
+      );
       //add new filters
-      new_filter_labels.push(newLabel)
+      new_filter_labels.push(newLabel);
       selected_filters.append(`
         <span class="current-filter ${id}_${delimiter}"
               data-id="${id}_${delimiter}">
                 ${field_name} ${delimiter_label}:${date}
         </span>
-      `)
+      `);
     },
     changeMonth: true,
     changeYear: true,
-    yearRange: "-20:+10",
-  })
+    yearRange: '-20:+10',
+  });
 
   $('#filter-modal .clear-date-picker').on('click', function () {
-    let id = $(this).data('for')
-    $(`#filter-modal #${id}`).datepicker('setDate', null)
-    window.lodash.pullAllBy(new_filter_labels, [{id:`${id}`}], "id")
-    $(`.current-filter[data-id="${id}"]`).remove()
-  })
+    let id = $(this).data('for');
+    $(`#filter-modal #${id}`).datepicker('setDate', null);
+    window.lodash.pullAllBy(new_filter_labels, [{ id: `${id}` }], 'id');
+    $(`.current-filter[data-id="${id}"]`).remove();
+  });
 
   //save the filter in the user meta
   $(`#confirm-filter-save`).on('click', function () {
-    let filterName = $('#filter-name').val()
-    let filter = window.lodash.find(custom_filters, {ID:filter_to_save})
-    filter.name = window.SHAREDFUNCTIONS.escapeHTML( filterName )
-    filter.tab = 'custom'
-    if (filter.query){
-      list_settings.filters.filters.push(filter)
-      window.API.save_filters(list_settings.post_type, filter).then(()=>{
-        $(`.custom-filters [class*="list-view ${filter_to_save}`).remove()
-        setup_filters()
-        let active_tab = $('.accordion-item.is-active ').data('id');
-        if ( active_tab !== 'custom' ){
-          $(`#list-filter-tabs [data-id='custom'] a`).click()
-        }
-        $(`input[name="view"][value="saved-filters"][data-id='${filter_to_save}']`).prop('checked', true);
-        get_records_for_current_filter()
-        $('#filter-name').val("")
-      }).catch(err => {
-        console.error(err)
-      })
+    let filterName = $('#filter-name').val();
+    let filter = window.lodash.find(custom_filters, { ID: filter_to_save });
+    filter.name = window.SHAREDFUNCTIONS.escapeHTML(filterName);
+    filter.tab = 'custom';
+    if (filter.query) {
+      list_settings.filters.filters.push(filter);
+      window.API.save_filters(list_settings.post_type, filter)
+        .then(() => {
+          $(`.custom-filters [class*="list-view ${filter_to_save}`).remove();
+          setup_filters();
+          let active_tab = $('.accordion-item.is-active ').data('id');
+          if (active_tab !== 'custom') {
+            $(`#list-filter-tabs [data-id='custom'] a`).click();
+          }
+          $(
+            `input[name="view"][value="saved-filters"][data-id='${filter_to_save}']`,
+          ).prop('checked', true);
+          get_records_for_current_filter();
+          $('#filter-name').val('');
+        })
+        .catch((err) => {
+          console.error(err);
+        });
     }
-  })
+  });
 
   //delete a filter
   $(`#confirm-filter-delete`).on('click', function () {
-
-    let filter = window.lodash.find(list_settings.filters.filters, {ID:filter_to_delete})
-    if ( filter && ( filter.visible === true || filter.visible === '1' ) ){
+    let filter = window.lodash.find(list_settings.filters.filters, {
+      ID: filter_to_delete,
+    });
+    if (filter && (filter.visible === true || filter.visible === '1')) {
       filter.visible = false;
-      window.API.save_filters(list_settings.post_type,filter).then(()=>{
-        window.lodash.pullAllBy(list_settings.filters.filters, [{ID:filter_to_delete}], "ID")
-        setup_filters()
-        $(`#list-filter-tabs [data-id='custom'] a`).click()
-      }).catch(err => {
-        console.error(err)
-      })
+      window.API.save_filters(list_settings.post_type, filter)
+        .then(() => {
+          window.lodash.pullAllBy(
+            list_settings.filters.filters,
+            [{ ID: filter_to_delete }],
+            'ID',
+          );
+          setup_filters();
+          $(`#list-filter-tabs [data-id='custom'] a`).click();
+        })
+        .catch((err) => {
+          console.error(err);
+        });
     } else {
-      window.API.delete_filter(list_settings.post_type, filter_to_delete).then(()=>{
-        window.lodash.pullAllBy(list_settings.filters.filters, [{ID:filter_to_delete}], "ID")
-        setup_filters()
-        check_first_filter()
-        get_records_for_current_filter()
-      }).catch(err => {
-        console.error(err)
-      })
+      window.API.delete_filter(list_settings.post_type, filter_to_delete)
+        .then(() => {
+          window.lodash.pullAllBy(
+            list_settings.filters.filters,
+            [{ ID: filter_to_delete }],
+            'ID',
+          );
+          setup_filters();
+          check_first_filter();
+          get_records_for_current_filter();
+        })
+        .catch((err) => {
+          console.error(err);
+        });
     }
-  })
+  });
 
-  $('#advanced_search').on('click', function() {
+  $('#advanced_search').on('click', function () {
     $('#advanced_search_picker').toggle();
   });
 
-  $('#advanced_search_mobile').on('click', function(){
+  $('#advanced_search_mobile').on('click', function () {
     $('#advanced_search_picker_mobile').toggle();
   });
 
   $('#advanced_search_reset').on('click', function () {
-    let fields_to_search = []
-    window.SHAREDFUNCTIONS.save_json_cookie('fields_to_search', fields_to_search, list_settings.post_type )
+    let fields_to_search = [];
+    window.SHAREDFUNCTIONS.save_json_cookie(
+      'fields_to_search',
+      fields_to_search,
+      list_settings.post_type,
+    );
 
     //clear all checkboxes
-    $('#advanced_search_picker ul li input:checked').each(function ( index ) {
-      $( this ).prop('checked', false);
+    $('#advanced_search_picker ul li input:checked').each(function (index) {
+      $(this).prop('checked', false);
     });
     $('#search').click();
-
   });
 
-  $('#advanced_search_reset_mobile').on('click', function(){
-    let fields_to_search = []
-    window.SHAREDFUNCTIONS.save_json_cookie('fields_to_search', fields_to_search, list_settings.post_type )
+  $('#advanced_search_reset_mobile').on('click', function () {
+    let fields_to_search = [];
+    window.SHAREDFUNCTIONS.save_json_cookie(
+      'fields_to_search',
+      fields_to_search,
+      list_settings.post_type,
+    );
 
     //clear all checkboxes
-    $('#advanced_search_picker_mobile ul li input:checked').each(function( index ) {
-      $( this ).prop('checked', false);
-    });
+    $('#advanced_search_picker_mobile ul li input:checked').each(
+      function (index) {
+        $(this).prop('checked', false);
+      },
+    );
     $('#search-mobile').click();
-
   });
 
-  $('#save_advanced_search_choices').on("click", function() {
+  $('#save_advanced_search_choices').on('click', function () {
     let fields_to_search = [];
-    $('#advanced_search_picker ul li input:checked').each(function( index ) {
-      fields_to_search.push($( this ).val());
+    $('#advanced_search_picker ul li input:checked').each(function (index) {
+      fields_to_search.push($(this).val());
     });
-    window.SHAREDFUNCTIONS.save_json_cookie('fields_to_search', fields_to_search, list_settings.post_type );
-    if ($("#search-query").val() !== "") {
+    window.SHAREDFUNCTIONS.save_json_cookie(
+      'fields_to_search',
+      fields_to_search,
+      list_settings.post_type,
+    );
+    if ($('#search-query').val() !== '') {
       $('#search').click();
     } else {
       $('#advanced_search_picker').hide();
     }
-  })
+  });
 
-  $('#save_advanced_search_choices_mobile').on("click", function() {
+  $('#save_advanced_search_choices_mobile').on('click', function () {
     let fields_to_search = [];
-    $('#advanced_search_picker_mobile ul li input:checked').each(function( index ) {
-      fields_to_search.push($( this ).val());
-    });
-    window.SHAREDFUNCTIONS.save_json_cookie('fields_to_search', fields_to_search, list_settings.post_type );
-    if ($("#search-query-mobile").val() !== "") {
+    $('#advanced_search_picker_mobile ul li input:checked').each(
+      function (index) {
+        fields_to_search.push($(this).val());
+      },
+    );
+    window.SHAREDFUNCTIONS.save_json_cookie(
+      'fields_to_search',
+      fields_to_search,
+      list_settings.post_type,
+    );
+    if ($('#search-query-mobile').val() !== '') {
       $('#search-mobile').click();
     } else {
       $('#advanced_search_picker_mobile').hide();
     }
-  })
-  $("#search").on("click", function () {
-    let searchText = $("#search-query").val()
+  });
+  $('#search').on('click', function () {
+    let searchText = $('#search-query').val();
     let fieldsToSearch = [];
-    $('#advanced_search_picker ul li input:checked').each(function( index ) {
-      fieldsToSearch.push($( this ).val());
+    $('#advanced_search_picker ul li input:checked').each(function (index) {
+      fieldsToSearch.push($(this).val());
     });
-    window.SHAREDFUNCTIONS.save_json_cookie('fields_to_search', fieldsToSearch, list_settings.post_type );
+    window.SHAREDFUNCTIONS.save_json_cookie(
+      'fields_to_search',
+      fieldsToSearch,
+      list_settings.post_type,
+    );
 
-    if (fieldsToSearch.length > 0 ) {
-      $('.advancedSearch-count').text(fieldsToSearch.length).css('display', 'inline-block')
+    if (fieldsToSearch.length > 0) {
+      $('.advancedSearch-count')
+        .text(fieldsToSearch.length)
+        .css('display', 'inline-block');
     } else {
       $('.advancedSearch-count').text('fields_to_search.length').hide();
     }
 
-    let query = {text:searchText}
-    query.sort = current_filter?.query?.sort || '-post_date'
+    let query = { text: searchText };
+    query.sort = current_filter?.query?.sort || '-post_date';
 
     if (fieldsToSearch.length !== 0) {
       query.fields_to_search = fieldsToSearch;
     }
 
-    let labels = [{ id:"search", name:searchText, field:"search"}]
-    add_custom_filter(searchText, "search", query, labels);
+    let labels = [{ id: 'search', name: searchText, field: 'search' }];
+    add_custom_filter(searchText, 'search', query, labels);
 
     $('#advanced_search_picker').hide();
-  })
+  });
 
-  $("#search-mobile").on("click", function () {
-    let searchText = window.SHAREDFUNCTIONS.escapeHTML( $("#search-query-mobile").val() )
+  $('#search-mobile').on('click', function () {
+    let searchText = window.SHAREDFUNCTIONS.escapeHTML(
+      $('#search-query-mobile').val(),
+    );
     let fieldsToSearch = [];
-    $('#advanced_search_picker_mobile ul li input:checked').each(function( index ) {
-      fieldsToSearch.push($( this ).val());
-    });
-    window.SHAREDFUNCTIONS.save_json_cookie('fields_to_search', fieldsToSearch, list_settings.post_type );
+    $('#advanced_search_picker_mobile ul li input:checked').each(
+      function (index) {
+        fieldsToSearch.push($(this).val());
+      },
+    );
+    window.SHAREDFUNCTIONS.save_json_cookie(
+      'fields_to_search',
+      fieldsToSearch,
+      list_settings.post_type,
+    );
 
-    if (fieldsToSearch.length > 0 ) {
-      $('.advancedSearch-count').text(fieldsToSearch.length).css('display', 'inline-block')
+    if (fieldsToSearch.length > 0) {
+      $('.advancedSearch-count')
+        .text(fieldsToSearch.length)
+        .css('display', 'inline-block');
     } else {
       $('.advancedSearch-count').text('fields_to_search.length').hide();
     }
 
-    let query = {text:searchText}
+    let query = { text: searchText };
 
     if (fieldsToSearch.length !== 0) {
       query.fields_to_search = fieldsToSearch;
     }
 
-    let labels = [{ id:"search", name:searchText, field:"search"}]
-    add_custom_filter(searchText, "search", query, labels);
+    let labels = [{ id: 'search', name: searchText, field: 'search' }];
+    add_custom_filter(searchText, 'search', query, labels);
 
     $('#advanced_search_picker_mobile').hide();
-
   });
 
   $('.search-input--desktop').on('keyup', function (e) {
-    clearSearchButton.css({'display': this.value.length ? 'flex' : 'none'})
-    if ( e.keyCode === 13 ){
-      $("#search").trigger("click")
+    clearSearchButton.css({ display: this.value.length ? 'flex' : 'none' });
+    if (e.keyCode === 13) {
+      $('#search').trigger('click');
     }
-  })
+  });
 
   $('.search-input--mobile').on('keyup', function (e) {
-    clearSearchButton.css({'display': this.value.length ? 'flex' : 'none'})
-    if ( e.keyCode === 13 ){
-      $("#search-mobile").trigger("click")
+    clearSearchButton.css({ display: this.value.length ? 'flex' : 'none' });
+    if (e.keyCode === 13) {
+      $('#search-mobile').trigger('click');
     }
-  })
+  });
 
   clearSearchButton.on('click', function () {
-    $('.search-input').val('')
-    clearSearchButton.css({'display': 'none'})
-  })
+    $('.search-input').val('');
+    clearSearchButton.css({ display: 'none' });
+  });
 
   //toggle show search input on mobile
-  $("#open-search").on("click", function () {
-    $(".hideable-search").toggle()
-  })
-
+  $('#open-search').on('click', function () {
+    $('.hideable-search').toggle();
+  });
 
   /***
    * Favorite from List
    */
   function favorite_edit_event() {
-    $("svg.icon-star").on('click', function (e) {
+    $('svg.icon-star').on('click', function (e) {
       e.stopImmediatePropagation();
-      let post_id = this.dataset.id
+      let post_id = this.dataset.id;
       let favoritedValue;
       if ($(this).hasClass('selected')) {
         favoritedValue = false;
       } else {
         favoritedValue = true;
       }
-      window.API.update_post(list_settings.post_type, post_id, {'favorite': favoritedValue}).then((new_post) => {
+      window.API.update_post(list_settings.post_type, post_id, {
+        favorite: favoritedValue,
+      }).then((new_post) => {
         $(this).toggleClass('selected');
-      })
-    })
+      });
+    });
   }
 
   /***
    * Bulk Edit
    */
 
-  $('#bulk_edit_controls').on('click', function(){
+  $('#bulk_edit_controls').on('click', function () {
     $('#bulk_edit_picker').toggle();
     $('#records-table').toggleClass('bulk_edit_on');
-  })
+  });
 
-  $('#bulk_edit_seeMore').on('click', function(){
+  $('#bulk_edit_seeMore').on('click', function () {
     $('#bulk_more').toggle();
-    $('#bulk_edit_seeMore').children().toggle()
-  })
+    $('#bulk_edit_seeMore').children().toggle();
+  });
 
   function bulk_edit_checkbox_event() {
-    $("tbody tr td.bulk_edit_checkbox").on('click', function(e) {
+    $('tbody tr td.bulk_edit_checkbox').on('click', function (e) {
       e.stopImmediatePropagation();
       bulk_edit_count();
     });
   }
 
-  $('#bulk_edit_master').on('click', function(e){
+  $('#bulk_edit_master').on('click', function (e) {
     e.stopImmediatePropagation();
     let checked = $(this).children('input').is(':checked');
-        $('.bulk_edit_checkbox input').each(function () {
-          $(this).prop('checked', checked);
-          bulk_edit_count();
-    })
-  })
+    $('.bulk_edit_checkbox input').each(function () {
+      $(this).prop('checked', checked);
+      bulk_edit_count();
+    });
+  });
 
   /***
    * Bulk Delete
@@ -2163,14 +2766,23 @@
 
   let bulk_edit_delete_submit_button = $('#bulk_edit_delete_submit');
   bulk_edit_delete_submit_button.on('click', function (e) {
-    let bulk_edit_total_checked = $('.bulk_edit_checkbox:not(#bulk_edit_master) input:checked').length;
+    let bulk_edit_total_checked = $(
+      '.bulk_edit_checkbox:not(#bulk_edit_master) input:checked',
+    ).length;
 
     if (bulk_edit_total_checked > 0) {
-      let bulk_edit_delete_submit_button_span = $('.bulk_edit_delete_submit_text');
-      let confirm_text = `${$(bulk_edit_delete_submit_button_span).data('pretext')} ${bulk_edit_total_checked} ${$(bulk_edit_delete_submit_button_span).data('posttext')}`
-      let confirm_text_capitalise = window.lodash.startCase(window.lodash.toLower(confirm_text));
+      let bulk_edit_delete_submit_button_span = $(
+        '.bulk_edit_delete_submit_text',
+      );
+      let confirm_text = `${$(bulk_edit_delete_submit_button_span).data('pretext')} ${bulk_edit_total_checked} ${$(bulk_edit_delete_submit_button_span).data('posttext')}`;
+      let confirm_text_capitalise = window.lodash.startCase(
+        window.lodash.toLower(confirm_text),
+      );
 
-      if (list_settings.permissions.delete_any && confirm(confirm_text_capitalise)) {
+      if (
+        list_settings.permissions.delete_any &&
+        confirm(confirm_text_capitalise)
+      ) {
         bulk_delete_submit();
       } else {
         window.location.reload();
@@ -2181,11 +2793,10 @@
   });
 
   function bulk_delete_submit() {
-
     // Build queue of post ids.
     let queue = [];
     $('.bulk_edit_checkbox input').each(function () {
-      if (this.checked && this.id!=='bulk_edit_master_checkbox') {
+      if (this.checked && this.id !== 'bulk_edit_master_checkbox') {
         let postId = parseInt($(this).val());
         queue.push(postId);
       }
@@ -2198,14 +2809,16 @@
    */
   let bulk_edit_submit_button = $('#bulk_edit_submit');
 
-  bulk_edit_submit_button.on('click', function(e) {
+  bulk_edit_submit_button.on('click', function (e) {
     bulk_edit_submit();
   });
 
   function bulk_edit_submit() {
     $('#bulk_edit_submit-spinner').addClass('active');
-    let allInputs = $('#bulk_edit_picker input, #bulk_edit_picker select, #bulk_edit_picker .button').not('#bulk_share');
-    let multiSelectInputs = $('#bulk_edit_picker .dt_multi_select')
+    let allInputs = $(
+      '#bulk_edit_picker input, #bulk_edit_picker select, #bulk_edit_picker .button',
+    ).not('#bulk_share');
+    let multiSelectInputs = $('#bulk_edit_picker .dt_multi_select');
     let shareInput = $('#bulk_share');
     let commentPayload = {};
     commentPayload['commentText'] = $('#bulk_comment-input').val();
@@ -2223,10 +2836,11 @@
             updatePayload[field_key] = value;
           }
         }
-      })
-    })
+      });
+    });
     if (window.location_data) {
-      updatePayload['location_grid_meta'] = window.location_data.location_grid_meta;
+      updatePayload['location_grid_meta'] =
+        window.location_data.location_grid_meta;
     }
 
     let multiSelectUpdatePayload = {};
@@ -2236,13 +2850,12 @@
         if (key.includes('bulk_key_') && value) {
           let field_key = key.replace('bulk_key_', '');
           if (!multiSelectUpdatePayload[field_key]) {
-            multiSelectUpdatePayload[field_key] = {'values': []};
+            multiSelectUpdatePayload[field_key] = { values: [] };
           }
           multiSelectUpdatePayload[field_key].values.push(value.values);
         }
-      })
-
-    })
+      });
+    });
     const multiSelectKeys = Object.keys(multiSelectUpdatePayload);
 
     multiSelectKeys.forEach((key, index) => {
@@ -2251,41 +2864,49 @@
 
     shareInput.each(function () {
       sharePayload = $(this).data('bulk_key_share');
-    })
+    });
 
     let shares = {
-      'users': sharePayload,
-      'unshare': $('#bulk_share_unshare').prop('checked')
+      users: sharePayload,
+      unshare: $('#bulk_share_unshare').prop('checked'),
     };
 
-    let queue =  [];
+    let queue = [];
     let count = 0;
     $('.bulk_edit_checkbox input').each(function () {
       if (this.checked && this.id !== 'bulk_edit_master_checkbox') {
         let postId = parseInt($(this).val());
-        queue.push( postId );
+        queue.push(postId);
       }
     });
     process(queue, 10, do_each, do_done, updatePayload, shares, commentPayload);
   }
 
   function bulk_edit_count() {
-    let bulk_edit_total_checked = $('.bulk_edit_checkbox:not(#bulk_edit_master) input:checked').length;
-    let bulk_edit_submit_button_text = $('.bulk_edit_submit_text')
-    let bulk_edit_delete_submit_button_text = $('.bulk_edit_delete_submit_text')
+    let bulk_edit_total_checked = $(
+      '.bulk_edit_checkbox:not(#bulk_edit_master) input:checked',
+    ).length;
+    let bulk_edit_submit_button_text = $('.bulk_edit_submit_text');
+    let bulk_edit_delete_submit_button_text = $(
+      '.bulk_edit_delete_submit_text',
+    );
 
     if (bulk_edit_total_checked == 0) {
-      bulk_edit_submit_button_text.text(`${list_settings.translations.make_selections_below}`)
+      bulk_edit_submit_button_text.text(
+        `${list_settings.translations.make_selections_below}`,
+      );
 
       if (list_settings.permissions.delete_any) {
-        bulk_edit_delete_submit_button_text.text(`${list_settings.translations.delete_selections_below}`);
+        bulk_edit_delete_submit_button_text.text(
+          `${list_settings.translations.delete_selections_below}`,
+        );
       }
     } else {
-      bulk_edit_submit_button_text.each(function( index ) {
-        let pretext = $( this ).data('pretext')
-        let posttext = $( this ).data('posttext')
-        $( this ).text(`${pretext} ${bulk_edit_total_checked} ${posttext}`)
-      })
+      bulk_edit_submit_button_text.each(function (index) {
+        let pretext = $(this).data('pretext');
+        let posttext = $(this).data('posttext');
+        $(this).text(`${pretext} ${bulk_edit_total_checked} ${posttext}`);
+      });
 
       if (list_settings.permissions.delete_any) {
         bulk_edit_delete_submit_button_text.each(function (index) {
@@ -2298,117 +2919,181 @@
   }
 
   let bulk_edit_picker_checkboxes = $('#bulk_edit_picker .update-needed');
-  bulk_edit_picker_checkboxes.on('click', function(e) {
+  bulk_edit_picker_checkboxes.on('click', function (e) {
     if ($(this).is(':checked')) {
       $(this).data('bulk_key_requires_update', true);
     }
-  })
+  });
 
   let bulk_edit_picker_select_field = $('#bulk_edit_picker select');
-  bulk_edit_picker_select_field.on('change', function(e) {
-      let field_key = this.id.replace('bulk_', '');
-      $(this).data(`bulk_key_${field_key}`, this.value);
-  })
+  bulk_edit_picker_select_field.on('change', function (e) {
+    let field_key = this.id.replace('bulk_', '');
+    $(this).data(`bulk_key_${field_key}`, this.value);
+  });
 
-  let bulk_edit_picker_button_groups= $('#bulk_edit_picker .select-button');
-  bulk_edit_picker_button_groups.on('click', function(e) {
-      let field_key = $(this).data('field-key').replace('bulk_', '');
-      let optionKey = $(this).attr('id')
+  let bulk_edit_picker_button_groups = $('#bulk_edit_picker .select-button');
+  bulk_edit_picker_button_groups.on('click', function (e) {
+    let field_key = $(this).data('field-key').replace('bulk_', '');
+    let optionKey = $(this).attr('id');
 
-      let fieldValue = {};
+    let fieldValue = {};
 
-      fieldValue.values = {value:optionKey};
+    fieldValue.values = { value: optionKey };
 
-
-      $(this).addClass('selected-select-button');
-      $(this).data(`bulk_key_${field_key}`, fieldValue);
-  })
+    $(this).addClass('selected-select-button');
+    $(this).data(`bulk_key_${field_key}`, fieldValue);
+  });
 
   //Bulk Update Queue
-  function process( q, num, fn, done, update, share, comment, event_type = 'update', responses = [] ) {
+  function process(
+    q,
+    num,
+    fn,
+    done,
+    update,
+    share,
+    comment,
+    event_type = 'update',
+    responses = [],
+  ) {
     // remove a batch of items from the queue
     let items = q.splice(0, num),
-        count = items.length;
+      count = items.length;
 
     // no more items?
-    if ( !count ) {
-        // exec done callback if specified
-        done && done( responses );
-        // quit
-        return;
+    if (!count) {
+      // exec done callback if specified
+      done && done(responses);
+      // quit
+      return;
     }
 
     // loop over each item
-    for ( let i = 0; i < count; i++ ) {
-        // call callback, passing item and
-        // a "done" callback
-        fn(items[i], function( response ) {
+    for (let i = 0; i < count; i++) {
+      // call callback, passing item and
+      // a "done" callback
+      fn(
+        items[i],
+        function (response) {
           // capture valid response
-          if ( response ) {
-            if ( Array.isArray( response ) ) {
-              response.forEach((element) => responses.push( element ));
+          if (response) {
+            if (Array.isArray(response)) {
+              response.forEach((element) => responses.push(element));
             } else {
-              responses.push( response );
+              responses.push(response);
             }
           }
 
           // when done, decrement counter and
           // if counter is 0, process next batch
-          --count || process(q, num, fn, done, update, share, comment, event_type, responses);
-        }, update, share, comment, event_type);
-
+          --count ||
+            process(
+              q,
+              num,
+              fn,
+              done,
+              update,
+              share,
+              comment,
+              event_type,
+              responses,
+            );
+        },
+        update,
+        share,
+        comment,
+        event_type,
+      );
     }
   }
 
   // a per-item action
-  function do_each( item, done, update, share, comment, event_type ) {
+  function do_each(item, done, update, share, comment, event_type) {
     let promises = [];
 
     switch (event_type) {
       case 'update': {
         if (Object.keys(update).length) {
-          promises.push(window.API.update_post(list_settings.post_type, item, update).catch(err => {
-            console.error(err);
-          }));
+          promises.push(
+            window.API.update_post(list_settings.post_type, item, update).catch(
+              (err) => {
+                console.error(err);
+              },
+            ),
+          );
         }
 
         if (share && share['users']) {
           share['users'].forEach(function (value) {
-            let promise = share['unshare'] ? window.API.remove_shared(list_settings.post_type, item, value).catch(err => {
-              console.error(err)
-            }) : window.API.add_shared(list_settings.post_type, item, value).catch(err => {
-              console.error(err)
-            });
+            let promise = share['unshare']
+              ? window.API.remove_shared(
+                  list_settings.post_type,
+                  item,
+                  value,
+                ).catch((err) => {
+                  console.error(err);
+                })
+              : window.API.add_shared(
+                  list_settings.post_type,
+                  item,
+                  value,
+                ).catch((err) => {
+                  console.error(err);
+                });
             promises.push(promise);
           });
         }
 
         if (comment.commentText) {
-          promises.push(window.API.post_comment(list_settings.post_type, item, comment.commentText, comment.commentType).catch(err => {
-            console.error(err);
-          }));
+          promises.push(
+            window.API.post_comment(
+              list_settings.post_type,
+              item,
+              comment.commentText,
+              comment.commentType,
+            ).catch((err) => {
+              console.error(err);
+            }),
+          );
         }
 
         break;
       }
       case 'delete': {
         if (list_settings.permissions.delete_any) {
-          promises.push(window.API.delete_post(list_settings.post_type, item).catch(err => {
-            console.error(err);
-          }));
+          promises.push(
+            window.API.delete_post(list_settings.post_type, item).catch(
+              (err) => {
+                console.error(err);
+              },
+            ),
+          );
         }
         break;
       }
       case 'message': {
-        if (update?.subject && update?.from_name && update?.send_method && update?.message) {
-          promises.push(window.makeRequestOnPosts("POST", `${list_settings.post_type}/${item}/post_messaging`, update).catch(err => {
-            console.error(err);
-          }));
+        if (
+          update?.subject &&
+          update?.from_name &&
+          update?.send_method &&
+          update?.message
+        ) {
+          promises.push(
+            window
+              .makeRequestOnPosts(
+                'POST',
+                `${list_settings.post_type}/${item}/post_messaging`,
+                update,
+              )
+              .catch((err) => {
+                console.error(err);
+              }),
+          );
         }
         break;
       }
     }
-    Promise.all(promises).then( function(responses) {
+    Promise.all(promises).then(function (responses) {
       done(responses);
     });
   }
@@ -2419,8 +3104,8 @@
     window.location.reload();
   }
 
-  let bulk_assigned_to_input = $(`.js-typeahead-bulk_assigned_to`)
-  if( bulk_assigned_to_input.length ) {
+  let bulk_assigned_to_input = $(`.js-typeahead-bulk_assigned_to`);
+  if (bulk_assigned_to_input.length) {
     $.typeahead({
       input: '.js-typeahead-bulk_assigned_to',
       minLength: 0,
@@ -2428,36 +3113,45 @@
       accent: true,
       searchOnFocus: true,
       source: window.TYPEAHEADS.typeaheadUserSource(),
-      templateValue: "{{name}}",
+      templateValue: '{{name}}',
       template: function (query, item) {
         return `<div class="assigned-to-row" dir="auto">
         <span>
             <span class="avatar"><img style="vertical-align: text-bottom" src="{{avatar}}"/></span>
             ${window.SHAREDFUNCTIONS.escapeHTML(item.name)}
         </span>
-        ${item.status_color ? `<span class="status-square" style="background-color: ${window.SHAREDFUNCTIONS.escapeHTML(item.status_color)};">&nbsp;</span>`:''}
-        ${item.update_needed && item.update_needed > 0 ? `<span>
+        ${item.status_color ? `<span class="status-square" style="background-color: ${window.SHAREDFUNCTIONS.escapeHTML(item.status_color)};">&nbsp;</span>` : ''}
+        ${
+          item.update_needed && item.update_needed > 0
+            ? `<span>
           <img style="height: 12px;" src="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.template_dir)}/dt-assets/images/broken.svg"/>
           <span style="font-size: 14px">${window.SHAREDFUNCTIONS.escapeHTML(item.update_needed)}</span>
-        </span>`:''}
-      </div>`
+        </span>`
+            : ''
+        }
+      </div>`;
       },
       dynamic: true,
       hint: true,
-      emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.no_records_found),
+      emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(
+        window.wpApiShare.translations.no_records_found,
+      ),
       callback: {
         onClick: function (node, a, item) {
           node.data('bulk_key_assigned_to', `user-${item.ID}`);
         },
         onResult: function (node, query, result, resultCount) {
-          let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+          let text = window.TYPEAHEADS.typeaheadHelpText(
+            resultCount,
+            query,
+            result,
+          );
           $('#bulk_assigned_to-result-container').html(text);
         },
         onHideLayout: function () {
-          $('.bulk_assigned_to-result-container').html("");
+          $('.bulk_assigned_to-result-container').html('');
         },
-        onReady: function () {
-        }
+        onReady: function () {},
       },
     });
   }
@@ -2481,99 +3175,103 @@
 
     // If multiple options detected, ensure correct selection is made.
     const checked_send_method = $('.bulk-send-msg-method:checked');
-    if ( $(checked_send_method).length > 0 ) {
+    if ($(checked_send_method).length > 0) {
       send_method = $(checked_send_method).val().trim();
     }
 
-    let queue =  [];
+    let queue = [];
     $('.bulk_edit_checkbox input').each(function () {
       if (this.checked && this.id !== 'bulk_edit_master_checkbox') {
-        queue.push( parseInt( $(this).val() ) );
+        queue.push(parseInt($(this).val()));
       }
     });
 
     // Validate entries.
     if (!subject) {
-      $("#bulk_send_msg_subject_support_text").show();
+      $('#bulk_send_msg_subject_support_text').show();
       return;
-
     } else {
-      $("#bulk_send_msg_subject_support_text").hide();
+      $('#bulk_send_msg_subject_support_text').hide();
     }
 
     if (!from_name) {
-      $("#bulk_send_msg_from_name_support_text").show();
+      $('#bulk_send_msg_from_name_support_text').show();
       return;
-
     } else {
-      $("#bulk_send_msg_from_name_support_text").hide();
+      $('#bulk_send_msg_from_name_support_text').hide();
     }
 
     if (!send_method) {
-      $("#bulk_send_msg_method_support_text").show();
+      $('#bulk_send_msg_method_support_text').show();
       return;
-
     } else {
-      $("#bulk_send_msg_method_support_text").hide();
+      $('#bulk_send_msg_method_support_text').hide();
     }
 
     if (!message) {
-      $("#bulk_send_msg_support_text").show();
+      $('#bulk_send_msg_support_text').show();
       return;
-
     } else {
-      $("#bulk_send_msg_support_text").hide();
+      $('#bulk_send_msg_support_text').hide();
     }
 
     if (!queue || queue.length < 1) {
-      $("#bulk_send_msg_submit_support_text").show();
+      $('#bulk_send_msg_submit_support_text').show();
       return;
-
     } else {
-      $("#bulk_send_msg_submit_support_text").hide();
+      $('#bulk_send_msg_submit_support_text').hide();
     }
 
     // Proceed with staged-based message send requests.
     $(spinner).addClass('active');
-    process(queue, 10, do_each, function (responses) {
-
-      // If available, extract response summary.
-      if ( responses && responses.length > 0 ) {
-        let email_queue_link = `<a target="_blank" href="${window.wpApiShare.site_url + '/wp-admin/admin.php?page=dt_utilities&tab=background_jobs'}">${list_settings.translations.see_queue}</a>`;
-        let count_sent = 0;
-        let count_fails = 0;
-        responses.forEach(function (response) {
-          if ( response && ( response['sent'] !== undefined ) ) {
-            if ( response['sent'] ) {
-              count_sent++;
-            } else {
-              count_fails++;
+    process(
+      queue,
+      10,
+      do_each,
+      function (responses) {
+        // If available, extract response summary.
+        if (responses && responses.length > 0) {
+          let email_queue_link = `<a target="_blank" href="${window.wpApiShare.site_url + '/wp-admin/admin.php?page=dt_utilities&tab=background_jobs'}">${list_settings.translations.see_queue}</a>`;
+          let count_sent = 0;
+          let count_fails = 0;
+          responses.forEach(function (response) {
+            if (response && response['sent'] !== undefined) {
+              if (response['sent']) {
+                count_sent++;
+              } else {
+                count_fails++;
+              }
             }
-          }
-        });
+          });
 
-        $('#bulk_send_msg_submit-message').html(`<strong>${count_sent}</strong> ${list_settings.translations.sent}! ${window.wpApiShare.can_manage_dt ? email_queue_link : '' }<br><strong>${count_fails}</strong> ${list_settings.translations.not_sent}`);
-      }
+          $('#bulk_send_msg_submit-message').html(
+            `<strong>${count_sent}</strong> ${list_settings.translations.sent}! ${window.wpApiShare.can_manage_dt ? email_queue_link : ''}<br><strong>${count_fails}</strong> ${list_settings.translations.not_sent}`,
+          );
+        }
 
-      // Reset record selections.
-      $(spinner).removeClass('active');
-      $('#bulk_edit_master_checkbox').prop("checked", false);
-      $('.bulk_edit_checkbox input').prop("checked", false);
-      bulk_edit_count();
-      // window.location.reload();
-
-    }, {
-      'subject': subject,
-      'from_name': from_name,
-      'reply_to': reply_to,
-      'send_method': send_method,
-      'message': message
-    }, {}, {}, 'message');
+        // Reset record selections.
+        $(spinner).removeClass('active');
+        $('#bulk_edit_master_checkbox').prop('checked', false);
+        $('.bulk_edit_checkbox input').prop('checked', false);
+        bulk_edit_count();
+        // window.location.reload();
+      },
+      {
+        subject: subject,
+        from_name: from_name,
+        reply_to: reply_to,
+        send_method: send_method,
+        message: message,
+      },
+      {},
+      {},
+      'message',
+    );
   }
 
   /**
    * Bulk share
-  */
+   */
   $.typeahead({
     input: '#bulk_share',
     minLength: 0,
@@ -2581,16 +3279,15 @@
     accent: true,
     searchOnFocus: true,
     source: window.TYPEAHEADS.typeaheadUserSource(),
-    templateValue: "{{name}}",
+    templateValue: '{{name}}',
     dynamic: true,
     multiselect: {
-      matchOn: ["ID"],
+      matchOn: ['ID'],
       callback: {
         onCancel: function (node, item) {
-          $(node).removeData( `bulk_key_bulk_share` );
-          $('#share-result-container').html("");
-
-        }
+          $(node).removeData(`bulk_key_bulk_share`);
+          $('#share-result-container').html('');
+        },
       },
     },
     callback: {
@@ -2606,27 +3303,37 @@
       },
       onResult: function (node, query, result, resultCount) {
         if (query) {
-          let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+          let text = window.TYPEAHEADS.typeaheadHelpText(
+            resultCount,
+            query,
+            result,
+          );
           $('#share-result-container').html(text);
         }
       },
       onHideLayout: function () {
-        $('#share-result-container').html("");
-      }
-    }
+        $('#share-result-container').html('');
+      },
+    },
   });
 
   /**
- * Bulk Typeahead
- */
+   * Bulk Typeahead
+   */
   let field_settings = window.list_settings.post_type_settings.fields;
 
-  $('#bulk_edit_picker .dt_typeahead').each((key, el)=>{
-    let element_id =  $(el).attr('id').replace(/_connection$/, '');
-    let div_id = $(el).attr('id')
-    let field_id = $(`#${div_id} input`).data('field')
-    if (element_id !== "bulk_share") {
-      let listing_post_type = window.lodash.get(window.list_settings.post_type_settings.fields[field_id], "post_type", 'contacts')
+  $('#bulk_edit_picker .dt_typeahead').each((key, el) => {
+    let element_id = $(el)
+      .attr('id')
+      .replace(/_connection$/, '');
+    let div_id = $(el).attr('id');
+    let field_id = $(`#${div_id} input`).data('field');
+    if (element_id !== 'bulk_share') {
+      let listing_post_type = window.lodash.get(
+        window.list_settings.post_type_settings.fields[field_id],
+        'post_type',
+        'contacts',
+      );
       $.typeahead({
         input: `.js-typeahead-${element_id}`,
         minLength: 0,
@@ -2634,53 +3341,58 @@
         maxItem: 30,
         searchOnFocus: true,
         template: window.TYPEAHEADS.contactListRowTemplate,
-        source: window.TYPEAHEADS.typeaheadPostsSource(listing_post_type, {field_key:field_id}),
-        display: "name",
-        templateValue: "{{name}}",
+        source: window.TYPEAHEADS.typeaheadPostsSource(listing_post_type, {
+          field_key: field_id,
+        }),
+        display: 'name',
+        templateValue: '{{name}}',
         dynamic: true,
         multiselect: {
-          matchOn: ["ID"],
+          matchOn: ['ID'],
           data: '',
           callback: {
             onCancel: function (node, item) {
-              $(node).removeData( `bulk_key_${field_id}` );
-            }
+              $(node).removeData(`bulk_key_${field_id}`);
+            },
           },
-          href: window.wpApiShare.site_url + `/${listing_post_type}/{{ID}}`
+          href: window.wpApiShare.site_url + `/${listing_post_type}/{{ID}}`,
         },
         callback: {
-          onClick: function(node, a, item, event){
+          onClick: function (node, a, item, event) {
             let multiUserArray;
-            if ( node.data(`bulk_key_${field_id}`) ) {
+            if (node.data(`bulk_key_${field_id}`)) {
               multiUserArray = node.data(`bulk_key_${field_id}`).values;
             } else {
               multiUserArray = [];
             }
-            multiUserArray.push({"value":item.ID});
+            multiUserArray.push({ value: item.ID });
 
-            node.data(`bulk_key_${field_id}`, {values: multiUserArray});
-            this.addMultiselectItemLayout(item)
-            event.preventDefault()
+            node.data(`bulk_key_${field_id}`, { values: multiUserArray });
+            this.addMultiselectItemLayout(item);
+            event.preventDefault();
             this.hideLayout();
             this.resetInput();
           },
           onResult: function (node, query, result, resultCount) {
-            let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+            let text = window.TYPEAHEADS.typeaheadHelpText(
+              resultCount,
+              query,
+              result,
+            );
             $(`#${element_id}-result-container`).html(text);
           },
           onHideLayout: function (event, query) {
             if (!query) {
-              $(`#${element_id}-result-container`).empty()
+              $(`#${element_id}-result-container`).empty();
             }
           },
-          onShowLayout (){
-          }
-        }
-      })
+          onShowLayout() {},
+        },
+      });
     }
-  })
+  });
 
-  $('#bulk_edit_picker .dt_location_grid').each(()=> {
+  $('#bulk_edit_picker .dt_location_grid').each(() => {
     let field_id = 'location_grid';
     let typeaheadTotals = {};
     $.typeahead({
@@ -2689,80 +3401,104 @@
       accent: true,
       searchOnFocus: true,
       maxItem: 20,
-      dropdownFilter: [{
-        key: 'group',
-        value: 'focus',
-        template: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.regions_of_focus),
-        all: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.all_locations),
-      }],
+      dropdownFilter: [
+        {
+          key: 'group',
+          value: 'focus',
+          template: window.SHAREDFUNCTIONS.escapeHTML(
+            window.wpApiShare.translations.regions_of_focus,
+          ),
+          all: window.SHAREDFUNCTIONS.escapeHTML(
+            window.wpApiShare.translations.all_locations,
+          ),
+        },
+      ],
       source: {
         focus: {
-          display: "name",
+          display: 'name',
           ajax: {
-            url: window.wpApiShare.root + 'dt/v1/mapping_module/search_location_grid_by_name',
+            url:
+              window.wpApiShare.root +
+              'dt/v1/mapping_module/search_location_grid_by_name',
             data: {
-              s: "{{query}}",
+              s: '{{query}}',
               filter: function () {
                 // return window.lodash.get(window.Typeahead['.js-typeahead-location_grid'].filters.dropdown, 'value', 'all')
-              }
+              },
             },
             beforeSend: function (xhr) {
               xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce);
             },
             callback: {
               done: function (data) {
-                if (typeof window.typeaheadTotals!=="undefined") {
-                  window.typeaheadTotals.field = data.total
+                if (typeof window.typeaheadTotals !== 'undefined') {
+                  window.typeaheadTotals.field = data.total;
                 }
-                return data.location_grid
-              }
-            }
-          }
-        }
+                return data.location_grid;
+              },
+            },
+          },
+        },
       },
-      display: "name",
-      templateValue: "{{name}}",
+      display: 'name',
+      templateValue: '{{name}}',
       dynamic: true,
       multiselect: {
-        matchOn: ["ID"],
+        matchOn: ['ID'],
         data: '',
         callback: {
           onCancel: function (node, item) {
-            $(node).removeData( `bulk_key_${field_id}` );
-          }
-        }
+            $(node).removeData(`bulk_key_${field_id}`);
+          },
+        },
       },
       callback: {
         onClick: function (node, a, item, event) {
           // $(`#${element_id}-spinner`).addClass('active');
-          node.data(`bulk_key_${field_id}`, {values:[{"value":item.ID}]});
+          node.data(`bulk_key_${field_id}`, { values: [{ value: item.ID }] });
         },
         onReady() {
           this.filters.dropdown = {
-            key: "group",
-            value: "focus",
-            template: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.regions_of_focus)
-          }
+            key: 'group',
+            value: 'focus',
+            template: window.SHAREDFUNCTIONS.escapeHTML(
+              window.wpApiShare.translations.regions_of_focus,
+            ),
+          };
           this.container
-          .removeClass("filter")
-          .find("." + this.options.selector.filterButton)
-          .html(window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.regions_of_focus));
+            .removeClass('filter')
+            .find('.' + this.options.selector.filterButton)
+            .html(
+              window.SHAREDFUNCTIONS.escapeHTML(
+                window.wpApiShare.translations.regions_of_focus,
+              ),
+            );
         },
         onResult: function (node, query, result, resultCount) {
-          resultCount = typeaheadTotals.location_grid
-          let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+          resultCount = typeaheadTotals.location_grid;
+          let text = window.TYPEAHEADS.typeaheadHelpText(
+            resultCount,
+            query,
+            result,
+          );
           $('#location_grid-result-container').html(text);
         },
         onHideLayout: function () {
-          $('#location_grid-result-container').html("");
-        }
-      }
+          $('#location_grid-result-container').html('');
+        },
+      },
     });
-  })
+  });
 
-  $('#bulk_edit_picker .tags input, #bulk_edit_picker .multi_select input').each((key, input)=>{
-    let field = $(input).data('field') || 'tags'
-    let field_options = window.lodash.get(list_settings, `post_type_settings.fields.${field}.default`, {})
+  $(
+    '#bulk_edit_picker .tags input, #bulk_edit_picker .multi_select input',
+  ).each((key, input) => {
+    let field = $(input).data('field') || 'tags';
+    let field_options = window.lodash.get(
+      list_settings,
+      `post_type_settings.fields.${field}.default`,
+      {},
+    );
     $.typeahead({
       input: input,
       minLength: 0,
@@ -2770,256 +3506,278 @@
       searchOnFocus: true,
       source: {
         tags: {
-          display: ["name"],
+          display: ['name'],
           ajax: {
-            url: window.wpApiShare.root + `dt-posts/v2/${list_settings.post_type}/multi-select-values`,
+            url:
+              window.wpApiShare.root +
+              `dt-posts/v2/${list_settings.post_type}/multi-select-values`,
             data: {
-              s: "{{query}}",
-              field: field
+              s: '{{query}}',
+              field: field,
             },
             beforeSend: function (xhr) {
               xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce);
             },
             callback: {
               done: function (data) {
-                return (data || []).map(tag => {
-                  let label = window.lodash.get(field_options, tag + ".label", tag)
-                  return {name: label || tag, key: tag}
-                })
-              }
-            }
-          }
-        }
+                return (data || []).map((tag) => {
+                  let label = window.lodash.get(
+                    field_options,
+                    tag + '.label',
+                    tag,
+                  );
+                  return { name: label || tag, key: tag };
+                });
+              },
+            },
+          },
+        },
       },
-      display: "name",
-      templateValue: "{{name}}",
+      display: 'name',
+      templateValue: '{{name}}',
       dynamic: true,
       multiselect: {
-        matchOn: ["key"],
+        matchOn: ['key'],
         callback: {
-            onCancel: function (node, item) {
-              $(node).removeData( `bulk_key_${field}` );
-            }
+          onCancel: function (node, item) {
+            $(node).removeData(`bulk_key_${field}`);
           },
+        },
       },
       callback: {
         onClick: function (node, a, item, event) {
           let multiUserArray;
-          if ( node.data(`bulk_key_${field}`) ) {
+          if (node.data(`bulk_key_${field}`)) {
             multiUserArray = node.data(`bulk_key_${field}`).values;
           } else {
             multiUserArray = [];
           }
-          multiUserArray.push({"value":item.key});
+          multiUserArray.push({ value: item.key });
 
-          node.data(`bulk_key_${field}`, {values: multiUserArray});
-          this.addMultiselectItemLayout(item)
-          event.preventDefault()
+          node.data(`bulk_key_${field}`, { values: multiUserArray });
+          this.addMultiselectItemLayout(item);
+          event.preventDefault();
           this.hideLayout();
           this.resetInput();
         },
         onResult: function (node, query, result, resultCount) {
-          let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+          let text = window.TYPEAHEADS.typeaheadHelpText(
+            resultCount,
+            query,
+            result,
+          );
           $(`#${field}-result-container`).html(text);
         },
         onHideLayout: function () {
-          $(`#${field}-result-container`).html("");
+          $(`#${field}-result-container`).html('');
         },
-      }
+      },
     });
-  })
+  });
 
-  $('button.follow').on("click", function () {
-    let following = !($(this).data('value') === "following")
-    $(this).data("value", following ? "following" : "" )
-    $(this).html( following ? "Unfollow" : "Follow")
-    $(this).toggleClass( "hollow" )
-    let follow = { values:[{value:current_user_id, delete:!following}] }
+  $('button.follow').on('click', function () {
+    let following = !($(this).data('value') === 'following');
+    $(this).data('value', following ? 'following' : '');
+    $(this).html(following ? 'Unfollow' : 'Follow');
+    $(this).toggleClass('hollow');
+    let follow = { values: [{ value: current_user_id, delete: !following }] };
 
-    let unfollow = {values:[{value:current_user_id, delete:following}]}
+    let unfollow = { values: [{ value: current_user_id, delete: following }] };
 
     $(this).data('bulk_key_follow', follow);
     $(this).data('bulk_key_unfollow', unfollow);
-  })
+  });
 
-  $('#bulk_edit_picker input.text-input').change(function(){
-    const val = $(this).val()
-    let field_key = this.id.replace('bulk_', '')
+  $('#bulk_edit_picker input.text-input').change(function () {
+    const val = $(this).val();
+    let field_key = this.id.replace('bulk_', '');
     $(this).data(`bulk_key_${field_key}`, val);
   });
 
-  $('#bulk_edit_picker .dt_textarea').change(function(){
-    const val = $(this).val()
-    let field_key = this.id.replace('bulk_', '')
+  $('#bulk_edit_picker .dt_textarea').change(function () {
+    const val = $(this).val();
+    let field_key = this.id.replace('bulk_', '');
     $(this).data(`bulk_key_${field_key}`, val);
-  })
+  });
 
-  $('#bulk_edit_picker .dt_date_picker').datepicker({
-    constrainInput: false,
-    dateFormat: 'yy-mm-dd',
-    onClose: function (date) {
-      date = window.SHAREDFUNCTIONS.convertArabicToEnglishNumbers(date);
+  $('#bulk_edit_picker .dt_date_picker')
+    .datepicker({
+      constrainInput: false,
+      dateFormat: 'yy-mm-dd',
+      onClose: function (date) {
+        date = window.SHAREDFUNCTIONS.convertArabicToEnglishNumbers(date);
 
-      if (!$(this).val()) {
-        date = " ";//null;
+        if (!$(this).val()) {
+          date = ' '; //null;
+        }
+
+        let formattedDate = window.moment.utc(date).unix();
+
+        let field_key = this.id.replace('bulk_', '');
+        $(this).data(`bulk_key_${field_key}`, formattedDate);
+      },
+      changeMonth: true,
+      changeYear: true,
+      yearRange: '1900:2050',
+    })
+    .each(function () {
+      if (this.value && window.moment.unix(this.value).isValid()) {
+        this.value = window.SHAREDFUNCTIONS.formatDate(this.value);
       }
+    });
 
-      let formattedDate = window.moment.utc(date).unix();
-
-      let field_key = this.id.replace('bulk_', '')
-      $(this).data(`bulk_key_${field_key}`, formattedDate);
-    },
-    changeMonth: true,
-    changeYear: true,
-    yearRange: "1900:2050",
-  }).each(function() {
-    if (this.value && window.moment.unix(this.value).isValid()) {
-      this.value = window.SHAREDFUNCTIONS.formatDate(this.value);
-    }
-  })
-
-
-  let mcleardate = $("#bulk_edit_picker .clear-date-button");
-  mcleardate.click(function() {
+  let mcleardate = $('#bulk_edit_picker .clear-date-button');
+  mcleardate.click(function () {
     let input_id = this.dataset.inputid;
     let date = null;
     // $(`#${input_id}-spinner`).addClass('active')
-    let field_key = this.id.replace('bulk_', '')
+    let field_key = this.id.replace('bulk_', '');
     $(this).removeData(`bulk_key_${field_key}`);
-    $(`#${input_id}`).val("");
+    $(`#${input_id}`).val('');
   });
 
-  $('#bulk_edit_picker select.select-field').change(e => {
-    const val = $(e.currentTarget).val()
+  $('#bulk_edit_picker select.select-field').change((e) => {
+    const val = $(e.currentTarget).val();
 
-    if (val === "paused") {
-      $('#reason-paused-options').parent().toggle()
+    if (val === 'paused') {
+      $('#reason-paused-options').parent().toggle();
     }
 
-    let field_key = e.currentTarget.id.replace('bulk_', '')
+    let field_key = e.currentTarget.id.replace('bulk_', '');
     $(e.currentTarget).data(`bulk_key_${field_key}`, val);
+  });
 
-  })
+  $('#bulk_edit_picker input.number-input').on('blur', function () {
+    const id = $(this).attr('id');
+    const val = $(this).val();
 
-  $('#bulk_edit_picker input.number-input').on("blur", function(){
-    const id = $(this).attr('id')
-    const val = $(this).val()
-
-    let field_key = this.id.replace('bulk_', '')
+    let field_key = this.id.replace('bulk_', '');
     $(this).data(`bulk_key_${field_key}`, val);
-  })
+  });
 
-  $('#bulk_edit_picker .dt_contenteditable').on('blur', function(){
-    const id = $(this).attr('id')
-    let val = $(this).html()
+  $('#bulk_edit_picker .dt_contenteditable').on('blur', function () {
+    const id = $(this).attr('id');
+    let val = $(this).html();
 
-    let field_key = this.id.replace('bulk_', '')
+    let field_key = this.id.replace('bulk_', '');
     $(this).data(`bulk_key_${field_key}`, val);
-  })
+  });
 
-  $('.list-dropdown-submenu-item-link').on('click', function() {
+  $('.list-dropdown-submenu-item-link').on('click', function () {
     // Hide bulk select modals
-    $('#records-table').removeClass('bulk_edit_on')
+    $('#records-table').removeClass('bulk_edit_on');
 
     // Close all open modals
-    $('.list-dropdown-submenu-item-link').each(function(){
+    $('.list-dropdown-submenu-item-link').each(function () {
       let open_modals = $(this).data('modal');
-      $( '#' + open_modals ).hide();
+      $('#' + open_modals).hide();
     });
 
     // Open modal for clicked menu item
     let display_modal = $(this).data('modal');
-    $( '#' + display_modal ).show();
+    $('#' + display_modal).show();
 
     // Show bulk select checkboxes if applicable
-    if ( $(this).data('checkboxes') === true ) {
+    if ($(this).data('checkboxes') === true) {
       $('#records-table').addClass('bulk_edit_on');
     }
   });
 
-  $('.list-action-close-button').on('click', function (){
-    let section = $(this).data('close')
+  $('.list-action-close-button').on('click', function () {
+    let section = $(this).data('close');
     $(`#${section}`).hide();
-  })
+  });
 
   /*****
    * Bulk Send App
    */
   let bulk_send_app_button = $('#bulk_send_app_submit');
-  bulk_send_app_button.on('click', function(e) {
+  bulk_send_app_button.on('click', function (e) {
     bulk_send_app();
   });
 
   function bulk_send_app() {
-
     let subject = $('#bulk_send_app_subject').val();
     let note = $('#bulk_send_app_msg').val();
 
-    let selected_input = jQuery('.bulk_send_app.dt-radio.button-group input:checked')
-    if ( selected_input.length < 1 ) {
-      $("#bulk_send_app_required_selection").show()
-      return
+    let selected_input = jQuery(
+      '.bulk_send_app.dt-radio.button-group input:checked',
+    );
+    if (selected_input.length < 1) {
+      $('#bulk_send_app_required_selection').show();
+      return;
     } else {
-      $("#bulk_send_app_required_selection").hide()
+      $('#bulk_send_app_required_selection').hide();
     }
 
-    let root = selected_input.data('root')
-    let type = selected_input.data('type')
+    let root = selected_input.data('root');
+    let type = selected_input.data('type');
 
-    let queue =  [];
+    let queue = [];
     $('.bulk_edit_checkbox input').each(function () {
       if (this.checked && this.id !== 'bulk_edit_master_checkbox') {
         let postId = parseInt($(this).val());
-        queue.push( postId );
+        queue.push(postId);
       }
     });
 
-    if ( queue.length < 1 ) {
-      $('#bulk_send_app_required_elements').show()
+    if (queue.length < 1) {
+      $('#bulk_send_app_required_elements').show();
       return;
     } else {
-      $('#bulk_send_app_required_elements').hide()
+      $('#bulk_send_app_required_elements').hide();
     }
 
-    $('#bulk_send_app_submit-spinner').addClass('active')
+    $('#bulk_send_app_submit-spinner').addClass('active');
 
     let email_queue_link = `<a target="_blank" href="${window.wpApiShare.site_url + '/wp-admin/admin.php?page=dt_utilities&tab=background_jobs'}">See queue</a>`;
 
-    window.makeRequest('POST', list_settings.post_type + '/email_magic', { root: root, type: type, subject: subject, note: note, post_ids: queue } )
-      .done( data => {
-        $('#bulk_send_app_submit-spinner').removeClass('active')
-        $('#bulk_send_app_submit-message').html(`<strong>${data.total_sent}</strong> ${list_settings.translations.sent}! ${window.wpApiShare.can_manage_dt ? email_queue_link : '' }<br><strong>${data.total_unsent}</strong> ${list_settings.translations.not_sent}`)
-        $('#bulk_edit_master_checkbox').prop("checked", false);
-        $('.bulk_edit_checkbox input').prop("checked", false);
-        bulk_edit_count()
+    window
+      .makeRequest('POST', list_settings.post_type + '/email_magic', {
+        root: root,
+        type: type,
+        subject: subject,
+        note: note,
+        post_ids: queue,
+      })
+      .done((data) => {
+        $('#bulk_send_app_submit-spinner').removeClass('active');
+        $('#bulk_send_app_submit-message').html(
+          `<strong>${data.total_sent}</strong> ${list_settings.translations.sent}! ${window.wpApiShare.can_manage_dt ? email_queue_link : ''}<br><strong>${data.total_unsent}</strong> ${list_settings.translations.not_sent}`,
+        );
+        $('#bulk_edit_master_checkbox').prop('checked', false);
+        $('.bulk_edit_checkbox input').prop('checked', false);
+        bulk_edit_count();
         // window.location.reload();
       })
-      .fail( e => {
-        $('#bulk_send_app_submit-spinner').removeClass('active')
-        $('#bulk_send_app_submit-message').html('Oops. Something went wrong! Check log.')
-        console.log( e )
-      })
+      .fail((e) => {
+        $('#bulk_send_app_submit-spinner').removeClass('active');
+        $('#bulk_send_app_submit-message').html(
+          'Oops. Something went wrong! Check log.',
+        );
+        console.log(e);
+      });
   }
 
   /**
    * Split By Feature
    */
 
-  $("#split_by_current_filter_button").on("click", function () {
-    let field_id = $("#split_by_current_filter_select").val();
-    if ( !field_id ) {
+  $('#split_by_current_filter_button').on('click', function () {
+    let field_id = $('#split_by_current_filter_select').val();
+    if (!field_id) {
       return;
     }
     $(this).addClass('loading');
-    let split_by_accordion = $(".split-by-current-filter-accordion");
-    let split_by_results = $("#split_by_current_filter_results");
-    let split_by_no_results_msg = $("#split_by_current_filter_no_results_msg");
+    let split_by_accordion = $('.split-by-current-filter-accordion');
+    let split_by_results = $('#split_by_current_filter_results');
+    let split_by_no_results_msg = $('#split_by_current_filter_no_results_msg');
 
     $(split_by_no_results_msg).fadeOut('fast');
 
-
     $(split_by_results).slideUp('fast', function () {
-      let filters = (current_filter.query !== undefined) ? current_filter.query:[];
+      let filters =
+        current_filter.query !== undefined ? current_filter.query : [];
       window.API.split_by(list_settings.post_type, field_id, filters).then(
         function (response) {
           $('#split_by_current_filter_button').removeClass('loading');
@@ -3030,7 +3788,8 @@
               if (result['value']) {
                 summary_displayed = true;
                 let option_id = result['value'];
-                let option_id_label = (result['label'] !== '') ? result['label'] : result['value'];
+                let option_id_label =
+                  result['label'] !== '' ? result['label'] : result['value'];
 
                 html += `
                     <label class="list-view">
@@ -3053,7 +3812,7 @@
               $(split_by_no_results_msg).fadeIn('fast');
             });
           }
-        }
+        },
       );
     });
   });
@@ -3064,7 +3823,6 @@
 
   function apply_split_by_filters(filter, field_id, option_id, option_label) {
     if (filter && field_id && option_id && option_label) {
-
       // Fetch field and option display labels.
       let field_id_label = field_id;
       let option_id_label = option_label;
@@ -3075,9 +3833,9 @@
 
       // Add new label.
       filter['labels'].push({
-        'id': option_id,
-        'field': field_id,
-        'name': `${window.SHAREDFUNCTIONS.escapeHTML(field_id_label)}: ${window.SHAREDFUNCTIONS.escapeHTML(option_id_label)}`
+        id: option_id,
+        field: field_id,
+        name: `${window.SHAREDFUNCTIONS.escapeHTML(field_id_label)}: ${window.SHAREDFUNCTIONS.escapeHTML(option_id_label)}`,
       });
 
       // Ensure a fields array is available.
@@ -3086,7 +3844,7 @@
       }
 
       let query_field_obj = {};
-      query_field_obj[field_id] = (option_id !== 'NULL') ? [option_id] : [];
+      query_field_obj[field_id] = option_id !== 'NULL' ? [option_id] : [];
       if (filter['query']['fields'].push !== undefined) {
         filter['query']['fields'].push(query_field_obj);
       }
@@ -3096,23 +3854,23 @@
   }
 
   function reset_split_by_filters() {
-    let split_by_filter_select = $("#split_by_current_filter_select");
-    if (current_filter && (current_filter['query']['fields'] !== undefined)) {
+    let split_by_filter_select = $('#split_by_current_filter_select');
+    if (current_filter && current_filter['query']['fields'] !== undefined) {
       let field_id = $(split_by_filter_select).val();
       $.each(current_filter['query']['fields'], function (field_idx, field) {
-
         // Identify selected split by filters to be removed from main current global filter.
         if (field[field_id] !== undefined) {
-          $('.current-filter-list.' + field_id).find('.current-filter-list-close').click();
+          $('.current-filter-list.' + field_id)
+            .find('.current-filter-list-close')
+            .click();
         }
       });
     }
 
     // Clear down split-by area.
     $(split_by_filter_select).val('');
-    $("#split_by_current_filter_no_results_msg").fadeOut('fast');
-    $(".split-by-current-filter-accordion").slideUp('fast', function () {
-    });
+    $('#split_by_current_filter_no_results_msg').fadeOut('fast');
+    $('.split-by-current-filter-accordion').slideUp('fast', function () {});
   }
 
   /**
@@ -3127,12 +3885,15 @@
     let modal = null;
 
     // Adjust export reveal model accordingly, based on incoming type.
-    switch ( type ) {
+    switch (type) {
       case 'csv':
       case 'email':
       case 'phone': {
         modal = $('#modal-large');
-        $('#modal-large-title').html(title + '<span class="loading-spinner" style="margin-left: 10px;"></span>');
+        $('#modal-large-title').html(
+          title +
+            '<span class="loading-spinner" style="margin-left: 10px;"></span>',
+        );
         break;
       }
       case 'map': {
@@ -3141,15 +3902,14 @@
       }
     }
 
-    if ( modal ) {
+    if (modal) {
       display_function();
       $(modal).foundation('open');
     }
   }
 
-  $("#export_csv_list").on("click", function (e) {
+  $('#export_csv_list').on('click', function (e) {
     export_list_display('csv', $(e.currentTarget).text(), function () {
-
       // Show spinners.
       const spinner = $('#modal-large-title').find('.loading-spinner');
       $(spinner).addClass('active');
@@ -3158,31 +3918,40 @@
       let exporting_fields_all = [];
       let exporting_fields_visible = [];
 
-      $.each(window.list_settings['post_type_settings']['fields'], function (field_id, field_setting) {
-        if ( ( (field_setting['private'] === undefined) || !field_setting['private'] ) && ( (field_setting['hidden'] === undefined) || !field_setting['hidden'] ) && !['task', 'array'].includes( field_setting['type'] ) ) {
-          let setting = field_setting;
-          setting['field_id'] = field_id;
-          exporting_fields_all.push(setting);
-
-          // Separately capture currently shown table fields.
-          if ( fields_to_show_in_table.includes( field_id ) ) {
-            exporting_fields_visible.push(setting);
-          }
-
-          // Insert additional locations id column, if needed.
-          if ( ['location', 'location_meta'].includes( setting['type'] ) ) {
-            let location_settings = JSON.parse( JSON.stringify( setting ) );
-            location_settings['name'] = `${location_settings['name']} [ID]`;
-            location_settings['dynamic_csv_col'] = true;
-            exporting_fields_all.push(location_settings);
+      $.each(
+        window.list_settings['post_type_settings']['fields'],
+        function (field_id, field_setting) {
+          if (
+            (field_setting['private'] === undefined ||
+              !field_setting['private']) &&
+            (field_setting['hidden'] === undefined ||
+              !field_setting['hidden']) &&
+            !['task', 'array'].includes(field_setting['type'])
+          ) {
+            let setting = field_setting;
+            setting['field_id'] = field_id;
+            exporting_fields_all.push(setting);
 
             // Separately capture currently shown table fields.
-            if ( fields_to_show_in_table.includes( field_id ) ) {
-              exporting_fields_visible.push(location_settings);
+            if (fields_to_show_in_table.includes(field_id)) {
+              exporting_fields_visible.push(setting);
+            }
+
+            // Insert additional locations id column, if needed.
+            if (['location', 'location_meta'].includes(setting['type'])) {
+              let location_settings = JSON.parse(JSON.stringify(setting));
+              location_settings['name'] = `${location_settings['name']} [ID]`;
+              location_settings['dynamic_csv_col'] = true;
+              exporting_fields_all.push(location_settings);
+
+              // Separately capture currently shown table fields.
+              if (fields_to_show_in_table.includes(field_id)) {
+                exporting_fields_visible.push(location_settings);
+              }
             }
           }
-        }
-      });
+        },
+      );
 
       // Sort identified fields by name into ascending order.
       exporting_fields_all.sort(function (a, b) {
@@ -3224,21 +3993,21 @@
         <div class="cell">
           <label>
             <input type="radio" name="csv_exported_list_fields" value="all" checked />
-            ${ window.SHAREDFUNCTIONS.escapeHTML( window.list_settings['translations']['exports']['csv']['fields_msg_all'].replaceAll( '%2$s', exporting_fields_all.length ) ) }
+            ${window.SHAREDFUNCTIONS.escapeHTML(window.list_settings['translations']['exports']['csv']['fields_msg_all'].replaceAll('%2$s', exporting_fields_all.length))}
           </label>
           <label>
             <input type="radio" name="csv_exported_list_fields" value="visible" />
-            ${ window.SHAREDFUNCTIONS.escapeHTML( window.list_settings['translations']['exports']['csv']['fields_msg_visible'].replaceAll( '%2$s', exporting_fields_visible.length ) ) }
+            ${window.SHAREDFUNCTIONS.escapeHTML(window.list_settings['translations']['exports']['csv']['fields_msg_visible'].replaceAll('%2$s', exporting_fields_visible.length))}
           </label>
-          ${ fields_to_show_in_table_html }
+          ${fields_to_show_in_table_html}
         </div>`;
 
       let record_total = window.records_list['total'];
-      html +=`<div class="cell"><hr></div>
+      html += `<div class="cell"><hr></div>
         <div class="cell">
-            <button class="button" id="export_csv_list_download" ${ (record_total <= 0) ? 'disabled' : '' }>
+            <button class="button" id="export_csv_list_download" ${record_total <= 0 ? 'disabled' : ''}>
             <i class="mdi mdi-cloud-download-outline" style="font-size: 22px; margin-right: 10px;"></i>
-            <span style="font-size: 20px;">[ ${ window.SHAREDFUNCTIONS.escapeHTML(record_total)} ]</span>
+            <span style="font-size: 20px;">[ ${window.SHAREDFUNCTIONS.escapeHTML(record_total)} ]</span>
             </button>
         </div>
       </div>`;
@@ -3247,235 +4016,293 @@
 
       // Terminate any spinners and prepare download button event listener.
       $(spinner).removeClass('active');
-      $('#export_csv_list_download').on('click', function(){
+      $('#export_csv_list_download').on('click', function () {
         $(spinner).addClass('active');
         $('#export_csv_list_download').prop('disabled', true);
 
         // Ensure to determine which field groupings to move forward with....? All or Currently Visible?
-        export_csv_list_download( ( $('input[name="csv_exported_list_fields"]:checked').val() === 'visible' ) ? exporting_fields_visible : exporting_fields_all, function () {
-          $(spinner).removeClass('active');
-          $('#modal-large').foundation('close');
-        });
+        export_csv_list_download(
+          $('input[name="csv_exported_list_fields"]:checked').val() ===
+            'visible'
+            ? exporting_fields_visible
+            : exporting_fields_all,
+          function () {
+            $(spinner).removeClass('active');
+            $('#modal-large').foundation('close');
+          },
+        );
       });
     });
   });
 
   function export_csv_list_download(exporting_fields, callback = null) {
-
     // First retrieve all records associated with currently selected filter.
-    recursively_fetch_posts(0, 500, window.records_list['total'], [], function ( posts ) {
-      if ( posts && posts.length > 0 ) {
-        let csv_export = [];
+    recursively_fetch_posts(
+      0,
+      500,
+      window.records_list['total'],
+      [],
+      function (posts) {
+        if (posts && posts.length > 0) {
+          let csv_export = [];
 
-        // Structure csv shape to be downloaded.
-        $.each(posts, function(post_idx, post) {
-          let csv_row = [];
-          let token_array_delimiter = ';';
+          // Structure csv shape to be downloaded.
+          $.each(posts, function (post_idx, post) {
+            let csv_row = [];
+            let token_array_delimiter = ';';
 
-          // Capture ID & Name.
-          csv_row.push(post['ID']);
-          csv_row.push(post['name']);
+            // Capture ID & Name.
+            csv_row.push(post['ID']);
+            csv_row.push(post['name']);
 
-          // Proceed with extraction of remaining fields.
-          $.each(exporting_fields, function (field_idx, field) {
-            let field_id = field['field_id'];
+            // Proceed with extraction of remaining fields.
+            $.each(exporting_fields, function (field_idx, field) {
+              let field_id = field['field_id'];
 
-            // As well as names, also ignore dynamic csv columns; which are typically populated via other means.
-            if ( !['name'].includes( field_id ) && ( ( field['dynamic_csv_col'] === undefined ) || !field['dynamic_csv_col'] ) ) {
-
-              // Next, extract post field value accordingly, based on field type.
-              switch (field['type']) {
-                case 'text':
-                case 'number':
-                case 'boolean':
-                case 'textarea': {
-                  let token = (post[field_id]) ? post[field_id] : '';
-                  csv_row.push(token);
-                  break;
-                }
-                case 'user_select': {
-                  let token = (post[field_id] && post[field_id]['display']) ? post[field_id]['display'] : '';
-                  csv_row.push(token);
-                  break;
-                }
-                case 'key_select': {
-                  let token = (post[field_id] && post[field_id]['label']) ? post[field_id]['label'] : '';
-                  csv_row.push(token);
-                  break;
-                }
-                case 'date':
-                case 'datetime': {
-                  let token = (post[field_id] && post[field_id]['formatted']) ? post[field_id]['formatted'] : '';
-                  csv_row.push(token);
-                  break;
-                }
-                case 'multi_select': {
-                  let token_array = [];
-                  if (post[field_id]) {
-                    $.each(post[field_id], function(cell_index, cell_value) {
-                      token_array.push( field['default'][cell_value]['label'] );
-                    });
+              // As well as names, also ignore dynamic csv columns; which are typically populated via other means.
+              if (
+                !['name'].includes(field_id) &&
+                (field['dynamic_csv_col'] === undefined ||
+                  !field['dynamic_csv_col'])
+              ) {
+                // Next, extract post field value accordingly, based on field type.
+                switch (field['type']) {
+                  case 'text':
+                  case 'number':
+                  case 'boolean':
+                  case 'textarea': {
+                    let token = post[field_id] ? post[field_id] : '';
+                    csv_row.push(token);
+                    break;
                   }
-                  csv_row.push(token_array.join(token_array_delimiter));
-                  break;
-                }
-                case 'connection': {
-                  let token_array = [];
-                  if (post[field_id]) {
-                    $.each(post[field_id], function(cell_index, cell_value) {
-                      token_array.push( cell_value['post_title'] );
-                    });
+                  case 'user_select': {
+                    let token =
+                      post[field_id] && post[field_id]['display']
+                        ? post[field_id]['display']
+                        : '';
+                    csv_row.push(token);
+                    break;
                   }
-                  csv_row.push(token_array.join(token_array_delimiter));
-                  break;
-                }
-                case 'communication_channel': {
-                  let token_array = [];
-                  if (post[field_id]) {
-                    $.each(post[field_id], function(cell_index, cell_value) {
-                      token_array.push( cell_value['value'] );
-                    });
+                  case 'key_select': {
+                    let token =
+                      post[field_id] && post[field_id]['label']
+                        ? post[field_id]['label']
+                        : '';
+                    csv_row.push(token);
+                    break;
                   }
-                  csv_row.push(token_array.join(token_array_delimiter));
-                  break;
-                }
-                case 'location':
-                case 'location_meta': {
-                  let token_array = [];
-                  let id_array = [];
-                  if (post[field_id]) {
-                    $.each(post[field_id], function(cell_index, cell_value) {
-                      token_array.push( cell_value['label'] );
+                  case 'date':
+                  case 'datetime': {
+                    let token =
+                      post[field_id] && post[field_id]['formatted']
+                        ? post[field_id]['formatted']
+                        : '';
+                    csv_row.push(token);
+                    break;
+                  }
+                  case 'multi_select': {
+                    let token_array = [];
+                    if (post[field_id]) {
+                      $.each(post[field_id], function (cell_index, cell_value) {
+                        token_array.push(field['default'][cell_value]['label']);
+                      });
+                    }
+                    csv_row.push(token_array.join(token_array_delimiter));
+                    break;
+                  }
+                  case 'connection': {
+                    let token_array = [];
+                    if (post[field_id]) {
+                      $.each(post[field_id], function (cell_index, cell_value) {
+                        token_array.push(cell_value['post_title']);
+                      });
+                    }
+                    csv_row.push(token_array.join(token_array_delimiter));
+                    break;
+                  }
+                  case 'communication_channel': {
+                    let token_array = [];
+                    if (post[field_id]) {
+                      $.each(post[field_id], function (cell_index, cell_value) {
+                        token_array.push(cell_value['value']);
+                      });
+                    }
+                    csv_row.push(token_array.join(token_array_delimiter));
+                    break;
+                  }
+                  case 'location':
+                  case 'location_meta': {
+                    let token_array = [];
+                    let id_array = [];
+                    if (post[field_id]) {
+                      $.each(post[field_id], function (cell_index, cell_value) {
+                        token_array.push(cell_value['label']);
 
-                      // Extract id accordingly based on value shape; to be appended within dynamic csv column.
-                      let grid_id = '';
-                      if ( cell_value['id'] ) {
-                        grid_id = cell_value['id'];
-
-                      } else if ( cell_value['grid_id'] ) {
-                        grid_id = cell_value['grid_id'];
-                      }
-                      id_array.push( grid_id );
-                    });
+                        // Extract id accordingly based on value shape; to be appended within dynamic csv column.
+                        let grid_id = '';
+                        if (cell_value['id']) {
+                          grid_id = cell_value['id'];
+                        } else if (cell_value['grid_id']) {
+                          grid_id = cell_value['grid_id'];
+                        }
+                        id_array.push(grid_id);
+                      });
+                    }
+                    csv_row.push(token_array.join(token_array_delimiter));
+                    csv_row.push(id_array.join(token_array_delimiter));
+                    break;
                   }
-                  csv_row.push(token_array.join(token_array_delimiter));
-                  csv_row.push(id_array.join(token_array_delimiter));
-                  break;
-                }
-                case 'tags': {
-                  let token_array = [];
-                  if (post[field_id]) {
-                    $.each(post[field_id], function(cell_index, cell_value) {
-                      token_array.push( cell_value );
-                    });
+                  case 'tags': {
+                    let token_array = [];
+                    if (post[field_id]) {
+                      $.each(post[field_id], function (cell_index, cell_value) {
+                        token_array.push(cell_value);
+                      });
+                    }
+                    csv_row.push(token_array.join(token_array_delimiter));
+                    break;
                   }
-                  csv_row.push(token_array.join(token_array_delimiter));
-                  break;
-                }
-                case 'link': {
-                  let token_array = [];
-                  if (post[field_id]) {
-                    $.each(post[field_id], function (cell_index, cell_value) {
-                      if (field['default'][cell_value['type']]) {
-                        let category_label = field['default'][cell_value['type']]['label'];
-                        let token = category_label +': '+ cell_value['value'];
-                        token_array.push(token);
-                      }
-                    });
+                  case 'link': {
+                    let token_array = [];
+                    if (post[field_id]) {
+                      $.each(post[field_id], function (cell_index, cell_value) {
+                        if (field['default'][cell_value['type']]) {
+                          let category_label =
+                            field['default'][cell_value['type']]['label'];
+                          let token =
+                            category_label + ': ' + cell_value['value'];
+                          token_array.push(token);
+                        }
+                      });
+                    }
+                    csv_row.push(token_array.join(token_array_delimiter));
+                    break;
                   }
-                  csv_row.push(token_array.join(token_array_delimiter));
-                  break;
-                }
-                case 'task':
-                case 'array':
-                default: {
-                  csv_row.push('');
-                  break;
+                  case 'task':
+                  case 'array':
+                  default: {
+                    csv_row.push('');
+                    break;
+                  }
                 }
               }
+            });
+
+            // Assuming counts match, assign to parent csv download array.
+            if (csv_row.length === exporting_fields.length + 1) {
+              csv_export.push(csv_row);
             }
           });
 
-          // Assuming counts match, assign to parent csv download array.
-          if (csv_row.length === (exporting_fields.length + 1)) {
-            csv_export.push(csv_row);
-          }
-        });
+          // Generate export csv headers and prefix to parent csv download array.
+          let csv_headers = ['ID', 'Name'].concat(
+            exporting_fields
+              .filter((field) => !['name'].includes(field['field_id']))
+              .map((field) => field['name']),
+          );
+          csv_export.unshift(csv_headers);
 
-        // Generate export csv headers and prefix to parent csv download array.
-        let csv_headers = ['ID', 'Name'].concat( exporting_fields.filter((field) => !['name'].includes( field['field_id'] )).map((field) => field['name']) );
-        csv_export.unshift(csv_headers);
+          // Convert csv arrays into raw downloadable data.
+          const csv = csv_export
+            .map((row) => {
+              return row.map((item) => {
+                let escapeditem = item;
+                //if the string contains a doublequote escape it by doubling the double quoate like "" - https://stackoverflow.com/a/769675
+                if (String(item).includes('"')) {
+                  escapeditem = item.replaceAll('"', '""');
+                }
 
-        // Convert csv arrays into raw downloadable data.
-        const csv = csv_export.map(row => {
-          return row.map((item) => {
-            let escapeditem = item;
-            //if the string contains a doublequote escape it by doubling the double quoate like "" - https://stackoverflow.com/a/769675
-            if (String(item).includes('"')) {
-              escapeditem = item.replaceAll('"', '""');
-            }
+                return `"${escapeditem}"`;
+              });
+            })
+            .join('\r\n');
 
-            return `"${escapeditem}"`;
-          });
-        }).join('\r\n');
+          // Finally, automatically execute a download of generated csv data.
+          let csv_download_link = document.createElement('a');
+          let date = new Date();
+          let year = new Intl.DateTimeFormat('en', { year: 'numeric' }).format(
+            date,
+          );
+          let month = new Intl.DateTimeFormat('en', {
+            month: 'numeric',
+          }).format(date);
+          let day = new Intl.DateTimeFormat('en', { day: '2-digit' }).format(
+            date,
+          );
+          let hour = new Intl.DateTimeFormat('en', {
+            hour: 'numeric',
+            hour12: false,
+          }).format(date);
+          let minute = new Intl.DateTimeFormat('en', {
+            minute: 'numeric',
+          }).format(date);
+          let second = new Intl.DateTimeFormat('en', {
+            second: 'numeric',
+          }).format(date);
+          csv_download_link.download = `${year}_${month}_${day}_${hour}_${minute}_${second}_${window.list_settings.post_type}_list_export.csv`;
+          csv_download_link.href =
+            'data:text/csv;charset=utf-8;base64,' + window.Base64.encode(csv);
+          csv_download_link.click();
+          csv_download_link.remove();
+        }
 
-        // Finally, automatically execute a download of generated csv data.
-        let csv_download_link = document.createElement('a');
-        let date = new Date();
-        let year = new Intl.DateTimeFormat('en', { year: 'numeric' }).format(date);
-        let month = new Intl.DateTimeFormat('en', { month: 'numeric' }).format(date);
-        let day = new Intl.DateTimeFormat('en', { day: '2-digit' }).format(date);
-        let hour = new Intl.DateTimeFormat('en', { hour: 'numeric', hour12: false, }).format(date);
-        let minute = new Intl.DateTimeFormat('en', { minute: 'numeric' }).format(date);
-        let second = new Intl.DateTimeFormat('en', { second: 'numeric' }).format(date);
-        csv_download_link.download = `${year}_${month}_${day}_${hour}_${minute}_${second}_${window.list_settings.post_type}_list_export.csv`;
-        csv_download_link.href = "data:text/csv;charset=utf-8;base64," + window.Base64.encode( csv );
-        csv_download_link.click();
-        csv_download_link.remove();
-      }
-
-      // Callback to original caller...! ;)
-      if ( callback ) {
-        callback();
-      }
-    });
+        // Callback to original caller...! ;)
+        if (callback) {
+          callback();
+        }
+      },
+    );
   }
 
-  function recursively_fetch_posts(offset, limit, total, posts, callback = null) {
-
+  function recursively_fetch_posts(
+    offset,
+    limit,
+    total,
+    posts,
+    callback = null,
+  ) {
     // Build query based on current filter, to be executed.
     let query = current_filter.query;
-    query["offset"] = offset;
+    query['offset'] = offset;
     query['limit'] = limit;
     query['fields_to_return'] = [];
 
-    window.makeRequestOnPosts( 'POST', `${window.list_settings.post_type}/list`, JSON.parse(JSON.stringify(query)))
-    .promise()
-    .then(response => {
+    window
+      .makeRequestOnPosts(
+        'POST',
+        `${window.list_settings.post_type}/list`,
+        JSON.parse(JSON.stringify(query)),
+      )
+      .promise()
+      .then((response) => {
+        // Concat any returned posts to main parent posts array.
+        posts = posts.concat(
+          response && response['posts'] ? response['posts'] : [],
+        );
 
-      // Concat any returned posts to main parent posts array.
-      posts = posts.concat( ( ( response && response['posts'] ) ? response['posts'] : [] ) );
-
-      // Recurse if more records are available, otherwise proceed with export callback.
-      if ( (offset + limit) < total ) {
-        recursively_fetch_posts((offset + limit), limit, total, posts, callback );
-
-      } else if ( callback ) {
-        callback( posts );
-      }
-    })
-    .catch(error => {
-      console.log(error);
-      if ( callback ) {
-        callback( posts );
-      }
-    });
-
+        // Recurse if more records are available, otherwise proceed with export callback.
+        if (offset + limit < total) {
+          recursively_fetch_posts(
+            offset + limit,
+            limit,
+            total,
+            posts,
+            callback,
+          );
+        } else if (callback) {
+          callback(posts);
+        }
+      })
+      .catch((error) => {
+        console.log(error);
+        if (callback) {
+          callback(posts);
+        }
+      });
   }
 
-  $("#export_bcc_email_list").on("click", function (e) {
+  $('#export_bcc_email_list').on('click', function (e) {
     export_list_display('email', $(e.currentTarget).text(), function () {
-
       // Show spinners.
       const spinner = $('#modal-large-title').find('.loading-spinner');
       $(spinner).addClass('active');
@@ -3487,15 +4314,15 @@
             </div>
 
             <div class="cell">
-                <a onclick="jQuery('#email-list-print').toggle();"><strong>${window.SHAREDFUNCTIONS.escapeHTML( window.list_settings['translations']['exports']['bcc']['full_list'] )} (<span id="list-count-full"></span>)</strong></a>
+                <a onclick="jQuery('#email-list-print').toggle();"><strong>${window.SHAREDFUNCTIONS.escapeHTML(window.list_settings['translations']['exports']['bcc']['full_list'])} (<span id="list-count-full"></span>)</strong></a>
                 <div class="cell" id="email-list-print" style="display:none;"></div>
             </div>
             <div class="cell">
-                <a onclick="jQuery('#contacts-without').toggle();"><strong>${window.SHAREDFUNCTIONS.escapeHTML( window.list_settings['translations']['exports']['bcc']['no_addr'] )} (<span id="list-count-without"></span>)</strong></a>
+                <a onclick="jQuery('#contacts-without').toggle();"><strong>${window.SHAREDFUNCTIONS.escapeHTML(window.list_settings['translations']['exports']['bcc']['no_addr'])} (<span id="list-count-without"></span>)</strong></a>
                 <div id="contacts-without" style="display:none;"></div>
             </div>
             <div class="cell">
-                <a onclick="jQuery('#contacts-with').toggle();"><strong>${window.SHAREDFUNCTIONS.escapeHTML( window.list_settings['translations']['exports']['bcc']['with_addr'] )} (<span id="list-count-with"></span>)</strong></a>
+                <a onclick="jQuery('#contacts-with').toggle();"><strong>${window.SHAREDFUNCTIONS.escapeHTML(window.list_settings['translations']['exports']['bcc']['with_addr'])} (<span id="list-count-with"></span>)</strong></a>
                 <div id="contacts-with" style="display:none;"></div>
             </div>
         </div>`;
@@ -3503,142 +4330,161 @@
       $('#modal-large-content').html(html);
 
       // Recursively fetch all filtered list posts, to be processed.
-      recursively_fetch_posts(0, 500, window.records_list['total'], [], function ( posts ) {
-        let email_totals = []
-        let list_count = {
-          with: 0,
-          without: 0,
-          full: 0
-        }
-        let count = 0
-        let group = 0
-        let contacts_with = jQuery('#contacts-with')
-        let contacts_without = jQuery('#contacts-without')
+      recursively_fetch_posts(
+        0,
+        500,
+        window.records_list['total'],
+        [],
+        function (posts) {
+          let email_totals = [];
+          let list_count = {
+            with: 0,
+            without: 0,
+            full: 0,
+          };
+          let count = 0;
+          let group = 0;
+          let contacts_with = jQuery('#contacts-with');
+          let contacts_without = jQuery('#contacts-without');
 
-        // Generate totals.
-        $.each(posts, function (i, v) {
-          let has_email = false
-          if (typeof v.contact_email !== "undefined" && v.contact_email !== '') {
-            if (typeof email_totals[group] === "undefined") {
-              email_totals[group] = []
-            }
-            let non_empty_values = v.contact_email.filter(val=>val.value)
-            non_empty_values.forEach(vv => {
-              let email = window.SHAREDFUNCTIONS.escapeHTML(vv.value);
-              if (validate_email_address(email)) {
-                email_totals[group].push(email)
-                count++
-                list_count['full']++
-                has_email = true;
-              } else {
-                console.log(`Invalid Email Format: ${email}`);
+          // Generate totals.
+          $.each(posts, function (i, v) {
+            let has_email = false;
+            if (
+              typeof v.contact_email !== 'undefined' &&
+              v.contact_email !== ''
+            ) {
+              if (typeof email_totals[group] === 'undefined') {
+                email_totals[group] = [];
               }
-            })
-            if (count > 50) {
-              group++
-              count = 0
-            }
-            if ( non_empty_values.length > 1 ){
-              contacts_with.append(`<a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/contacts/${window.SHAREDFUNCTIONS.escapeHTML(v.ID)}">${window.SHAREDFUNCTIONS.escapeHTML(v.post_title)}</a><br>`)
-              list_count['with']++
-            }
-          }
-          if ( !has_email ){
-            contacts_without.append(`<a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/contacts/${window.SHAREDFUNCTIONS.escapeHTML(v.ID)}">${window.SHAREDFUNCTIONS.escapeHTML(v.post_title)}</a><br>`)
-            list_count['without']++
-          }
-        });
-
-        // Update count findings.
-        let list_print = jQuery('#email-list-print')
-        $.each(email_totals, function (index, values) {
-          list_print.append(window.SHAREDFUNCTIONS.escapeHTML(values.join(', ')))
-        })
-
-        jQuery('#list-count-with').html(list_count['with'])
-        jQuery('#list-count-without').html(list_count['without'])
-        jQuery('#list-count-full').html(list_count['full'])
-
-        // Generate links.
-        let email_links = []
-        group = 0
-
-        $.each(posts, function (i, v) {
-          if (typeof v.contact_email !== "undefined" && v.contact_email !== '') {
-            if (typeof email_links[group] === "undefined") {
-              email_links[group] = []
-            }
-            $.each(v.contact_email, function (ii, vv) {
-              let email = window.SHAREDFUNCTIONS.escapeHTML(vv.value);
-              if ( validate_email_address(email) ){
-                email_links[group].push( email )
+              let non_empty_values = v.contact_email.filter((val) => val.value);
+              non_empty_values.forEach((vv) => {
+                let email = window.SHAREDFUNCTIONS.escapeHTML(vv.value);
+                if (validate_email_address(email)) {
+                  email_totals[group].push(email);
+                  count++;
+                  list_count['full']++;
+                  has_email = true;
+                } else {
+                  console.log(`Invalid Email Format: ${email}`);
+                }
+              });
+              if (count > 50) {
+                group++;
+                count = 0;
               }
-            })
-            if (email_links[group].length > 50) {
-              group++
+              if (non_empty_values.length > 1) {
+                contacts_with.append(
+                  `<a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/contacts/${window.SHAREDFUNCTIONS.escapeHTML(v.ID)}">${window.SHAREDFUNCTIONS.escapeHTML(v.post_title)}</a><br>`,
+                );
+                list_count['with']++;
+              }
             }
-          }
-        });
+            if (!has_email) {
+              contacts_without.append(
+                `<a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/contacts/${window.SHAREDFUNCTIONS.escapeHTML(v.ID)}">${window.SHAREDFUNCTIONS.escapeHTML(v.post_title)}</a><br>`,
+              );
+              list_count['without']++;
+            }
+          });
 
-        // loop 50 each
-        let grouping_table = $('#grouping-table')
-        let email_strings = []
-        $.each(email_links, function (index, values) {
-          index++
-          email_strings = []
-          email_strings = window.SHAREDFUNCTIONS.escapeHTML(values.join(', '))
-          email_strings.replace(/,/g, ', ')
+          // Update count findings.
+          let list_print = jQuery('#email-list-print');
+          $.each(email_totals, function (index, values) {
+            list_print.append(
+              window.SHAREDFUNCTIONS.escapeHTML(values.join(', ')),
+            );
+          });
 
+          jQuery('#list-count-with').html(list_count['with']);
+          jQuery('#list-count-without').html(list_count['without']);
+          jQuery('#list-count-full').html(list_count['full']);
+
+          // Generate links.
+          let email_links = [];
+          group = 0;
+
+          $.each(posts, function (i, v) {
+            if (
+              typeof v.contact_email !== 'undefined' &&
+              v.contact_email !== ''
+            ) {
+              if (typeof email_links[group] === 'undefined') {
+                email_links[group] = [];
+              }
+              $.each(v.contact_email, function (ii, vv) {
+                let email = window.SHAREDFUNCTIONS.escapeHTML(vv.value);
+                if (validate_email_address(email)) {
+                  email_links[group].push(email);
+                }
+              });
+              if (email_links[group].length > 50) {
+                group++;
+              }
+            }
+          });
+
+          // loop 50 each
+          let grouping_table = $('#grouping-table');
+          let email_strings = [];
+          $.each(email_links, function (index, values) {
+            index++;
+            email_strings = [];
+            email_strings = window.SHAREDFUNCTIONS.escapeHTML(
+              values.join(', '),
+            );
+            email_strings.replace(/,/g, ', ');
+
+            grouping_table.append(`
+            <tr><td style="vertical-align:top; width:50%;"><a href="mailto:?subject=group${index}&bcc=${email_strings}" id="group-link-${index}" class="button expanded export-link-button">${window.SHAREDFUNCTIONS.escapeHTML(window.list_settings['translations']['exports']['bcc']['open_email'])} ${index}</a></td>
+            <td><a onclick="jQuery('#group-addresses-${index}').toggle()">${window.SHAREDFUNCTIONS.escapeHTML(window.list_settings['translations']['exports']['bcc']['show_group_addrs'])}</a> <p style="display:none;overflow-wrap: break-word;" id="group-addresses-${index}">${email_strings.replace(/,/g, ', ')}</p></td></tr>
+          `);
+          });
           grouping_table.append(`
-            <tr><td style="vertical-align:top; width:50%;"><a href="mailto:?subject=group${index}&bcc=${email_strings}" id="group-link-${index}" class="button expanded export-link-button">${window.SHAREDFUNCTIONS.escapeHTML( window.list_settings['translations']['exports']['bcc']['open_email'] )} ${index}</a></td>
-            <td><a onclick="jQuery('#group-addresses-${index}').toggle()">${window.SHAREDFUNCTIONS.escapeHTML( window.list_settings['translations']['exports']['bcc']['show_group_addrs'] )}</a> <p style="display:none;overflow-wrap: break-word;" id="group-addresses-${index}">${email_strings.replace(/,/g, ', ')}</p></td></tr>
-          `)
+            <tr><td style="vertical-align:top; text-align:center; width:50%;"><a class="button expanded export-link-button" id="open_all">${window.SHAREDFUNCTIONS.escapeHTML(window.list_settings['translations']['exports']['bcc']['open_all'])}</a></td><td></td></tr>
+        `);
 
-        })
-        grouping_table.append(`
-            <tr><td style="vertical-align:top; text-align:center; width:50%;"><a class="button expanded export-link-button" id="open_all">${window.SHAREDFUNCTIONS.escapeHTML( window.list_settings['translations']['exports']['bcc']['open_all'] )}</a></td><td></td></tr>
-        `)
+          $('.export-link-button').on('click', function () {
+            $(this).addClass('warning');
+          });
+          $('#open_all').on('click', function () {
+            $('.export-link-button').each(function (i, v) {
+              document.getElementById(v.id).click();
+            });
+          });
 
-        $('.export-link-button').on('click',function(){
-          $(this).addClass('warning');
-        })
-        $('#open_all').on('click', function(){
-          $('.export-link-button').each(function(i,v){
-            document.getElementById(v.id).click()
-          })
-        })
-
-        // Hide spinners.
-        $(spinner).removeClass('active');
-      });
+          // Hide spinners.
+          $(spinner).removeClass('active');
+        },
+      );
     });
   });
 
   function validate_email_address(email) {
-    const regex = /^([a-zA-Z0-9_.+-])+\@(([a-zA-Z0-9-])+\.)+([a-zA-Z0-9]{2,4})+$/;
+    const regex =
+      /^([a-zA-Z0-9_.+-])+\@(([a-zA-Z0-9-])+\.)+([a-zA-Z0-9]{2,4})+$/;
     return regex.test(email);
   }
 
-  $("#export_phone_list").on("click", function (e) {
+  $('#export_phone_list').on('click', function (e) {
     export_list_display('phone', $(e.currentTarget).text(), function () {
-
       // Show spinners.
       const spinner = $('#modal-large-title').find('.loading-spinner');
       $(spinner).addClass('active');
 
       let html = `
         <div class="grid-x">
-            <a onclick="jQuery('#email-list-print').toggle();"><strong>${window.SHAREDFUNCTIONS.escapeHTML( window.list_settings['translations']['exports']['phone']['full_list'] )} (<span id="list-count-full"></span>)</strong></a>
+            <a onclick="jQuery('#email-list-print').toggle();"><strong>${window.SHAREDFUNCTIONS.escapeHTML(window.list_settings['translations']['exports']['phone']['full_list'])} (<span id="list-count-full"></span>)</strong></a>
             <div class="cell" id="email-list-print"></div>
         </div>
         <hr>
         <div class="grid-x">
             <div class="cell">
-                <a onclick="jQuery('#contacts-without').toggle();"><strong>${window.SHAREDFUNCTIONS.escapeHTML( window.list_settings['translations']['exports']['phone']['no_phone'] )} (<span id="list-count-without"></span>)</strong></a>
+                <a onclick="jQuery('#contacts-without').toggle();"><strong>${window.SHAREDFUNCTIONS.escapeHTML(window.list_settings['translations']['exports']['phone']['no_phone'])} (<span id="list-count-without"></span>)</strong></a>
                 <div id="contacts-without" style="display:none;"></div>
             </div>
             <div class="cell">
-                <a onclick="jQuery('#contacts-with').toggle();"><strong>${window.SHAREDFUNCTIONS.escapeHTML( window.list_settings['translations']['exports']['phone']['with_phone'] )} (<span id="list-count-with"></span>)</strong></a>
+                <a onclick="jQuery('#contacts-with').toggle();"><strong>${window.SHAREDFUNCTIONS.escapeHTML(window.list_settings['translations']['exports']['phone']['with_phone'])} (<span id="list-count-with"></span>)</strong></a>
                 <div id="contacts-with" style="display:none;"></div>
             </div>
         </div>`;
@@ -3646,71 +4492,85 @@
       $('#modal-large-content').html(html);
 
       // Recursively fetch all filtered list posts, to be processed.
-      recursively_fetch_posts(0, 500, window.records_list['total'], [], function (posts) {
-        let phone_list = []
-        let list_count = {
-          with: 0,
-          without: 0,
-          full: 0
-        }
-        let group = 0
-        let contacts_with = jQuery('#contacts-with')
-        let contacts_without = jQuery('#contacts-without')
+      recursively_fetch_posts(
+        0,
+        500,
+        window.records_list['total'],
+        [],
+        function (posts) {
+          let phone_list = [];
+          let list_count = {
+            with: 0,
+            without: 0,
+            full: 0,
+          };
+          let group = 0;
+          let contacts_with = jQuery('#contacts-with');
+          let contacts_without = jQuery('#contacts-without');
 
-        // Generate totals.
-        $.each(posts, function (i, v) {
-          let has_phone = false
-          if (typeof v.contact_phone !== 'undefined' && v.contact_phone !== '') {
-            if (typeof phone_list[group]==="undefined") {
-              phone_list[group] = []
+          // Generate totals.
+          $.each(posts, function (i, v) {
+            let has_phone = false;
+            if (
+              typeof v.contact_phone !== 'undefined' &&
+              v.contact_phone !== ''
+            ) {
+              if (typeof phone_list[group] === 'undefined') {
+                phone_list[group] = [];
+              }
+              let non_empty_values = v.contact_phone.filter((val) => val.value);
+              non_empty_values.forEach((vv) => {
+                phone_list[group].push(vv.value);
+                list_count['full']++;
+                has_phone = true;
+              });
+              if (non_empty_values.length > 1) {
+                contacts_with.append(
+                  `<a  href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/contacts/${window.SHAREDFUNCTIONS.escapeHTML(v.ID)}">${window.SHAREDFUNCTIONS.escapeHTML(v.post_title)}</a><br>`,
+                );
+                list_count['with']++;
+              }
+              if (phone_list.length > 50) {
+                group++;
+              }
             }
-            let non_empty_values = v.contact_phone.filter(val=>val.value)
-            non_empty_values.forEach(vv=>{
-              phone_list[group].push(vv.value)
-              list_count['full']++
-              has_phone = true
-            })
-            if ( non_empty_values.length > 1 ){
-              contacts_with.append(`<a  href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/contacts/${window.SHAREDFUNCTIONS.escapeHTML(v.ID)}">${window.SHAREDFUNCTIONS.escapeHTML(v.post_title)}</a><br>`)
-              list_count['with']++
+            if (!has_phone) {
+              contacts_without.append(
+                `<a  href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/contacts/${window.SHAREDFUNCTIONS.escapeHTML(v.ID)}">${window.SHAREDFUNCTIONS.escapeHTML(v.post_title)}</a><br>`,
+              );
+              list_count['without']++;
             }
-            if (phone_list.length > 50) {
-              group++
-            }
-          }
-          if ( !has_phone ) {
-            contacts_without.append(`<a  href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/contacts/${window.SHAREDFUNCTIONS.escapeHTML(v.ID)}">${window.SHAREDFUNCTIONS.escapeHTML(v.post_title)}</a><br>`)
-            list_count['without']++
-          }
-        });
+          });
 
-        // Update count findings.
-        let list_print = jQuery('#email-list-print')
-        let all_numbers = []
-        $.each(phone_list, function (index, values) {
-          all_numbers = all_numbers.concat(values)
-        })
-        list_print.append(window.SHAREDFUNCTIONS.escapeHTML(all_numbers.join(', ')))
+          // Update count findings.
+          let list_print = jQuery('#email-list-print');
+          let all_numbers = [];
+          $.each(phone_list, function (index, values) {
+            all_numbers = all_numbers.concat(values);
+          });
+          list_print.append(
+            window.SHAREDFUNCTIONS.escapeHTML(all_numbers.join(', ')),
+          );
 
-        // console.log(list_count)
-        jQuery('#list-count-with').html(list_count['with'])
-        jQuery('#list-count-without').html(list_count['without'])
-        jQuery('#list-count-full').html(list_count['full'])
+          // console.log(list_count)
+          jQuery('#list-count-with').html(list_count['with']);
+          jQuery('#list-count-without').html(list_count['without']);
+          jQuery('#list-count-full').html(list_count['full']);
 
-        // Hide spinners.
-        $(spinner).removeClass('active');
-      });
+          // Hide spinners.
+          $(spinner).removeClass('active');
+        },
+      );
     });
   });
 
-  $(".export_map_list").on("click", function (e) {
-    if ( window.list_settings['translations']['exports']['map']['mapbox_key'] ) {
+  $('.export_map_list').on('click', function (e) {
+    if (window.list_settings['translations']['exports']['map']['mapbox_key']) {
       const title = $(e.currentTarget).text();
       export_list_display('map', title, function () {
-
         // Generate modal html.
         let html = `
-        <span class="section-header"> ${window.SHAREDFUNCTIONS.escapeHTML(title)} | ${window.SHAREDFUNCTIONS.escapeHTML( window.list_settings['translations']['exports']['map']['mapped_locations'] )}: <span id="mapped" class="loading-spinner active"></span> | ${window.SHAREDFUNCTIONS.escapeHTML( window.list_settings['translations']['exports']['map']['without_locations'] )}: <span id="unmapped" class="loading-spinner active"></span> </span><br><br>
+        <span class="section-header"> ${window.SHAREDFUNCTIONS.escapeHTML(title)} | ${window.SHAREDFUNCTIONS.escapeHTML(window.list_settings['translations']['exports']['map']['mapped_locations'])}: <span id="mapped" class="loading-spinner active"></span> | ${window.SHAREDFUNCTIONS.escapeHTML(window.list_settings['translations']['exports']['map']['without_locations'])}: <span id="unmapped" class="loading-spinner active"></span> </span><br><br>
         <div id="dynamic-styles"></div>
         <div class="grid-x">
           <div class="cell medium-9" id="export_map_container">
@@ -3735,9 +4595,8 @@
         $(spinner).addClass('active');
 
         // Insert dynamic styles.
-        let map_content = jQuery('#dynamic-styles')
-        map_content
-          .append(`
+        let map_content = jQuery('#dynamic-styles');
+        map_content.append(`
             <style>
                 #map-wrapper {
                     height: ${window.innerHeight - 100}px !important;
@@ -3750,271 +4609,344 @@
           `);
 
         // Recursively fetch all filtered list posts, to be processed.
-        recursively_fetch_posts(0, 500, window.records_list['total'], [], function ( posts ) {
-          window.mapboxgl.accessToken = window.list_settings['translations']['exports']['map']['mapbox_key'];
-          var map = new window.mapboxgl.Map({
-            container: 'map',
-            style: 'mapbox://styles/mapbox/light-v10',
-            center: [-30, 20],
-            minZoom: 1,
-            zoom: 2
-          });
-
-          // Handle open zoomed map records button clicks.
-          $("#export_map_sidebar_menu_open_but").on("click", function (e) {
-            e.preventDefault();
-
-            // Obtain handle to current map bounds.
-            const bounds = map.getBounds();
-            const bounds_ne = bounds.getNorthEast();
-            const bounds_sw = bounds.getSouthWest();
-
-            // Build query based on current filter and identified map bounds.
-            let query = current_filter.query;
-            query["offset"] = 0;
-            query['limit'] = 500;
-            query['fields_to_return'] = [];
-            query['map_bounds'] = {
-              'ne': {
-                'lat': bounds_ne['lat'],
-                'lng': bounds_ne['lng']
-              },
-              'sw': {
-                'lat': bounds_sw['lat'],
-                'lng': bounds_sw['lng']
-              }
-            };
-
-            window.makeRequestOnPosts( 'POST', `${window.list_settings.post_type}/list`, JSON.parse(JSON.stringify(query)))
-            .promise()
-            .then(response => {
-              if ( response?.posts?.length > 0 ) {
-                items = response.posts || [];
-                window.records_list.posts = items // adds global access to current list for plugins
-                window.records_list.total = response.total
-
-                // save
-                if (Object.prototype.hasOwnProperty.call(response, 'posts') && response.posts.length > 0) {
-                  let records_list_ids_and_type = [];
-
-                  $.each(items, function(id, post_object ) {
-                    records_list_ids_and_type.push({ ID: post_object.ID });
-                  });
-
-                  window.SHAREDFUNCTIONS.save_json_cookie(`records_list`, records_list_ids_and_type, list_settings.post_type);
-                }
-
-                $('#bulk_edit_master_checkbox').prop("checked", false); //unchecks the bulk edit master checkbox when the list reloads.
-                $('#load-more').toggle(items.length !== parseInt( response.total ));
-                let result_text = list_settings.translations.txt_info.replace("_START_", items.length).replace("_TOTAL_", response.total);
-                $('.filter-result-text').html(result_text);
-                build_table(items);
-
-                // Generate corresponding custom filter.
-                reset_split_by_filters();
-                add_custom_filter(esc(window.list_settings.translations.exports.map['filter_name']), "custom-filter", query, new_filter_labels, false);
-
-                // Capture custom filter label and refresh ui.
-                current_filter['labels'] = [{
-                  'id': 'map',
-                  'name': esc(window.list_settings.translations.exports.map['filter_label'])
-                }];
-                setup_current_filter_labels();
-
-                // Persist updated custom filter url parameters.
-                update_url_query( current_filter );
-
-                // Reset vertical scrollbar to start position.
-                window.setTimeout(function() {
-                  $(window).scrollTop(0);
-                }, 0);
-
-                // Close modal window to display updated records list.
-                $('#modal-full').foundation('close');
-
-              } else {
-                alert(`${esc(window.list_settings.translations.exports.map['no_records_on_zoomed_map_alert'])}`);
-              }
-            })
-            .catch(error => {
-              console.log(error);
+        recursively_fetch_posts(
+          0,
+          500,
+          window.records_list['total'],
+          [],
+          function (posts) {
+            window.mapboxgl.accessToken =
+              window.list_settings['translations']['exports']['map'][
+                'mapbox_key'
+              ];
+            var map = new window.mapboxgl.Map({
+              container: 'map',
+              style: 'mapbox://styles/mapbox/light-v10',
+              center: [-30, 20],
+              minZoom: 1,
+              zoom: 2,
             });
-          });
 
-          // disable map rotation using right click + drag
-          map.dragRotate.disable();
-          map.touchZoomRotate.disableRotation();
+            // Handle open zoomed map records button clicks.
+            $('#export_map_sidebar_menu_open_but').on('click', function (e) {
+              e.preventDefault();
 
-          // load sources
-          map.on('load', function () {
-            let features = []
-            let mapped = 0
-            let unmapped = 0
-            $.each(posts, function(i,v){
-              if ( typeof v.location_grid_meta !== "undefined") {
-                features.push({
-                  'type': 'Feature',
-                  'geometry': {
-                    'type': 'Point',
-                    'coordinates': [v.location_grid_meta[0].lng, v.location_grid_meta[0].lat]
-                  },
-                  'properties': {
-                    'id': v.ID,
-                    'post_type': v.post_type,
-                    'title': v.post_title,
-                    'label': v.location_grid_meta[0].label
+              // Obtain handle to current map bounds.
+              const bounds = map.getBounds();
+              const bounds_ne = bounds.getNorthEast();
+              const bounds_sw = bounds.getSouthWest();
+
+              // Build query based on current filter and identified map bounds.
+              let query = current_filter.query;
+              query['offset'] = 0;
+              query['limit'] = 500;
+              query['fields_to_return'] = [];
+              query['map_bounds'] = {
+                ne: {
+                  lat: bounds_ne['lat'],
+                  lng: bounds_ne['lng'],
+                },
+                sw: {
+                  lat: bounds_sw['lat'],
+                  lng: bounds_sw['lng'],
+                },
+              };
+
+              window
+                .makeRequestOnPosts(
+                  'POST',
+                  `${window.list_settings.post_type}/list`,
+                  JSON.parse(JSON.stringify(query)),
+                )
+                .promise()
+                .then((response) => {
+                  if (response?.posts?.length > 0) {
+                    items = response.posts || [];
+                    window.records_list.posts = items; // adds global access to current list for plugins
+                    window.records_list.total = response.total;
+
+                    // save
+                    if (
+                      Object.prototype.hasOwnProperty.call(response, 'posts') &&
+                      response.posts.length > 0
+                    ) {
+                      let records_list_ids_and_type = [];
+
+                      $.each(items, function (id, post_object) {
+                        records_list_ids_and_type.push({ ID: post_object.ID });
+                      });
+
+                      window.SHAREDFUNCTIONS.save_json_cookie(
+                        `records_list`,
+                        records_list_ids_and_type,
+                        list_settings.post_type,
+                      );
+                    }
+
+                    $('#bulk_edit_master_checkbox').prop('checked', false); //unchecks the bulk edit master checkbox when the list reloads.
+                    $('#load-more').toggle(
+                      items.length !== parseInt(response.total),
+                    );
+                    let result_text = list_settings.translations.txt_info
+                      .replace('_START_', items.length)
+                      .replace('_TOTAL_', response.total);
+                    $('.filter-result-text').html(result_text);
+                    build_table(items);
+
+                    // Generate corresponding custom filter.
+                    reset_split_by_filters();
+                    add_custom_filter(
+                      esc(
+                        window.list_settings.translations.exports.map[
+                          'filter_name'
+                        ],
+                      ),
+                      'custom-filter',
+                      query,
+                      new_filter_labels,
+                      false,
+                    );
+
+                    // Capture custom filter label and refresh ui.
+                    current_filter['labels'] = [
+                      {
+                        id: 'map',
+                        name: esc(
+                          window.list_settings.translations.exports.map[
+                            'filter_label'
+                          ],
+                        ),
+                      },
+                    ];
+                    setup_current_filter_labels();
+
+                    // Persist updated custom filter url parameters.
+                    update_url_query(current_filter);
+
+                    // Reset vertical scrollbar to start position.
+                    window.setTimeout(function () {
+                      $(window).scrollTop(0);
+                    }, 0);
+
+                    // Close modal window to display updated records list.
+                    $('#modal-full').foundation('close');
+                  } else {
+                    alert(
+                      `${esc(window.list_settings.translations.exports.map['no_records_on_zoomed_map_alert'])}`,
+                    );
                   }
                 })
-                mapped++
-              }
-              else {
-                unmapped++
-              }
-            })
-
-            $('#mapped').html('(' + mapped + ')')
-            $('#unmapped').html('(' + unmapped + ')')
-
-            let geojson = {
-              'type': 'FeatureCollection',
-              'features': features
-            }
-
-            map.addSource('dt-records-source', {
-              'type': 'geojson',
-              'data': geojson,
-              'cluster': true,
-              'clusterMaxZoom': 14,
-              'clusterRadius': 50
+                .catch((error) => {
+                  console.log(error);
+                });
             });
 
-            const layer_color = '#' + (Math.random() * 0xFFFFFF << 0).toString(16).padStart(6, '0');
-            map.addLayer({
-              id: 'dt-records-clusters',
-              type: 'circle',
-              source: 'dt-records-source',
-              filter: ['has', 'point_count'],
-              paint: {
-                'circle-color': [
-                  'step',
-                  ['get', 'point_count'],
-                  layer_color,
-                  100,
-                  layer_color,
-                  750,
-                  layer_color
-                ],
-                'circle-radius': [
-                  'step',
-                  ['get', 'point_count'],
-                  20,
-                  100,
-                  30,
-                  750,
-                  40
-                ],
-                'circle-stroke-width': 2,
-                'circle-stroke-color': '#fff'
-              }
-            });
+            // disable map rotation using right click + drag
+            map.dragRotate.disable();
+            map.touchZoomRotate.disableRotation();
 
-            map.addLayer({
-              id: 'dt-records-clusters-count',
-              type: 'symbol',
-              source: 'dt-records-source',
-              filter: ['has', 'point_count'],
-              layout: {
-                'text-field': '{point_count_abbreviated}',
-                'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
-                'text-size': 12
-              }
-            });
-
-            map.addLayer({
-              id: 'dt-records-unclustered-points',
-              type: 'circle',
-              source: 'dt-records-source',
-              filter: ['!', ['has', 'point_count']],
-              paint: {
-                'circle-color': layer_color,
-                'circle-radius': 5,
-                'circle-stroke-width': 2,
-                'circle-stroke-color': '#fff'
-              }
-            });
-
-            map.on('click', () => {
-              render_map_feature_details(map, map.queryRenderedFeatures({
-                layers: ['dt-records-clusters', 'dt-records-unclustered-points']
-              }));
-            });
-            map.on('dragend', () => {
-              render_map_feature_details(map, map.queryRenderedFeatures({
-                layers: ['dt-records-clusters', 'dt-records-unclustered-points']
-              }));
-            });
-            map.on('zoomend', () => {
-              render_map_feature_details(map, map.queryRenderedFeatures({
-                layers: ['dt-records-clusters', 'dt-records-unclustered-points']
-              }));
-            });
-
-            map.on('mouseenter', 'dt-records-clusters', () => {
-              map.getCanvas().style.cursor = 'pointer';
-            });
-
-            map.on('mouseenter', 'dt-records-clusters-count', () => {
-              map.getCanvas().style.cursor = 'pointer';
-            });
-
-            map.on('mouseenter', 'dt-records-unclustered-points', () => {
-              map.getCanvas().style.cursor = 'pointer';
-            });
-
-            map.on('mouseleave', 'dt-records-clusters', () => {
-              map.getCanvas().style.cursor = '';
-            });
-
-            map.on('mouseleave', 'dt-records-clusters-count', () => {
-              map.getCanvas().style.cursor = '';
-            });
-
-            map.on('mouseleave', 'dt-records-unclustered-points', () => {
-              map.getCanvas().style.cursor = '';
-            });
-
-            // To avoid unwanted exceptions, ensure valid features are available, prior to rendering.
-            if (geojson.features && geojson.features.length > 0) {
-              var bounds = new window.mapboxgl.LngLatBounds();
-              geojson.features.forEach(function(feature) {
-                if ( feature.geometry.coordinates && !feature.geometry.coordinates.includes(undefined) ) {
-                  bounds.extend(feature.geometry.coordinates);
+            // load sources
+            map.on('load', function () {
+              let features = [];
+              let mapped = 0;
+              let unmapped = 0;
+              $.each(posts, function (i, v) {
+                if (typeof v.location_grid_meta !== 'undefined') {
+                  features.push({
+                    type: 'Feature',
+                    geometry: {
+                      type: 'Point',
+                      coordinates: [
+                        v.location_grid_meta[0].lng,
+                        v.location_grid_meta[0].lat,
+                      ],
+                    },
+                    properties: {
+                      id: v.ID,
+                      post_type: v.post_type,
+                      title: v.post_title,
+                      label: v.location_grid_meta[0].label,
+                    },
+                  });
+                  mapped++;
+                } else {
+                  unmapped++;
                 }
               });
-              map.fitBounds(bounds);
 
-              // Display initial feature details.
-              const details_panel = $('#export_map_sidebar_menu_details_panel');
-              const map_height = $(map.getContainer()).height();
-              $(details_panel).css('height', (map_height - 100) + 'px');
-              $(details_panel).css('min-height', (map_height - 100) + 'px');
-              $(details_panel).css('max-height', (map_height - 100) + 'px');
-              render_map_feature_details(map.queryRenderedFeatures({
-                layers: ['dt-records-clusters', 'dt-records-unclustered-points']
-              }));
-            }
+              $('#mapped').html('(' + mapped + ')');
+              $('#unmapped').html('(' + unmapped + ')');
 
-            // Hide spinners.
-            $(spinner).removeClass('active');
-          });
-        });
+              let geojson = {
+                type: 'FeatureCollection',
+                features: features,
+              };
+
+              map.addSource('dt-records-source', {
+                type: 'geojson',
+                data: geojson,
+                cluster: true,
+                clusterMaxZoom: 14,
+                clusterRadius: 50,
+              });
+
+              const layer_color =
+                '#' +
+                ((Math.random() * 0xffffff) << 0).toString(16).padStart(6, '0');
+              map.addLayer({
+                id: 'dt-records-clusters',
+                type: 'circle',
+                source: 'dt-records-source',
+                filter: ['has', 'point_count'],
+                paint: {
+                  'circle-color': [
+                    'step',
+                    ['get', 'point_count'],
+                    layer_color,
+                    100,
+                    layer_color,
+                    750,
+                    layer_color,
+                  ],
+                  'circle-radius': [
+                    'step',
+                    ['get', 'point_count'],
+                    20,
+                    100,
+                    30,
+                    750,
+                    40,
+                  ],
+                  'circle-stroke-width': 2,
+                  'circle-stroke-color': '#fff',
+                },
+              });
+
+              map.addLayer({
+                id: 'dt-records-clusters-count',
+                type: 'symbol',
+                source: 'dt-records-source',
+                filter: ['has', 'point_count'],
+                layout: {
+                  'text-field': '{point_count_abbreviated}',
+                  'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
+                  'text-size': 12,
+                },
+              });
+
+              map.addLayer({
+                id: 'dt-records-unclustered-points',
+                type: 'circle',
+                source: 'dt-records-source',
+                filter: ['!', ['has', 'point_count']],
+                paint: {
+                  'circle-color': layer_color,
+                  'circle-radius': 5,
+                  'circle-stroke-width': 2,
+                  'circle-stroke-color': '#fff',
+                },
+              });
+
+              map.on('click', () => {
+                render_map_feature_details(
+                  map,
+                  map.queryRenderedFeatures({
+                    layers: [
+                      'dt-records-clusters',
+                      'dt-records-unclustered-points',
+                    ],
+                  }),
+                );
+              });
+              map.on('dragend', () => {
+                render_map_feature_details(
+                  map,
+                  map.queryRenderedFeatures({
+                    layers: [
+                      'dt-records-clusters',
+                      'dt-records-unclustered-points',
+                    ],
+                  }),
+                );
+              });
+              map.on('zoomend', () => {
+                render_map_feature_details(
+                  map,
+                  map.queryRenderedFeatures({
+                    layers: [
+                      'dt-records-clusters',
+                      'dt-records-unclustered-points',
+                    ],
+                  }),
+                );
+              });
+
+              map.on('mouseenter', 'dt-records-clusters', () => {
+                map.getCanvas().style.cursor = 'pointer';
+              });
+
+              map.on('mouseenter', 'dt-records-clusters-count', () => {
+                map.getCanvas().style.cursor = 'pointer';
+              });
+
+              map.on('mouseenter', 'dt-records-unclustered-points', () => {
+                map.getCanvas().style.cursor = 'pointer';
+              });
+
+              map.on('mouseleave', 'dt-records-clusters', () => {
+                map.getCanvas().style.cursor = '';
+              });
+
+              map.on('mouseleave', 'dt-records-clusters-count', () => {
+                map.getCanvas().style.cursor = '';
+              });
+
+              map.on('mouseleave', 'dt-records-unclustered-points', () => {
+                map.getCanvas().style.cursor = '';
+              });
+
+              // To avoid unwanted exceptions, ensure valid features are available, prior to rendering.
+              if (geojson.features && geojson.features.length > 0) {
+                var bounds = new window.mapboxgl.LngLatBounds();
+                geojson.features.forEach(function (feature) {
+                  if (
+                    feature.geometry.coordinates &&
+                    !feature.geometry.coordinates.includes(undefined)
+                  ) {
+                    bounds.extend(feature.geometry.coordinates);
+                  }
+                });
+                map.fitBounds(bounds);
+
+                // Display initial feature details.
+                const details_panel = $(
+                  '#export_map_sidebar_menu_details_panel',
+                );
+                const map_height = $(map.getContainer()).height();
+                $(details_panel).css('height', map_height - 100 + 'px');
+                $(details_panel).css('min-height', map_height - 100 + 'px');
+                $(details_panel).css('max-height', map_height - 100 + 'px');
+                render_map_feature_details(
+                  map.queryRenderedFeatures({
+                    layers: [
+                      'dt-records-clusters',
+                      'dt-records-unclustered-points',
+                    ],
+                  }),
+                );
+              }
+
+              // Hide spinners.
+              $(spinner).removeClass('active');
+            });
+          },
+        );
       });
     }
   });
 
   function render_map_feature_details(map, features) {
     if (features) {
-
       // First, reset details html.
       const details_table = $('#export_map_sidebar_menu_details_panel_table');
       $(details_table).html(`<tbody></tbody>`);
@@ -4040,24 +4972,34 @@
       const point_count = cluster?.properties.point_count;
 
       if (cluster_source && cluster_id && point_count) {
-
         // Get all points under given cluster.
-        cluster_source.getClusterLeaves(cluster_id, point_count, 0, function (err, features) {
-
-          // Ensure feature is a valid sought after record.
-          features.forEach(function (feature) {
-            let feature_html = render_map_feature_details_point_html(feature);
-            if (feature_html) {
-              $('#export_map_sidebar_menu_details_panel_table').find(`tbody`).append(feature_html);
-            }
-          });
-        });
+        cluster_source.getClusterLeaves(
+          cluster_id,
+          point_count,
+          0,
+          function (err, features) {
+            // Ensure feature is a valid sought after record.
+            features.forEach(function (feature) {
+              let feature_html = render_map_feature_details_point_html(feature);
+              if (feature_html) {
+                $('#export_map_sidebar_menu_details_panel_table')
+                  .find(`tbody`)
+                  .append(feature_html);
+              }
+            });
+          },
+        );
       }
     }
   }
 
   function render_map_feature_details_point_html(feature) {
-    if (feature?.properties?.id && feature?.properties?.post_type && feature?.properties?.title && feature?.properties?.label) {
+    if (
+      feature?.properties?.id &&
+      feature?.properties?.post_type &&
+      feature?.properties?.title &&
+      feature?.properties?.label
+    ) {
       return `<tr><td><a target="_blank" href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/${window.SHAREDFUNCTIONS.escapeHTML(feature?.properties?.post_type)}/${window.SHAREDFUNCTIONS.escapeHTML(feature?.properties?.id)}">${window.SHAREDFUNCTIONS.escapeHTML(feature?.properties?.title)}</a> <span style="color: #808080;">${window.SHAREDFUNCTIONS.escapeHTML(feature?.properties?.label)}</span></td></tr>`;
     }
 
@@ -4067,5 +5009,4 @@
   /**
    * List Exports
    */
-
 })(window.jQuery, window.list_settings, window.Foundation);

--- a/dt-assets/js/new-record.js
+++ b/dt-assets/js/new-record.js
@@ -1,32 +1,33 @@
-jQuery(function($) {
-  window.post_type_fields = window.new_record_localized.post_type_settings.fields
-  let new_post = {}
-  let temp_type = $('.type-options .selected').attr('id')
-  if ( temp_type ){
+jQuery(function ($) {
+  window.post_type_fields =
+    window.new_record_localized.post_type_settings.fields;
+  let new_post = {};
+  let temp_type = $('.type-options .selected').attr('id');
+  if (temp_type) {
     new_post.type = temp_type;
   }
-  document.querySelector('.form-fields input').focus()
-  $('.type-option').on('click', function(){
-    let type = $(this).attr('id')
-    $('.type-option.selected').removeClass('selected')
-    $(this).addClass('selected')
-    $(`#${type} input`).prop('checked', true)
+  document.querySelector('.form-fields input').focus();
+  $('.type-option').on('click', function () {
+    let type = $(this).attr('id');
+    $('.type-option.selected').removeClass('selected');
+    $(this).addClass('selected');
+    $(`#${type} input`).prop('checked', true);
     $('.form-fields').show();
-    $(`.form-field`).hide()
-    $(`.form-field.all`).show()
-    $(`.form-field.${type}`).show()
-    $('#show-shield-banner').show()
+    $(`.form-field`).hide();
+    $(`.form-field.all`).show();
+    $(`.form-field.${type}`).show();
+    $('#show-shield-banner').show();
     $('#show-hidden-fields').show();
     $('#hide-hidden-fields').hide();
-    new_post.type = type
+    new_post.type = type;
     /* Focus first field in form */
-    document.querySelector('.form-fields input').focus()
-  })
-  $('#show-hidden-fields').on('click', function (){
-    $('.form-field').show()
-    $('#show-hidden-fields').hide()
+    document.querySelector('.form-fields input').focus();
+  });
+  $('#show-hidden-fields').on('click', function () {
+    $('.form-field').show();
+    $('#show-hidden-fields').hide();
     $('#hide-hidden-fields').show();
-  })
+  });
   $('#hide-hidden-fields').on('click', function () {
     $('.form-field').hide();
     $(`.form-field.all`).show();
@@ -35,138 +36,149 @@ jQuery(function($) {
     $('#show-hidden-fields').show();
   });
 
-  $(".js-create-post-button").removeAttr("disabled");
+  $('.js-create-post-button').removeAttr('disabled');
 
   // Clicking the plus sign next to the field label
-  $('button.add-button').on('click', e => {
-    const listClass = $(e.currentTarget).data('list-class')
-    const $list = $(`#edit-${listClass}`)
-    const field = $(e.currentTarget).data('list-class')
-    const fieldName = window.new_record_localized.post_type_settings.fields[field].name
-    const fieldType = $(e.currentTarget).data('field-type')
-    var elementIndex = $(`input[data-${field}-index]`).length
+  $('button.add-button').on('click', (e) => {
+    const listClass = $(e.currentTarget).data('list-class');
+    const $list = $(`#edit-${listClass}`);
+    const field = $(e.currentTarget).data('list-class');
+    const fieldName =
+      window.new_record_localized.post_type_settings.fields[field].name;
+    const fieldType = $(e.currentTarget).data('field-type');
+    var elementIndex = $(`input[data-${field}-index]`).length;
 
     if (fieldType === 'link') {
-      const addLinkForm = $(`.add-link-${field}`)
-      addLinkForm.show()
+      const addLinkForm = $(`.add-link-${field}`);
+      addLinkForm.show();
 
-      $(`#cancel-link-button-${field}`).on('click', () => addLinkForm.hide())
+      $(`#cancel-link-button-${field}`).on('click', () => addLinkForm.hide());
     } else {
       $list.append(`<li style="display: flex">
-                <input type="text" class="dt-communication-channel" data-field="${window.SHAREDFUNCTIONS.escapeHTML( listClass )}" data-${field}-index="${window.SHAREDFUNCTIONS.escapeHTML( elementIndex )}"/>
-                <button class="button clear delete-button new-${window.SHAREDFUNCTIONS.escapeHTML( listClass )}" type="button" data-${field}-index="${elementIndex}">
-                    <img src="${window.SHAREDFUNCTIONS.escapeHTML( window.wpApiShare.template_dir )}/dt-assets/images/invalid.svg">
+                <input type="text" class="dt-communication-channel" data-field="${window.SHAREDFUNCTIONS.escapeHTML(listClass)}" data-${field}-index="${window.SHAREDFUNCTIONS.escapeHTML(elementIndex)}"/>
+                <button class="button clear delete-button new-${window.SHAREDFUNCTIONS.escapeHTML(listClass)}" type="button" data-${field}-index="${elementIndex}">
+                    <img src="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.template_dir)}/dt-assets/images/invalid.svg">
                 </button>
-                <span class="loading-spinner" data-${field}-index="${window.SHAREDFUNCTIONS.escapeHTML( elementIndex )}" style="margin: 0.5rem;"></span>
+                <span class="loading-spinner" data-${field}-index="${window.SHAREDFUNCTIONS.escapeHTML(elementIndex)}" style="margin: 0.5rem;"></span>
               </li>
-              <div class="communication-channel-error" data-${field}-index="${window.SHAREDFUNCTIONS.escapeHTML( elementIndex )}" style="display: none;">
+              <div class="communication-channel-error" data-${field}-index="${window.SHAREDFUNCTIONS.escapeHTML(elementIndex)}" style="display: none;">
                 ${window.new_record_localized.translations.value_already_exists.replace('%s', fieldName)}:
-                <span class="duplicate-ids" data-${field}-index="${window.SHAREDFUNCTIONS.escapeHTML( elementIndex )}" style="color: #3f729b;"></span>
-              </div>`)
+                <span class="duplicate-ids" data-${field}-index="${window.SHAREDFUNCTIONS.escapeHTML(elementIndex)}" style="color: #3f729b;"></span>
+              </div>`);
     }
-  })
+  });
 
   /* breadcrumb: new-field-type Add anything that the field type needs for creating a new record */
 
-  $('.add-link-dropdown[data-only-one-option]').on('click', window.SHAREDFUNCTIONS.addLink)
+  $('.add-link-dropdown[data-only-one-option]').on(
+    'click',
+    window.SHAREDFUNCTIONS.addLink,
+  );
 
   $('.add-link__option').on('click', (event) => {
-    window.SHAREDFUNCTIONS.addLink(event)
-    $(event.target).parent().hide()
+    window.SHAREDFUNCTIONS.addLink(event);
+    $(event.target).parent().hide();
     setTimeout(() => {
-      event.target.parentElement.removeAttribute('style')
-    }, 100)
-  })
+      event.target.parentElement.removeAttribute('style');
+    }, 100);
+  });
 
-  $(document).on('click', '.link-delete-button', function(){
-    $(this).closest('.link-section').remove()
-  })
+  $(document).on('click', '.link-delete-button', function () {
+    $(this).closest('.link-section').remove();
+  });
 
   $('.js-create-post').on('click', '.delete-button', function () {
-    var field_type = $(this).prev('input').data('field')
-    var element_index = $(this).data(`${field_type}-index`)
-    console.log(field_type, element_index)
-    $(`.communication-channel-error[data-${field_type}-index="${element_index}"]`).remove()
-    $(this).parent().remove()
-  })
+    var field_type = $(this).prev('input').data('field');
+    var element_index = $(this).data(`${field_type}-index`);
+    console.log(field_type, element_index);
+    $(
+      `.communication-channel-error[data-${field_type}-index="${element_index}"]`,
+    ).remove();
+    $(this).parent().remove();
+  });
 
   /* breadcrumb: new-field-type Add the new link type data to the new_post array */
-  $(".js-create-post").on("submit", function() {
-    $(".js-create-post-button")
-    .attr("disabled", true)
-    .addClass("loading");
-    new_post.title = $(".js-create-post input[name=title]").val()
-    $('.select-field').each((index, entry)=>{
-      if ( $(entry).val() ){
-        new_post[$(entry).attr('id')] = $(entry).val()
+  $('.js-create-post').on('submit', function () {
+    $('.js-create-post-button').attr('disabled', true).addClass('loading');
+    new_post.title = $('.js-create-post input[name=title]').val();
+    $('.select-field').each((index, entry) => {
+      if ($(entry).val()) {
+        new_post[$(entry).attr('id')] = $(entry).val();
       }
-    })
-    $('.text-input').each((index, entry)=>{
-      if ( $(entry).val() ){
-        new_post[$(entry).attr('id')] = $(entry).val()
+    });
+    $('.text-input').each((index, entry) => {
+      if ($(entry).val()) {
+        new_post[$(entry).attr('id')] = $(entry).val();
       }
-    })
+    });
     $('.link-input').each((index, entry) => {
-      let fieldKey = $(entry).data('field-key')
-      let type = $(entry).data('type')
-      if ( $(entry).val() ){
-        if ( !Object.prototype.hasOwnProperty.call( new_post, fieldKey ) ) {
-          new_post[fieldKey] = { values: [] }
+      let fieldKey = $(entry).data('field-key');
+      let type = $(entry).data('type');
+      if ($(entry).val()) {
+        if (!Object.prototype.hasOwnProperty.call(new_post, fieldKey)) {
+          new_post[fieldKey] = { values: [] };
         }
-        new_post[fieldKey].values.push( {
+        new_post[fieldKey].values.push({
           value: $(entry).val(),
           type: type,
-        } )
-      }
-    })
-    $('.dt_textarea').each((index, entry)=>{
-      if ( $(entry).val() ){
-        new_post[$(entry).attr('id')] = $(entry).val()
+        });
       }
     });
-    $('.dt-communication-channel').each((index, entry)=>{
-      let val = $(entry).val()
-      if ( val.length > 0 ){
-        let channel = $(entry).data('field')
-        if ( !new_post[channel]){
-          new_post[channel] =[]
+    $('.dt_textarea').each((index, entry) => {
+      if ($(entry).val()) {
+        new_post[$(entry).attr('id')] = $(entry).val();
+      }
+    });
+    $('.dt-communication-channel').each((index, entry) => {
+      let val = $(entry).val();
+      if (val.length > 0) {
+        let channel = $(entry).data('field');
+        if (!new_post[channel]) {
+          new_post[channel] = [];
         }
         new_post[channel].push({
-          value: $(entry).val()
-        })
+          value: $(entry).val(),
+        });
       }
-    })
-    $('.selected-select-button').each((index, entry)=>{
-      let optionKey = $(entry).attr('id')
-      let fieldKey = $(entry).data("field-key")
-      if ( !new_post[fieldKey]){
-        new_post[fieldKey] = {values:[]};
+    });
+    $('.selected-select-button').each((index, entry) => {
+      let optionKey = $(entry).attr('id');
+      let fieldKey = $(entry).data('field-key');
+      if (!new_post[fieldKey]) {
+        new_post[fieldKey] = { values: [] };
       }
       new_post[fieldKey].values.push({
-        "value": optionKey
-      })
-    })
-    if ( typeof window.selected_location_grid_meta !== 'undefined' ){
-      new_post['location_grid_meta'] = window.selected_location_grid_meta.location_grid_meta
+        value: optionKey,
+      });
+    });
+    if (typeof window.selected_location_grid_meta !== 'undefined') {
+      new_post['location_grid_meta'] =
+        window.selected_location_grid_meta.location_grid_meta;
     }
 
-
-    window.API.create_post( window.new_record_localized.post_type, new_post).promise().then(function(data) {
-      window.location = data.permalink;
-    }).catch(function(error) {
-      const message = error.responseJSON?.message || error.responseText
-      $(".js-create-post-button").removeClass("loading").addClass("alert").attr("disabled", false)
-      $(".error-text").html(message);
-    });
+    window.API.create_post(window.new_record_localized.post_type, new_post)
+      .promise()
+      .then(function (data) {
+        window.location = data.permalink;
+      })
+      .catch(function (error) {
+        const message = error.responseJSON?.message || error.responseText;
+        $('.js-create-post-button')
+          .removeClass('loading')
+          .addClass('alert')
+          .attr('disabled', false);
+        $('.error-text').html(message);
+      });
     return false;
   });
 
-  let field_settings = window.new_record_localized.post_type_settings.fields
+  let field_settings = window.new_record_localized.post_type_settings.fields;
 
   function date_picker_init(is_bulk = false, bulk_id = 0) {
-
     // Determine field class name to be used.
-    let field_class = (!is_bulk) ? `.dt_date_picker` : `.dt_date_picker-${bulk_id}`;
+    let field_class = !is_bulk
+      ? `.dt_date_picker`
+      : `.dt_date_picker-${bulk_id}`;
 
     // Assign on click listener.
     $(field_class).datepicker({
@@ -175,12 +187,14 @@ jQuery(function($) {
       onClose: function (date) {
         date = window.SHAREDFUNCTIONS.convertArabicToEnglishNumbers(date);
         if (!$(this).val()) {
-          date = " ";//null;
+          date = ' '; //null;
         }
-        let id = $(this).attr('id')
-        new_post[id] = date
+        let id = $(this).attr('id');
+        new_post[id] = date;
         if (this.value) {
-          this.value = window.SHAREDFUNCTIONS.formatDate(window.moment.utc(date).unix());
+          this.value = window.SHAREDFUNCTIONS.formatDate(
+            window.moment.utc(date).unix(),
+          );
         }
 
         // If bulk related, capture epoch
@@ -190,45 +204,44 @@ jQuery(function($) {
       },
       changeMonth: true,
       changeYear: true,
-      yearRange: "1900:2050",
+      yearRange: '1900:2050',
     });
   }
 
   function button_multi_select_init(is_bulk = false, bulk_id = 0) {
-
     // Determine field class name to be used.
-    let field_class = (!is_bulk) ? `.dt_multi_select` : `.dt_multi_select-${bulk_id}`;
+    let field_class = !is_bulk
+      ? `.dt_multi_select`
+      : `.dt_multi_select-${bulk_id}`;
 
     // Assign on click listener.
     $(field_class).on('click', function () {
-
       let field = $(this);
 
-      if (field.hasClass("selected-select-button")) {
-        field.addClass("empty-select-button")
-        field.removeClass("selected-select-button")
+      if (field.hasClass('selected-select-button')) {
+        field.addClass('empty-select-button');
+        field.removeClass('selected-select-button');
       } else {
-        field.removeClass("empty-select-button")
-        field.addClass("selected-select-button")
+        field.removeClass('empty-select-button');
+        field.addClass('selected-select-button');
       }
-
     });
   }
 
   function typeahead_general_init(is_bulk = false, bulk_id = 0) {
-    $(".typeahead__query input").each((key, el)=>{
-      let field_key = $(el).data('field')
-      let post_type = $(el).data('post_type')
-      let field_type = $(el).data('field_type')
-      window.typeaheadTotals = {}
+    $('.typeahead__query input').each((key, el) => {
+      let field_key = $(el).data('field');
+      let post_type = $(el).data('post_type');
+      let field_type = $(el).data('field_type');
+      window.typeaheadTotals = {};
 
       // Determine field class name to be used.
-      let field_class = (!is_bulk) ? `.js-typeahead-${field_key}` : `.js-typeahead-${field_key}-${bulk_id}`;
+      let field_class = !is_bulk
+        ? `.js-typeahead-${field_key}`
+        : `.js-typeahead-${field_key}-${bulk_id}`;
 
       if (!window.Typeahead[field_class]) {
-
-        if ( field_type === "connection"){
-
+        if (field_type === 'connection') {
           $.typeahead({
             input: field_class,
             minLength: 0,
@@ -236,134 +249,175 @@ jQuery(function($) {
             searchOnFocus: true,
             maxItem: 20,
             template: window.TYPEAHEADS.contactListRowTemplate,
-            source: window.TYPEAHEADS.typeaheadPostsSource(post_type, field_key),
-            display: ["name", "label"],
-            templateValue: function() {
+            source: window.TYPEAHEADS.typeaheadPostsSource(
+              post_type,
+              field_key,
+            ),
+            display: ['name', 'label'],
+            templateValue: function () {
               if (this.items[this.items.length - 1].label) {
-                return "{{label}}"
+                return '{{label}}';
               } else {
-                return "{{name}}"
+                return '{{name}}';
               }
             },
             dynamic: true,
             multiselect: {
-              matchOn: ["ID"],
+              matchOn: ['ID'],
               data: [],
               callback: {
                 onCancel: function (node, item) {
                   if (!is_bulk) {
-                    window.lodash.pullAllBy(new_post[field_key].values, [{value: item.ID}], "value");
+                    window.lodash.pullAllBy(
+                      new_post[field_key].values,
+                      [{ value: item.ID }],
+                      'value',
+                    );
                   }
-                }
-              }
+                },
+              },
             },
             callback: {
               onResult: function (node, query, result, resultCount) {
-                let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+                let text = window.TYPEAHEADS.typeaheadHelpText(
+                  resultCount,
+                  query,
+                  result,
+                );
                 $(`#${field_key}-result-container`).html(text);
               },
               onHideLayout: function () {
-                $(`#${field_key}-result-container`).html("");
+                $(`#${field_key}-result-container`).html('');
               },
-              onClick: function (node, a, item, event ) {
+              onClick: function (node, a, item, event) {
                 if (!is_bulk) {
                   if (!new_post[field_key]) {
-                    new_post[field_key] = {values: []}
+                    new_post[field_key] = { values: [] };
                   }
-                  new_post[field_key].values.push({value: item.ID})
+                  new_post[field_key].values.push({ value: item.ID });
                 }
                 //get list from opening again
-                this.addMultiselectItemLayout(item)
-                event.preventDefault()
+                this.addMultiselectItemLayout(item);
+                event.preventDefault();
                 this.hideLayout();
                 this.resetInput();
-              }
-            }
+              },
+            },
           });
-        } else if ( field_type === "location" ){
+        } else if (field_type === 'location') {
           $.typeahead({
             input: field_class,
             minLength: 0,
             accent: true,
             searchOnFocus: true,
             maxItem: 20,
-            dropdownFilter: [{
-              key: 'group',
-              value: 'focus',
-              template: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.regions_of_focus),
-              all: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.all_locations),
-            }],
+            dropdownFilter: [
+              {
+                key: 'group',
+                value: 'focus',
+                template: window.SHAREDFUNCTIONS.escapeHTML(
+                  window.wpApiShare.translations.regions_of_focus,
+                ),
+                all: window.SHAREDFUNCTIONS.escapeHTML(
+                  window.wpApiShare.translations.all_locations,
+                ),
+              },
+            ],
             source: {
               focus: {
-                display: "name",
+                display: 'name',
                 ajax: {
-                  url: window.wpApiShare.root + 'dt/v1/mapping_module/search_location_grid_by_name',
+                  url:
+                    window.wpApiShare.root +
+                    'dt/v1/mapping_module/search_location_grid_by_name',
                   data: {
-                    s: "{{query}}",
+                    s: '{{query}}',
                     filter: function () {
-                      return window.lodash.get(window.Typeahead[field_class].filters.dropdown, 'value', 'all')
-                    }
+                      return window.lodash.get(
+                        window.Typeahead[field_class].filters.dropdown,
+                        'value',
+                        'all',
+                      );
+                    },
                   },
                   beforeSend: function (xhr) {
                     xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce);
                   },
                   callback: {
                     done: function (data) {
-                      if (typeof window.typeaheadTotals !== "undefined") {
-                        window.typeaheadTotals.field = data.total
+                      if (typeof window.typeaheadTotals !== 'undefined') {
+                        window.typeaheadTotals.field = data.total;
                       }
-                      return data.location_grid
-                    }
-                  }
-                }
-              }
+                      return data.location_grid;
+                    },
+                  },
+                },
+              },
             },
-            display: "name",
-            templateValue: "{{name}}",
+            display: 'name',
+            templateValue: '{{name}}',
             dynamic: true,
             multiselect: {
-              matchOn: ["ID"],
+              matchOn: ['ID'],
               data: [],
               callback: {
                 onCancel: function (node, item) {
                   if (!is_bulk) {
-                    window.lodash.pullAllBy(new_post[field_key].values, [{value: item.ID}], "value");
+                    window.lodash.pullAllBy(
+                      new_post[field_key].values,
+                      [{ value: item.ID }],
+                      'value',
+                    );
                   }
-                }
-              }
+                },
+              },
             },
             callback: {
-              onClick: function(node, a, item, event){
+              onClick: function (node, a, item, event) {
                 if (!is_bulk) {
                   if (!new_post[field_key]) {
-                    new_post[field_key] = {values: []}
+                    new_post[field_key] = { values: [] };
                   }
-                  new_post[field_key].values.push({value: item.ID})
+                  new_post[field_key].values.push({ value: item.ID });
                 }
                 //get list from opening again
-                this.addMultiselectItemLayout(item)
-                event.preventDefault()
+                this.addMultiselectItemLayout(item);
+                event.preventDefault();
                 this.hideLayout();
                 this.resetInput();
               },
-              onReady(){
-                this.filters.dropdown = {key: "group", value: "focus", template: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.regions_of_focus)}
+              onReady() {
+                this.filters.dropdown = {
+                  key: 'group',
+                  value: 'focus',
+                  template: window.SHAREDFUNCTIONS.escapeHTML(
+                    window.wpApiShare.translations.regions_of_focus,
+                  ),
+                };
                 this.container
-                  .removeClass("filter")
-                  .find("." + this.options.selector.filterButton)
-                  .html(window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.regions_of_focus));
+                  .removeClass('filter')
+                  .find('.' + this.options.selector.filterButton)
+                  .html(
+                    window.SHAREDFUNCTIONS.escapeHTML(
+                      window.wpApiShare.translations.regions_of_focus,
+                    ),
+                  );
               },
               onResult: function (node, query, result, resultCount) {
-                resultCount = window.typeaheadTotals.location_grid
-                let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+                resultCount = window.typeaheadTotals.location_grid;
+                let text = window.TYPEAHEADS.typeaheadHelpText(
+                  resultCount,
+                  query,
+                  result,
+                );
                 $('#location_grid-result-container').html(text);
               },
               onHideLayout: function () {
-                $('#location_grid-result-container').html("");
-              }
-            }
+                $('#location_grid-result-container').html('');
+              },
+            },
           });
-        } else if ( field_type === "user_select" ){
+        } else if (field_type === 'user_select') {
           $.typeahead({
             input: field_class,
             minLength: 0,
@@ -371,44 +425,54 @@ jQuery(function($) {
             accent: true,
             searchOnFocus: true,
             source: window.TYPEAHEADS.typeaheadUserSource(),
-            templateValue: "{{name}}",
+            templateValue: '{{name}}',
             template: function (query, item) {
               return `<div class="assigned-to-row" dir="auto">
               <span>
                   <span class="avatar"><img style="vertical-align: text-bottom" src="{{avatar}}"/></span>
-                  ${window.SHAREDFUNCTIONS.escapeHTML( item.name )}
+                  ${window.SHAREDFUNCTIONS.escapeHTML(item.name)}
               </span>
-              ${ item.status_color ? `<span class="status-square" style="background-color: ${window.SHAREDFUNCTIONS.escapeHTML(item.status_color)};">&nbsp;</span>` : '' }
-              ${ item.update_needed && item.update_needed > 0 ? `<span>
-                <img style="height: 12px;" src="${window.SHAREDFUNCTIONS.escapeHTML( window.wpApiShare.template_dir )}/dt-assets/images/broken.svg"/>
+              ${item.status_color ? `<span class="status-square" style="background-color: ${window.SHAREDFUNCTIONS.escapeHTML(item.status_color)};">&nbsp;</span>` : ''}
+              ${
+                item.update_needed && item.update_needed > 0
+                  ? `<span>
+                <img style="height: 12px;" src="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.template_dir)}/dt-assets/images/broken.svg"/>
                 <span style="font-size: 14px">${window.SHAREDFUNCTIONS.escapeHTML(item.update_needed)}</span>
-              </span>` : '' }
-            </div>`
+              </span>`
+                  : ''
+              }
+            </div>`;
             },
             dynamic: true,
             hint: true,
-            emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.no_records_found),
+            emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(
+              window.wpApiShare.translations.no_records_found,
+            ),
             callback: {
-              onClick: function(node, a, item){
+              onClick: function (node, a, item) {
                 if (!is_bulk) {
                   new_post[field_key] = item.ID;
                 }
               },
               onResult: function (node, query, result, resultCount) {
-                let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+                let text = window.TYPEAHEADS.typeaheadHelpText(
+                  resultCount,
+                  query,
+                  result,
+                );
                 $(`#${field_key}-result-container`).html(text);
               },
               onHideLayout: function () {
-                $(`.${field_key}-result-container`).html("");
-              }
+                $(`.${field_key}-result-container`).html('');
+              },
             },
           });
-          let user_input = $(`.js-typeahead-${field_key}`)
+          let user_input = $(`.js-typeahead-${field_key}`);
           $(`.search_${field_key}`).on('click', function () {
-            user_input.val("")
-            user_input.trigger('input.typeahead')
-            user_input.focus()
-          })
+            user_input.val('');
+            user_input.trigger('input.typeahead');
+            user_input.focus();
+          });
         }
       }
     });
@@ -416,51 +480,63 @@ jQuery(function($) {
 
   function typeahead_multi_select_init(is_bulk = false, bulk_id = 0) {
     //multi-select typeaheads
-    for (let input of $(".multi_select .typeahead__query input")) {
-      let field = $(input).data('field')
-      let typeahead_name = (!is_bulk) ? `.js-typeahead-${field}` : `.js-typeahead-${field}-${bulk_id}`;
-      const post_type = window.new_record_localized.post_type
+    for (let input of $('.multi_select .typeahead__query input')) {
+      let field = $(input).data('field');
+      let typeahead_name = !is_bulk
+        ? `.js-typeahead-${field}`
+        : `.js-typeahead-${field}-${bulk_id}`;
+      const post_type = window.new_record_localized.post_type;
 
       if (window.Typeahead[typeahead_name]) {
-        return
+        return;
       }
 
-      let source_data = {data: []}
-      let field_options = window.lodash.get(field_settings, `${field}.default`, {})
+      let source_data = { data: [] };
+      let field_options = window.lodash.get(
+        field_settings,
+        `${field}.default`,
+        {},
+      );
       if (Object.keys(field_options).length > 0) {
         window.lodash.forOwn(field_options, (val, key) => {
           if (!val.deleted) {
             source_data.data.push({
               key: key,
               name: key,
-              value: val.label || key
-            })
+              value: val.label || key,
+            });
           }
-        })
+        });
       } else {
         source_data = {
           [field]: {
-            display: ["value"],
+            display: ['value'],
             ajax: {
-              url: window.wpApiShare.root + `dt-posts/v2/${post_type}/multi-select-values`,
+              url:
+                window.wpApiShare.root +
+                `dt-posts/v2/${post_type}/multi-select-values`,
               data: {
-                s: "{{query}}",
-                field
+                s: '{{query}}',
+                field,
               },
               beforeSend: function (xhr) {
                 xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce);
               },
               callback: {
                 done: function (data) {
-                  return (data || []).map(tag => {
-                    let label = window.lodash.get(field_options, tag + ".label", tag)
-                    return {value: label, key: tag}
-                  })
-                }
-              }
-            }
-          }
-        }
+                  return (data || []).map((tag) => {
+                    let label = window.lodash.get(
+                      field_options,
+                      tag + '.label',
+                      tag,
+                    );
+                    return { value: label, key: tag };
+                  });
+                },
+              },
+            },
+          },
+        };
       }
       $.typeahead({
         input: typeahead_name,
@@ -468,48 +544,55 @@ jQuery(function($) {
         maxItem: 20,
         searchOnFocus: true,
         template: function (query, item) {
-          return `<span>${window.SHAREDFUNCTIONS.escapeHTML(item.value)}</span>`
+          return `<span>${window.SHAREDFUNCTIONS.escapeHTML(item.value)}</span>`;
         },
         source: source_data,
-        display: "value",
-        templateValue: "{{value}}",
+        display: 'value',
+        templateValue: '{{value}}',
         dynamic: true,
         multiselect: {
-          matchOn: ["key"],
+          matchOn: ['key'],
           data: [],
           callback: {
             onCancel: function (node, item, event) {
               if (!is_bulk) {
-                window.lodash.pullAllBy(new_post[field].values, [{value: item.key}], "value");
+                window.lodash.pullAllBy(
+                  new_post[field].values,
+                  [{ value: item.key }],
+                  'value',
+                );
               }
-            }
-          }
+            },
+          },
         },
         callback: {
           onClick: function (node, a, item, event) {
             if (!is_bulk) {
               if (!new_post[field]) {
-                new_post[field] = {values: []}
+                new_post[field] = { values: [] };
               }
-              new_post[field].values.push({value: item.key})
+              new_post[field].values.push({ value: item.key });
             }
-            this.addMultiselectItemLayout(item)
-            event.preventDefault()
+            this.addMultiselectItemLayout(item);
+            event.preventDefault();
             this.hideLayout();
             this.resetInput();
-
           },
           onResult: function (node, query, result, resultCount) {
-            let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+            let text = window.TYPEAHEADS.typeaheadHelpText(
+              resultCount,
+              query,
+              result,
+            );
             //adding the result text moves the input. timeout keeps the dropdown from closing as the user clicks and cursor moves away from the input.
             setTimeout(() => {
               $(`#${field}-result-container`).html(text);
             }, 200);
           },
           onHideLayout: function () {
-            $(`#${field}-result-container`).html("");
-          }
-        }
+            $(`#${field}-result-container`).html('');
+          },
+        },
       });
     }
   }
@@ -519,10 +602,12 @@ jQuery(function($) {
      * Tags
      */
     $('.tags .typeahead__query input').each((key, input) => {
-      let field = $(input).data('field') || 'tags'
-      let typeahead_name = (!is_bulk) ? `.js-typeahead-${field}` : `.js-typeahead-${field}-${bulk_id}`;
+      let field = $(input).data('field') || 'tags';
+      let typeahead_name = !is_bulk
+        ? `.js-typeahead-${field}`
+        : `.js-typeahead-${field}-${bulk_id}`;
 
-      const post_type = window.new_record_localized.post_type
+      const post_type = window.new_record_localized.post_type;
       $.typeahead({
         input: typeahead_name,
         minLength: 0,
@@ -530,106 +615,117 @@ jQuery(function($) {
         searchOnFocus: true,
         source: {
           tags: {
-            display: ["value"],
+            display: ['value'],
             ajax: {
-              url: window.wpApiShare.root + `dt-posts/v2/${post_type}/multi-select-values`,
+              url:
+                window.wpApiShare.root +
+                `dt-posts/v2/${post_type}/multi-select-values`,
               data: {
-                s: "{{query}}",
-                field: field
+                s: '{{query}}',
+                field: field,
               },
               beforeSend: function (xhr) {
                 xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce);
               },
               callback: {
                 done: function (data) {
-                  return (data || []).map(tag => {
-                    return {value: tag}
-                  })
-                }
-              }
-            }
-          }
+                  return (data || []).map((tag) => {
+                    return { value: tag };
+                  });
+                },
+              },
+            },
+          },
         },
-        display: "value",
-        templateValue: "{{value}}",
+        display: 'value',
+        templateValue: '{{value}}',
         emptyTemplate: function (query) {
-          const {addNewTagText, tagExistsText} = this.node[0].dataset
+          const { addNewTagText, tagExistsText } = this.node[0].dataset;
           if (this.comparedItems.includes(query)) {
-            return tagExistsText.replace('%s', query)
+            return tagExistsText.replace('%s', query);
           }
-          const liItem = $('<li>')
+          const liItem = $('<li>');
           const button = $('<button>', {
-            class: "button primary",
+            class: 'button primary',
             text: addNewTagText.replace('%s', query),
-          })
-          const tag = this.query
-          const typeahead = this
-          button.on("click", function (event) {
+          });
+          const tag = this.query;
+          const typeahead = this;
+          button.on('click', function (event) {
             if (!is_bulk) {
               if (!new_post[field]) {
-                new_post[field] = {values: []}
+                new_post[field] = { values: [] };
               }
-              new_post[field].values.push({value: tag})
+              new_post[field].values.push({ value: tag });
             }
-            typeahead.addMultiselectItemLayout({value: tag})
-            event.preventDefault()
+            typeahead.addMultiselectItemLayout({ value: tag });
+            event.preventDefault();
             typeahead.hideLayout();
             typeahead.resetInput();
-          })
-          liItem.append(button)
-          return liItem
+          });
+          liItem.append(button);
+          return liItem;
         },
         dynamic: true,
         multiselect: {
-          matchOn: ["value"],
+          matchOn: ['value'],
           data: [],
           callback: {
             onCancel: function (node, item) {
               if (!is_bulk) {
-                window.lodash.pullAllBy(new_post[field].values, [{value: item.value}], "value");
+                window.lodash.pullAllBy(
+                  new_post[field].values,
+                  [{ value: item.value }],
+                  'value',
+                );
               }
-            }
+            },
           },
         },
         callback: {
           onClick: function (node, a, item, event) {
             if (!is_bulk) {
               if (!new_post[field]) {
-                new_post[field] = {values: []}
+                new_post[field] = { values: [] };
               }
-              new_post[field].values.push({value: item.value})
+              new_post[field].values.push({ value: item.value });
             }
-            this.addMultiselectItemLayout(item)
-            event.preventDefault()
+            this.addMultiselectItemLayout(item);
+            event.preventDefault();
             this.hideLayout();
             this.resetInput();
           },
           onResult: function (node, query, result, resultCount) {
-            let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+            let text = window.TYPEAHEADS.typeaheadHelpText(
+              resultCount,
+              query,
+              result,
+            );
             $(`#${field}-result-container`).html(text);
           },
           onHideLayout: function () {
-            $(`#${field}-result-container`).html("");
+            $(`#${field}-result-container`).html('');
           },
-        }
+        },
       });
     });
   }
   $('.js-create-post').on('click', '.create-new-tag', function () {
-    let field = $(this).data("field");
-    $("#create-tag-modal").data("field", field)
-
+    let field = $(this).data('field');
+    $('#create-tag-modal').data('field', field);
   });
-  $("#create-tag-return").on("click", function () {
-    let field = $("#create-tag-modal").data("field");
-    let tag = $("#new-tag").val()
-    $('#new-tag').val("")
-    if ( !new_post[field] ){
-      new_post[field] = { values: [] }
+  $('#create-tag-return').on('click', function () {
+    let field = $('#create-tag-modal').data('field');
+    let tag = $('#new-tag').val();
+    $('#new-tag').val('');
+    if (!new_post[field]) {
+      new_post[field] = { values: [] };
     }
-    new_post[field].values.push({value: tag})
-    window.Typeahead['.js-typeahead-' + field].addMultiselectItemLayout({value: tag})
-  })
+    new_post[field].values.push({ value: tag });
+    window.Typeahead['.js-typeahead-' + field].addMultiselectItemLayout({
+      value: tag,
+    });
+  });
 
   /**
    * ============== [ BULK RECORD ADDING FUNCTIONALITY ] ==============
@@ -642,13 +738,14 @@ jQuery(function($) {
    */
 
   let bulk_record_id_counter = 1;
-  let is_normal_new_record = (!$('#form_fields_records').length) ? true : false;
+  let is_normal_new_record = !$('#form_fields_records').length ? true : false;
 
   $(document).ready(function () {
     if (!is_normal_new_record) {
-
       // If enabled, alter mapbox search location input shape, within first record
-      alter_mapbox_search_location_input_shape($('#form_fields_records').find('.form-fields-record').last());
+      alter_mapbox_search_location_input_shape(
+        $('#form_fields_records').find('.form-fields-record').last(),
+      );
 
       // Default to currently selected contact type.
       let selected_contact_type = $('.type-option.selected').attr('id');
@@ -662,15 +759,12 @@ jQuery(function($) {
   });
 
   if (is_normal_new_record) {
-
     date_picker_init();
     button_multi_select_init();
     typeahead_general_init();
     typeahead_multi_select_init();
     typeahead_tags_init();
-
   } else {
-
     let bulk_record_id = bulk_record_id_counter;
 
     adjust_new_button_multi_select_class_names(bulk_record_id);
@@ -684,7 +778,6 @@ jQuery(function($) {
     typeahead_general_init(true, bulk_record_id);
     typeahead_multi_select_init(true, bulk_record_id);
     typeahead_tags_init(true, bulk_record_id);
-
   }
 
   /*
@@ -692,11 +785,9 @@ jQuery(function($) {
    */
 
   $('#add_new_bulk_record').on('click', function () {
-
     let fields_html = window.new_record_localized.bulk_record_fields;
 
     if (fields_html) {
-
       let new_records_count = ++bulk_record_id_counter;
       let html = `<div class="form-fields-record form-fields-record-subsequent">
         <input type="hidden" id="bulk_record_id" value="${new_records_count}">
@@ -721,7 +812,9 @@ jQuery(function($) {
       typeahead_tags_init(true, new_records_count);
 
       // Apply and initialise copy controls
-      let new_record = $('#form_fields_records').find('.form-fields-record').last();
+      let new_record = $('#form_fields_records')
+        .find('.form-fields-record')
+        .last();
       apply_field_value_copy_controls_by_record(new_record);
       field_value_copy_controls_button_init();
 
@@ -729,14 +822,21 @@ jQuery(function($) {
       alter_mapbox_search_location_input_shape(new_record);
 
       // Ensure new record fields adhere to existing displayed fields shape
-      refresh_displayed_fields_by_record(list_currently_displayed_fields(), new_record);
+      refresh_displayed_fields_by_record(
+        list_currently_displayed_fields(),
+        new_record,
+      );
     }
   });
 
   function adjust_new_button_multi_select_class_names(bulk_id) {
-    $('#form_fields_records').find('.form-fields-record').last().find('.dt_multi_select').each((key, el) => {
-      adjust_new_button_multi_select_class_name(bulk_id, el);
-    });
+    $('#form_fields_records')
+      .find('.form-fields-record')
+      .last()
+      .find('.dt_multi_select')
+      .each((key, el) => {
+        adjust_new_button_multi_select_class_name(bulk_id, el);
+      });
   }
 
   function adjust_new_button_multi_select_class_name(bulk_id, element) {
@@ -749,25 +849,37 @@ jQuery(function($) {
   }
 
   function adjust_new_typeahead_general_element_class_names(bulk_id) {
-    $('#form_fields_records').find('.form-fields-record').last().find('.typeahead__query input').each((key, el) => {
-      adjust_new_typeahead_class_name(bulk_id, el);
-    });
+    $('#form_fields_records')
+      .find('.form-fields-record')
+      .last()
+      .find('.typeahead__query input')
+      .each((key, el) => {
+        adjust_new_typeahead_class_name(bulk_id, el);
+      });
   }
 
   function adjust_new_typeahead_multi_select_element_class_names(bulk_id) {
-    $('#form_fields_records').find('.form-fields-record').last().find('.multi_select .typeahead__query input').each((key, el) => {
-      adjust_new_typeahead_class_name(bulk_id, el);
-    });
+    $('#form_fields_records')
+      .find('.form-fields-record')
+      .last()
+      .find('.multi_select .typeahead__query input')
+      .each((key, el) => {
+        adjust_new_typeahead_class_name(bulk_id, el);
+      });
   }
 
   function adjust_new_typeahead_tags_element_class_names(bulk_id) {
-    $('#form_fields_records').find('.form-fields-record').last().find('.tags .typeahead__query input').each((key, el) => {
-      adjust_new_typeahead_class_name(bulk_id, el);
-    });
+    $('#form_fields_records')
+      .find('.form-fields-record')
+      .last()
+      .find('.tags .typeahead__query input')
+      .each((key, el) => {
+        adjust_new_typeahead_class_name(bulk_id, el);
+      });
   }
 
   function adjust_new_typeahead_class_name(bulk_id, element) {
-    let field_key = $(element).data('field')
+    let field_key = $(element).data('field');
     let old_field_class = `js-typeahead-${field_key}`;
 
     if ($(element).hasClass(old_field_class)) {
@@ -777,9 +889,13 @@ jQuery(function($) {
   }
 
   function adjust_new_date_picker_class_names(bulk_id) {
-    $('#form_fields_records').find('.form-fields-record').last().find('.dt_date_picker').each((key, el) => {
-      adjust_new_date_picker_class_name(bulk_id, el);
-    });
+    $('#form_fields_records')
+      .find('.form-fields-record')
+      .last()
+      .find('.dt_date_picker')
+      .each((key, el) => {
+        adjust_new_date_picker_class_name(bulk_id, el);
+      });
   }
 
   function adjust_new_date_picker_class_name(bulk_id, element) {
@@ -804,23 +920,44 @@ jQuery(function($) {
     let mapbox_search = $(record).find('#mapbox-search');
     let mapbox_autocomplete_list = $(record).find('#mapbox-autocomplete-list');
     let mapbox_spinner_button = $(record).find('#mapbox-spinner-button');
-    let mapbox_clear_autocomplete = $(record).find('#mapbox-clear-autocomplete');
-    if (mapbox_autocomplete && mapbox_search && mapbox_autocomplete_list && mapbox_spinner_button && mapbox_clear_autocomplete) {
-
+    let mapbox_clear_autocomplete = $(record).find(
+      '#mapbox-clear-autocomplete',
+    );
+    if (
+      mapbox_autocomplete &&
+      mapbox_search &&
+      mapbox_autocomplete_list &&
+      mapbox_spinner_button &&
+      mapbox_clear_autocomplete
+    ) {
       // Adjust attributes in order to force shape change.
       $(mapbox_autocomplete).prop('id', 'mapbox-autocomplete-altered');
-      $(mapbox_autocomplete_list).prop('id', 'mapbox-autocomplete-list-altered');
+      $(mapbox_autocomplete_list).prop(
+        'id',
+        'mapbox-autocomplete-list-altered',
+      );
       $(mapbox_spinner_button).prop('id', 'mapbox-spinner-button-altered');
-      $(mapbox_clear_autocomplete).prop('id', 'mapbox-clear-autocomplete-altered');
+      $(mapbox_clear_autocomplete).prop(
+        'id',
+        'mapbox-clear-autocomplete-altered',
+      );
       $(mapbox_search).prop('id', 'mapbox-search-altered');
       $(mapbox_search).prop('type', 'button');
-      $(mapbox_search).prop('value', window.SHAREDFUNCTIONS.escapeHTML(window.new_record_localized.bulk_mapbox_placeholder_txt));
+      $(mapbox_search).prop(
+        'value',
+        window.SHAREDFUNCTIONS.escapeHTML(
+          window.new_record_localized.bulk_mapbox_placeholder_txt,
+        ),
+      );
       $(mapbox_search).addClass('button');
       $(mapbox_search).addClass('mapbox-altered-input');
       $(mapbox_search).data('field', 'location_grid_meta');
 
       // Capture record id for processing further downstream.
-      $(mapbox_search).data('bulk_record_id', $(record).find('#bulk_record_id').val());
+      $(mapbox_search).data(
+        'bulk_record_id',
+        $(record).find('#bulk_record_id').val(),
+      );
     }
   }
 
@@ -835,9 +972,11 @@ jQuery(function($) {
     reset_altered_mapbox_search_field_values();
 
     // Persist bulk record id and display modal.
-    $('#altered_mapbox_search_modal').data('bulk_record_id', $(evt.currentTarget).data('bulk_record_id'));
+    $('#altered_mapbox_search_modal').data(
+      'bulk_record_id',
+      $(evt.currentTarget).data('bulk_record_id'),
+    );
     $('#altered_mapbox_search_modal').foundation('open');
-
   });
 
   $(document).on('open.zf.reveal', '[data-reveal]', function (evt) {
@@ -845,8 +984,7 @@ jQuery(function($) {
     window.write_input_widget();
   });
 
-  $(document).on('closed.zf.reveal', '[data-reveal]', function (evt) {
-  });
+  $(document).on('closed.zf.reveal', '[data-reveal]', function (evt) {});
 
   $('#altered_mapbox_search_modal_but_cancel').on('click', function () {
     reset_altered_mapbox_search_field_values();
@@ -854,24 +992,35 @@ jQuery(function($) {
   });
 
   $('#altered_mapbox_search_modal_but_update').on('click', function () {
-    let bulk_record_id = $('#altered_mapbox_search_modal').data('bulk_record_id');
-    if (bulk_record_id && (window.selected_location_grid_meta !== undefined)) {
-
+    let bulk_record_id = $('#altered_mapbox_search_modal').data(
+      'bulk_record_id',
+    );
+    if (bulk_record_id && window.selected_location_grid_meta !== undefined) {
       let selected_location = window.selected_location_grid_meta;
 
       // Search for corresponding record.
-      $('#form_fields_records').find('.form-fields-record').each((key, record) => {
-        if ($(record).find('#bulk_record_id').val() === bulk_record_id) {
+      $('#form_fields_records')
+        .find('.form-fields-record')
+        .each((key, record) => {
+          if ($(record).find('#bulk_record_id').val() === bulk_record_id) {
+            let mapbox_search = $(record).find('#mapbox-search-altered');
 
-          let mapbox_search = $(record).find('#mapbox-search-altered');
+            // Update button text to selected location.
+            mapbox_search.val(
+              window.lodash.truncate(
+                window.SHAREDFUNCTIONS.escapeHTML(
+                  selected_location['location_grid_meta']['values'][0]['label'],
+                ),
+              ),
+            );
 
-          // Update button text to selected location.
-          mapbox_search.val(window.lodash.truncate(window.SHAREDFUNCTIONS.escapeHTML(selected_location['location_grid_meta']['values'][0]['label'])));
-
-          // Capture selected location within data attribute.
-          mapbox_search.data('selected_location', JSON.stringify(selected_location));
-        }
-      });
+            // Capture selected location within data attribute.
+            mapbox_search.data(
+              'selected_location',
+              JSON.stringify(selected_location),
+            );
+          }
+        });
     }
     $('#altered_mapbox_search_modal').foundation('close');
   });
@@ -885,126 +1034,147 @@ jQuery(function($) {
    * Respond to bulk save requests.
    */
 
-  $(".js-create-post-bulk-button").removeAttr("disabled");
-  $(".js-create-post-bulk").on("submit", function (evt) {
+  $('.js-create-post-bulk-button').removeAttr('disabled');
+  $('.js-create-post-bulk').on('submit', function (evt) {
     evt.preventDefault();
 
     // Capture parent level settings
     let type = $('.type-options .selected').attr('id');
 
     // Change submit button loading state
-    $(".js-create-post-bulk-button").attr("disabled", true).addClass("loading");
+    $('.js-create-post-bulk-button').attr('disabled', true).addClass('loading');
 
     // Iterate over form records to be added
     let records_counter = 0;
-    let records_total = $('#form_fields_records').find('.form-fields-record').length;
-    $('#form_fields_records').find('.form-fields-record').each((key, record) => {
+    let records_total = $('#form_fields_records').find(
+      '.form-fields-record',
+    ).length;
+    $('#form_fields_records')
+      .find('.form-fields-record')
+      .each((key, record) => {
+        let bulk_record_id = $(record).find('#bulk_record_id').val();
 
-      let bulk_record_id = $(record).find('#bulk_record_id').val();
-
-      // Start to build new post object
-      let new_post = {}
-      if (type) {
-        new_post.type = type;
-      }
-
-      $(record).find('.select-field').each((index, entry) => {
-        if ($(entry).val()) {
-          new_post[$(entry).attr('id')] = $(entry).val()
+        // Start to build new post object
+        let new_post = {};
+        if (type) {
+          new_post.type = type;
         }
-      });
 
-      $(record).find('.text-input').each((index, entry) => {
-        if ($(entry).val()) {
-          new_post[$(entry).attr('id')] = $(entry).val()
-        }
-      });
-
-      $(record).find('.dt_textarea').each((index, entry) => {
-        if ($(entry).val()) {
-          new_post[$(entry).attr('id')] = $(entry).val()
-        }
-      });
-
-      $(record).find('.dt-communication-channel').each((index, entry) => {
-        let val = $(entry).val()
-        if (val.length > 0) {
-          let channel = $(entry).data('field')
-          if (!new_post[channel]) {
-            new_post[channel] = []
-          }
-          new_post[channel].push({
-            value: $(entry).val()
+        $(record)
+          .find('.select-field')
+          .each((index, entry) => {
+            if ($(entry).val()) {
+              new_post[$(entry).attr('id')] = $(entry).val();
+            }
           });
-        }
-      });
 
-      $(record).find('.selected-select-button').each((index, entry) => {
-        let optionKey = $(entry).attr('id')
-        let fieldKey = $(entry).data("field-key")
-        if (!new_post[fieldKey]) {
-          new_post[fieldKey] = {values: []};
-        }
-        new_post[fieldKey].values.push({
-          "value": optionKey
-        });
-      });
+        $(record)
+          .find('.text-input')
+          .each((index, entry) => {
+            if ($(entry).val()) {
+              new_post[$(entry).attr('id')] = $(entry).val();
+            }
+          });
 
-      // Capture available mapbox related locations
-      let mapbox_search = $(record).find('#mapbox-search-altered');
-      if (mapbox_search && mapbox_search.data('selected_location')) {
-        new_post['location_grid_meta'] = JSON.parse(mapbox_search.data('selected_location'))['location_grid_meta'];
-      }
+        $(record)
+          .find('.dt_textarea')
+          .each((index, entry) => {
+            if ($(entry).val()) {
+              new_post[$(entry).attr('id')] = $(entry).val();
+            }
+          });
 
-      // Package any available typeahead values
-      $(record).find('.typeahead__query input').each((index, entry) => {
-        let field_id = $(entry).data('field');
-        let typeahead_selector = '.js-typeahead-' + field_id + '-' + bulk_record_id;
-        let typeahead = window.Typeahead[typeahead_selector];
-
-        // Ensure typeahead contains stuff...!
-        if (typeahead && typeahead.items && typeahead.items.length > 0) {
-
-          // Instantiate new values array if required.
-          if (!new_post[field_id]) {
-            new_post[field_id] = {values: []};
-          }
-
-          // Populate values accordingly.
-          $.each(typeahead.items, function (idx, item) {
-            if (item.ID) {
-              new_post[field_id].values.push({
-                "value": item.ID
+        $(record)
+          .find('.dt-communication-channel')
+          .each((index, entry) => {
+            let val = $(entry).val();
+            if (val.length > 0) {
+              let channel = $(entry).data('field');
+              if (!new_post[channel]) {
+                new_post[channel] = [];
+              }
+              new_post[channel].push({
+                value: $(entry).val(),
               });
             }
           });
+
+        $(record)
+          .find('.selected-select-button')
+          .each((index, entry) => {
+            let optionKey = $(entry).attr('id');
+            let fieldKey = $(entry).data('field-key');
+            if (!new_post[fieldKey]) {
+              new_post[fieldKey] = { values: [] };
+            }
+            new_post[fieldKey].values.push({
+              value: optionKey,
+            });
+          });
+
+        // Capture available mapbox related locations
+        let mapbox_search = $(record).find('#mapbox-search-altered');
+        if (mapbox_search && mapbox_search.data('selected_location')) {
+          new_post['location_grid_meta'] = JSON.parse(
+            mapbox_search.data('selected_location'),
+          )['location_grid_meta'];
         }
+
+        // Package any available typeahead values
+        $(record)
+          .find('.typeahead__query input')
+          .each((index, entry) => {
+            let field_id = $(entry).data('field');
+            let typeahead_selector =
+              '.js-typeahead-' + field_id + '-' + bulk_record_id;
+            let typeahead = window.Typeahead[typeahead_selector];
+
+            // Ensure typeahead contains stuff...!
+            if (typeahead && typeahead.items && typeahead.items.length > 0) {
+              // Instantiate new values array if required.
+              if (!new_post[field_id]) {
+                new_post[field_id] = { values: [] };
+              }
+
+              // Populate values accordingly.
+              $.each(typeahead.items, function (idx, item) {
+                if (item.ID) {
+                  new_post[field_id].values.push({
+                    value: item.ID,
+                  });
+                }
+              });
+            }
+          });
+
+        // Package any available dates
+        $(record)
+          .find('.dt_date_picker-' + bulk_record_id)
+          .each((index, entry) => {
+            let field_id = $(entry).data('orig-field-id');
+            let date_epoch = $(entry).data('selected-date-epoch');
+
+            if (date_epoch) {
+              new_post[field_id] = date_epoch;
+            }
+          });
+
+        // Save new record post!
+        window.API.create_post(window.new_record_localized.post_type, new_post)
+          .promise()
+          .then(function (data) {
+            // Only redirect once all records have been processed!
+            if (++records_counter >= records_total) {
+              window.location =
+                window.new_record_localized.bulk_save_redirect_uri;
+            } else {
+              $(record).slideUp('slow');
+            }
+          })
+          .catch(function (error) {
+            console.error(error);
+          });
       });
-
-      // Package any available dates
-      $(record).find('.dt_date_picker-' + bulk_record_id).each((index, entry) => {
-        let field_id = $(entry).data('orig-field-id');
-        let date_epoch = $(entry).data('selected-date-epoch');
-
-        if (date_epoch) {
-          new_post[field_id] = date_epoch;
-        }
-      });
-
-      // Save new record post!
-      window.API.create_post(window.new_record_localized.post_type, new_post).promise().then(function (data) {
-
-        // Only redirect once all records have been processed!
-        if (++records_counter >= records_total) {
-          window.location = window.new_record_localized.bulk_save_redirect_uri;
-        } else {
-          $(record).slideUp('slow');
-        }
-
-      }).catch(function (error) {
-        console.error(error);
-      });
-    });
   });
 
   /*
@@ -1014,7 +1184,6 @@ jQuery(function($) {
   let default_filter_fields = [];
 
   if (!is_normal_new_record) {
-
     // Initial displayed fields, to be captured as defualts; ready for use further down stream!
     default_filter_fields = list_currently_displayed_fields();
   }
@@ -1040,13 +1209,10 @@ jQuery(function($) {
   });
 
   function adjust_selected_field_filters_by_currently_displayed_record_fields() {
-
     let fields = list_currently_displayed_fields();
     if (fields) {
-
       // Select corresponding field filters
       $('#list_fields_picker input').each((index, elem) => {
-
         // Select checkbox accordingly
         $(elem).prop('checked', window.lodash.includes(fields, $(elem).val()));
       });
@@ -1054,165 +1220,266 @@ jQuery(function($) {
   }
 
   function list_currently_displayed_fields() {
-
     // Field checks to be based on shape of first record.
     let record = $('#form_fields_records').find('.form-fields-record').first();
     let bulk_id = $(record).find('#bulk_record_id').val();
     let fields = [];
 
-    $(record).find('.select-field').each((index, entry) => {
-      if ($(entry).is(':visible')) {
-        fields.push($(entry).attr('id'));
-      }
-    });
+    $(record)
+      .find('.select-field')
+      .each((index, entry) => {
+        if ($(entry).is(':visible')) {
+          fields.push($(entry).attr('id'));
+        }
+      });
 
-    $(record).find('.text-input').each((index, entry) => {
-      if ($(entry).is(':visible')) {
-        fields.push($(entry).attr('id'));
-      }
-    });
+    $(record)
+      .find('.text-input')
+      .each((index, entry) => {
+        if ($(entry).is(':visible')) {
+          fields.push($(entry).attr('id'));
+        }
+      });
 
-    $(record).find('.dt_textarea').each((index, entry) => {
-      if ($(entry).is(':visible')) {
-        fields.push($(entry).attr('id'));
-      }
-    });
+    $(record)
+      .find('.dt_textarea')
+      .each((index, entry) => {
+        if ($(entry).is(':visible')) {
+          fields.push($(entry).attr('id'));
+        }
+      });
 
-    $(record).find('.dt-communication-channel').each((index, entry) => {
-      if ($(entry).is(':visible')) {
-        fields.push($(entry).data('field'));
-      }
-    });
+    $(record)
+      .find('.dt-communication-channel')
+      .each((index, entry) => {
+        if ($(entry).is(':visible')) {
+          fields.push($(entry).data('field'));
+        }
+      });
 
-    $(record).find('.selected-select-button').each((index, entry) => {
-      if ($(entry).is(':visible')) {
-        fields.push($(entry).data('field-key'));
-      }
-    });
+    $(record)
+      .find('.selected-select-button')
+      .each((index, entry) => {
+        if ($(entry).is(':visible')) {
+          fields.push($(entry).data('field-key'));
+        }
+      });
 
-    $(record).find(`.dt_multi_select-${bulk_id}`).each((index, entry) => {
-      if ($(entry).is(':visible')) {
-        fields.push($(entry).data('field-key'));
-      }
-    });
+    $(record)
+      .find(`.dt_multi_select-${bulk_id}`)
+      .each((index, entry) => {
+        if ($(entry).is(':visible')) {
+          fields.push($(entry).data('field-key'));
+        }
+      });
 
-    $(record).find('.typeahead__query input').each((index, entry) => {
-      if ($(entry).is(':visible')) {
-        fields.push($(entry).data('field'));
-      }
-    });
+    $(record)
+      .find('.typeahead__query input')
+      .each((index, entry) => {
+        if ($(entry).is(':visible')) {
+          fields.push($(entry).data('field'));
+        }
+      });
 
-    $(record).find('.multi_select .typeahead__query input').each((index, entry) => {
-      if ($(entry).is(':visible')) {
-        fields.push($(entry).data('field'));
-      }
-    });
+    $(record)
+      .find('.multi_select .typeahead__query input')
+      .each((index, entry) => {
+        if ($(entry).is(':visible')) {
+          fields.push($(entry).data('field'));
+        }
+      });
 
-    $(record).find('.tags .typeahead__query input').each((index, entry) => {
-      if ($(entry).is(':visible')) {
-        fields.push($(entry).data('field'));
-      }
-    });
+    $(record)
+      .find('.tags .typeahead__query input')
+      .each((index, entry) => {
+        if ($(entry).is(':visible')) {
+          fields.push($(entry).data('field'));
+        }
+      });
 
-    $(record).find('#mapbox-search-altered').each((index, entry) => {
-      if ($(entry).is(':visible')) {
-        fields.push($(entry).data('field'));
-      }
-    });
+    $(record)
+      .find('#mapbox-search-altered')
+      .each((index, entry) => {
+        if ($(entry).is(':visible')) {
+          fields.push($(entry).data('field'));
+        }
+      });
 
-    $(record).find(`.dt_date_picker-${bulk_id}`).each((index, entry) => {
-      if ($(entry).is(':visible')) {
-        fields.push($(entry).data('orig-field-id'));
-      }
-    });
+    $(record)
+      .find(`.dt_date_picker-${bulk_id}`)
+      .each((index, entry) => {
+        if ($(entry).is(':visible')) {
+          fields.push($(entry).data('orig-field-id'));
+        }
+      });
 
     return window.lodash.uniq(fields);
   }
 
   function refresh_displayed_fields(filter_fields) {
-    $('#form_fields_records').find('.form-fields-record').each((key, record) => {
-      refresh_displayed_fields_by_record(filter_fields, record);
-    });
+    $('#form_fields_records')
+      .find('.form-fields-record')
+      .each((key, record) => {
+        refresh_displayed_fields_by_record(filter_fields, record);
+      });
   }
 
   function refresh_displayed_fields_by_record(filter_fields, record) {
     let bulk_record_id = $(record).find('#bulk_record_id').val();
 
-    $(record).find('.select-field').each((index, entry) => {
-      let target_parent = $(entry).parent();
-      let is_displayed = window.lodash.includes(filter_fields, $(entry).attr('id'));
-      $(target_parent).toggle(is_displayed);
-    });
+    $(record)
+      .find('.select-field')
+      .each((index, entry) => {
+        let target_parent = $(entry).parent();
+        let is_displayed = window.lodash.includes(
+          filter_fields,
+          $(entry).attr('id'),
+        );
+        $(target_parent).toggle(is_displayed);
+      });
 
-    $(record).find('.text-input').each((index, entry) => {
-      let target_parent = $(entry).parent();
-      let is_displayed = window.lodash.includes(filter_fields, $(entry).attr('id'));
-      $(target_parent).toggle(is_displayed);
-    });
+    $(record)
+      .find('.text-input')
+      .each((index, entry) => {
+        let target_parent = $(entry).parent();
+        let is_displayed = window.lodash.includes(
+          filter_fields,
+          $(entry).attr('id'),
+        );
+        $(target_parent).toggle(is_displayed);
+      });
 
-    $(record).find('.dt_textarea').each((index, entry) => {
-      let target_parent = $(entry).parent();
-      let is_displayed = window.lodash.includes(filter_fields, $(entry).attr('id'));
-      $(target_parent).toggle(is_displayed);
-    });
+    $(record)
+      .find('.dt_textarea')
+      .each((index, entry) => {
+        let target_parent = $(entry).parent();
+        let is_displayed = window.lodash.includes(
+          filter_fields,
+          $(entry).attr('id'),
+        );
+        $(target_parent).toggle(is_displayed);
+      });
 
-    $(record).find('.dt-communication-channel').each((index, entry) => {
-      let target_parent = $(entry).parent().parent().parent();
-      let is_displayed = window.lodash.includes(filter_fields, $(entry).data('field'));
-      $(target_parent).toggle(is_displayed);
-    });
+    $(record)
+      .find('.dt-communication-channel')
+      .each((index, entry) => {
+        let target_parent = $(entry).parent().parent().parent();
+        let is_displayed = window.lodash.includes(
+          filter_fields,
+          $(entry).data('field'),
+        );
+        $(target_parent).toggle(is_displayed);
+      });
 
-    $(record).find('.selected-select-button').each((index, entry) => {
-      let target_parent = $(entry).parent();
-      let is_displayed = window.lodash.includes(filter_fields, $(entry).data('field-key'));
-      $(target_parent).toggle(is_displayed);
-    });
+    $(record)
+      .find('.selected-select-button')
+      .each((index, entry) => {
+        let target_parent = $(entry).parent();
+        let is_displayed = window.lodash.includes(
+          filter_fields,
+          $(entry).data('field-key'),
+        );
+        $(target_parent).toggle(is_displayed);
+      });
 
-    $(record).find(`.dt_multi_select-${bulk_record_id}`).each((index, entry) => {
-      let target_parent = $(entry).parent().parent();
-      let is_displayed = window.lodash.includes(filter_fields, $(entry).data('field-key'));
-      $(target_parent).toggle(is_displayed);
-    });
+    $(record)
+      .find(`.dt_multi_select-${bulk_record_id}`)
+      .each((index, entry) => {
+        let target_parent = $(entry).parent().parent();
+        let is_displayed = window.lodash.includes(
+          filter_fields,
+          $(entry).data('field-key'),
+        );
+        $(target_parent).toggle(is_displayed);
+      });
 
-    $(record).find('.typeahead__query input').each((index, entry) => {
-      let target_parent = $(entry).parent().parent().parent().parent().parent().parent();
-      let is_displayed = window.lodash.includes(filter_fields, $(entry).data('field'));
-      $(target_parent).toggle(is_displayed);
-    });
+    $(record)
+      .find('.typeahead__query input')
+      .each((index, entry) => {
+        let target_parent = $(entry)
+          .parent()
+          .parent()
+          .parent()
+          .parent()
+          .parent()
+          .parent();
+        let is_displayed = window.lodash.includes(
+          filter_fields,
+          $(entry).data('field'),
+        );
+        $(target_parent).toggle(is_displayed);
+      });
 
-    $(record).find('.multi_select .typeahead__query input').each((index, entry) => {
-      let target_parent = $(entry).parent().parent().parent().parent().parent().parent();
-      let is_displayed = window.lodash.includes(filter_fields, $(entry).data('field'));
-      $(target_parent).toggle(is_displayed);
-    });
+    $(record)
+      .find('.multi_select .typeahead__query input')
+      .each((index, entry) => {
+        let target_parent = $(entry)
+          .parent()
+          .parent()
+          .parent()
+          .parent()
+          .parent()
+          .parent();
+        let is_displayed = window.lodash.includes(
+          filter_fields,
+          $(entry).data('field'),
+        );
+        $(target_parent).toggle(is_displayed);
+      });
 
-    $(record).find('.tags .typeahead__query input').each((index, entry) => {
-      let target_parent = $(entry).parent().parent().parent().parent().parent().parent();
-      let is_displayed = window.lodash.includes(filter_fields, $(entry).data('field'));
-      $(target_parent).toggle(is_displayed);
-    });
+    $(record)
+      .find('.tags .typeahead__query input')
+      .each((index, entry) => {
+        let target_parent = $(entry)
+          .parent()
+          .parent()
+          .parent()
+          .parent()
+          .parent()
+          .parent();
+        let is_displayed = window.lodash.includes(
+          filter_fields,
+          $(entry).data('field'),
+        );
+        $(target_parent).toggle(is_displayed);
+      });
 
-    $(record).find('#mapbox-search-altered').each((index, entry) => {
-      let target_parent = $(entry).parent().parent();
-      let is_displayed = window.lodash.includes(filter_fields, $(entry).data('field'));
-      $(target_parent).toggle(is_displayed);
-    });
+    $(record)
+      .find('#mapbox-search-altered')
+      .each((index, entry) => {
+        let target_parent = $(entry).parent().parent();
+        let is_displayed = window.lodash.includes(
+          filter_fields,
+          $(entry).data('field'),
+        );
+        $(target_parent).toggle(is_displayed);
+      });
 
-    $(record).find(`.dt_date_picker-${bulk_record_id}`).each((index, entry) => {
-      let target_parent = $(entry).parent().parent();
-      let is_displayed = window.lodash.includes(filter_fields, $(entry).data('orig-field-id'));
-      $(target_parent).toggle(is_displayed);
-    });
+    $(record)
+      .find(`.dt_date_picker-${bulk_record_id}`)
+      .each((index, entry) => {
+        let target_parent = $(entry).parent().parent();
+        let is_displayed = window.lodash.includes(
+          filter_fields,
+          $(entry).data('orig-field-id'),
+        );
+        $(target_parent).toggle(is_displayed);
+      });
   }
 
   function apply_field_filters() {
     let new_selected = [];
     $('#list_fields_picker input:checked').each((index, elem) => {
-      new_selected.push($(elem).val())
+      new_selected.push($(elem).val());
     });
 
-    let fields_to_show_in_records = window.lodash.intersection([], new_selected); // remove unchecked
-    fields_to_show_in_records = window.lodash.uniq(window.lodash.union(fields_to_show_in_records, new_selected));
+    let fields_to_show_in_records = window.lodash.intersection(
+      [],
+      new_selected,
+    ); // remove unchecked
+    fields_to_show_in_records = window.lodash.uniq(
+      window.lodash.union(fields_to_show_in_records, new_selected),
+    );
 
     refresh_displayed_fields(fields_to_show_in_records);
     $('#list_fields_picker').toggle(false);
@@ -1220,19 +1487,16 @@ jQuery(function($) {
   }
 
   function reset_field_filters() {
-
     // Default to currently selected contact type or just revert back to plain-old-defaults!
     let selected_contact_type = $('.type-option.selected').attr('id');
     if (selected_contact_type) {
       $('#' + selected_contact_type + '.type-option').trigger('click');
-
     } else {
       refresh_displayed_fields(default_filter_fields);
     }
 
     $('#list_fields_picker').toggle(false);
     adjust_selected_field_filters_by_currently_displayed_record_fields();
-
   }
 
   /*
@@ -1245,111 +1509,164 @@ jQuery(function($) {
   }
 
   function field_value_copy_controls_button_init() {
-    $(".field-value-copy-controls-button").on("click", function (evt) {
+    $('.field-value-copy-controls-button').on('click', function (evt) {
       let field_div = $(evt.currentTarget).parent().parent().parent();
       let record_id = $(evt.currentTarget).data('record-id');
       let field_class = $(evt.currentTarget).data('field-class');
       let field_id = $(evt.currentTarget).data('field-id');
-      copy_field_value_across_records(record_id, field_div, field_class, field_id);
+      copy_field_value_across_records(
+        record_id,
+        field_div,
+        field_class,
+        field_id,
+      );
     });
   }
 
   function apply_field_value_copy_controls() {
-    $('#form_fields_records').find('.form-fields-record').each((key, record) => {
-      apply_field_value_copy_controls_by_record(record);
-    });
+    $('#form_fields_records')
+      .find('.form-fields-record')
+      .each((key, record) => {
+        apply_field_value_copy_controls_by_record(record);
+      });
   }
 
   function apply_field_value_copy_controls_by_record(record) {
     let bulk_record_id = $(record).find('#bulk_record_id').val();
 
-    $(record).find('.form-field').each((index, field_div) => {
-
-      // Only focus on required class field types.
-      if ($(field_div).find('.text-input').length !== 0) {
-        apply_field_value_copy_controls_button(bulk_record_id, field_div, 'text-input', $(field_div).find('.text-input').attr('id'));
-
-      } else if ($(field_div).find('.select-field').length !== 0) {
-        apply_field_value_copy_controls_button(bulk_record_id, field_div, 'select-field', $(field_div).find('.select-field').attr('id'));
-
-      } else if ($(field_div).find('.typeahead__query input').length !== 0) {
-        apply_field_value_copy_controls_button(bulk_record_id, field_div, 'typeahead__query input', $(field_div).find('.typeahead__query input').data('field'));
-
-      }
-
-    });
+    $(record)
+      .find('.form-field')
+      .each((index, field_div) => {
+        // Only focus on required class field types.
+        if ($(field_div).find('.text-input').length !== 0) {
+          apply_field_value_copy_controls_button(
+            bulk_record_id,
+            field_div,
+            'text-input',
+            $(field_div).find('.text-input').attr('id'),
+          );
+        } else if ($(field_div).find('.select-field').length !== 0) {
+          apply_field_value_copy_controls_button(
+            bulk_record_id,
+            field_div,
+            'select-field',
+            $(field_div).find('.select-field').attr('id'),
+          );
+        } else if ($(field_div).find('.typeahead__query input').length !== 0) {
+          apply_field_value_copy_controls_button(
+            bulk_record_id,
+            field_div,
+            'typeahead__query input',
+            $(field_div).find('.typeahead__query input').data('field'),
+          );
+        }
+      });
   }
 
-  function apply_field_value_copy_controls_button(record_id, field_div, field_class, field_id) {
+  function apply_field_value_copy_controls_button(
+    record_id,
+    field_div,
+    field_class,
+    field_id,
+  ) {
     if ($(field_div).find('.field-value-copy-controls').length === 0) {
-      let button_html = '<button style="margin-left: 10px;" data-field-class="' + field_class + '" data-field-id="' + field_id + '" data-record-id="' + record_id + '" class="field-value-copy-controls-button" type="button"><img src="' + window.SHAREDFUNCTIONS.escapeHTML(window.new_record_localized.bulk_copy_control_but_img_uri) + '"></button>';
-      $(field_div).find('.section-subheader').append('<span class="field-value-copy-controls" style="float: right; padding: 0; margin: 0;">' + button_html + '</span>');
+      let button_html =
+        '<button style="margin-left: 10px;" data-field-class="' +
+        field_class +
+        '" data-field-id="' +
+        field_id +
+        '" data-record-id="' +
+        record_id +
+        '" class="field-value-copy-controls-button" type="button"><img src="' +
+        window.SHAREDFUNCTIONS.escapeHTML(
+          window.new_record_localized.bulk_copy_control_but_img_uri,
+        ) +
+        '"></button>';
+      $(field_div)
+        .find('.section-subheader')
+        .append(
+          '<span class="field-value-copy-controls" style="float: right; padding: 0; margin: 0;">' +
+            button_html +
+            '</span>',
+        );
     }
   }
 
-  function copy_field_value_across_records(record_id, field_div, field_class, field_id) {
-
+  function copy_field_value_across_records(
+    record_id,
+    field_div,
+    field_class,
+    field_id,
+  ) {
     // First, source field value to be copied. Ensure typeaheads are handled with a little more tlc..! ;)
     let value = null;
     if (field_class === 'typeahead__query input') {
-
       let typeahead_selector = '.js-typeahead-' + field_id + '-' + record_id;
       let typeahead = window.Typeahead[typeahead_selector];
 
       value = {
         items: typeahead.items,
         items_compared: typeahead.comparedItems,
-        items_label_container: typeahead.label.container
+        items_label_container: typeahead.label.container,
       };
-
     } else {
-      value = $(field_div).find('.' + field_class).val();
+      value = $(field_div)
+        .find('.' + field_class)
+        .val();
     }
 
     // Assuming we have a valid value, proceed with copying across records.
     if (value) {
-      $('#form_fields_records').find('.form-fields-record').each((key, record) => {
+      $('#form_fields_records')
+        .find('.form-fields-record')
+        .each((key, record) => {
+          // Ignore primary source record!
+          if (record_id != $(record).find('#bulk_record_id').val()) {
+            // Copy value across to other record fields.
+            $(record)
+              .find('.text-input')
+              .each((index, field) => {
+                if ($(field).attr('id') == field_id) {
+                  $(field).val(value);
+                }
+              });
 
-        // Ignore primary source record!
-        if (record_id != $(record).find('#bulk_record_id').val()) {
+            $(record)
+              .find('.select-field')
+              .each((index, field) => {
+                if ($(field).attr('id') == field_id) {
+                  $(field).val(value);
+                }
+              });
 
-          // Copy value across to other record fields.
-          $(record).find('.text-input').each((index, field) => {
-            if ($(field).attr('id') == field_id) {
-              $(field).val(value);
-            }
-          });
+            // Again, handle typeaheads slightly differently!
+            $(record)
+              .find('.typeahead__query input')
+              .each((index, field) => {
+                if ($(field).data('field') == field_id) {
+                  let typeahead_selector =
+                    '.js-typeahead-' +
+                    field_id +
+                    '-' +
+                    $(record).find('#bulk_record_id').val();
+                  let typeahead = window.Typeahead[typeahead_selector];
 
-          $(record).find('.select-field').each((index, field) => {
-            if ($(field).attr('id') == field_id) {
-              $(field).val(value);
-            }
-          });
+                  // Assuming we have a valid handle, proceed.
+                  if (typeahead) {
+                    // Clear down existing typeahead arrays and containers
+                    typeahead.items = [];
+                    typeahead.comparedItems = [];
+                    jQuery(typeahead.label.container).empty();
 
-          // Again, handle typeaheads slightly differently!
-          $(record).find('.typeahead__query input').each((index, field) => {
-            if ($(field).data('field') == field_id) {
-
-              let typeahead_selector = '.js-typeahead-' + field_id + '-' + $(record).find('#bulk_record_id').val();
-              let typeahead = window.Typeahead[typeahead_selector];
-
-              // Assuming we have a valid handle, proceed.
-              if (typeahead) {
-
-                // Clear down existing typeahead arrays and containers
-                typeahead.items = [];
-                typeahead.comparedItems = [];
-                jQuery(typeahead.label.container).empty();
-
-                // Append copied items.
-                $.each(value.items, function (idx, item) {
-                  typeahead.addMultiselectItemLayout(item);
-                });
-              }
-            }
-          });
-        }
-      });
+                    // Append copied items.
+                    $.each(value.items, function (idx, item) {
+                      typeahead.addMultiselectItemLayout(item);
+                    });
+                  }
+                }
+              });
+          }
+        });
     }
   }
 
@@ -1368,15 +1685,16 @@ jQuery(function($) {
 
   function delete_record_by_id(record_id) {
     if (record_id) {
-
       let deleted_record = null;
 
       // Locate corresponding record.
-      $('#form_fields_records').find('.form-fields-record').each((key, record) => {
-        if ($(record).find('#bulk_record_id').val() == record_id) {
-          deleted_record = record;
-        }
-      });
+      $('#form_fields_records')
+        .find('.form-fields-record')
+        .each((key, record) => {
+          if ($(record).find('#bulk_record_id').val() == record_id) {
+            deleted_record = record;
+          }
+        });
 
       // If found, remove identified record from list.
       if (deleted_record) {
@@ -1387,65 +1705,93 @@ jQuery(function($) {
 
   // Check for phone and email duplication
   let non_duplicable_fields = ['contact_phone', 'contact_email'];
-  $.each(non_duplicable_fields, function(field_key, field_type){
-    if ( window.new_record_localized.post_type_settings.fields[field_type] ){
-      var field_name = window.new_record_localized.post_type_settings.fields[field_type].name
-      $(`input[data-field="${field_type}"]`).attr(`data-${field_type}-index`, '0');
-      $(`input[data-field="${field_type}"]`).after(`<span class="loading-spinner" data-${field_type}-index="0" style="margin: 0.5rem;"></span>`);
+  $.each(non_duplicable_fields, function (field_key, field_type) {
+    if (window.new_record_localized.post_type_settings.fields[field_type]) {
+      var field_name =
+        window.new_record_localized.post_type_settings.fields[field_type].name;
+      $(`input[data-field="${field_type}"]`).attr(
+        `data-${field_type}-index`,
+        '0',
+      );
+      $(`input[data-field="${field_type}"]`).after(
+        `<span class="loading-spinner" data-${field_type}-index="0" style="margin: 0.5rem;"></span>`,
+      );
       $(`input[data-field="${field_type}"]`).parent().after(`
         <div class="communication-channel-error" data-${field_type}-index="0" style="display: none;">
           ${window.new_record_localized.translations.value_already_exists.replace('%s', field_name)}:
           <span class="duplicate-ids" data-${field_type}-index="0" style="color: #3f729b;"></span>
           </div>`);
     }
-  })
+  });
 
   function check_field_value_exists(field_type, element_index) {
     var email = $(`input[data-${field_type}-index="${element_index}"]`).val();
-    $(`.loading-spinner[data-${field_type}-index="${element_index}"]`).attr('class','loading-spinner active');
+    $(`.loading-spinner[data-${field_type}-index="${element_index}"]`).attr(
+      'class',
+      'loading-spinner active',
+    );
     if (!email) {
-      $(`.communication-channel-error[data-${field_type}-index="${element_index}"]`).hide();
-      $(`.loading-spinner[data-${field_type}-index="${element_index}"]`).attr('class','loading-spinner');
+      $(
+        `.communication-channel-error[data-${field_type}-index="${element_index}"]`,
+      ).hide();
+      $(`.loading-spinner[data-${field_type}-index="${element_index}"]`).attr(
+        'class',
+        'loading-spinner',
+      );
       return;
     }
     var post_type = window.wpApiShare.post_type;
-    var data = {"communication_channel": `${field_type}`, "field_value": email,}
-    jQuery.ajax({
-      type: "POST",
-      data: JSON.stringify(data),
-      contentType: "application/json; charset=utf-8",
-      dataType: "json",
-      url: window.wpApiShare.root + `dt-posts/v2/${post_type}/check_field_value_exists`,
-      beforeSend: (xhr) => {
-        xhr.setRequestHeader("X-WP-Nonce", window.wpApiShare.nonce);
-      },
-    }).then(result => {
-      if (!$.isEmptyObject(result)) {
-        var duplicate_ids_html = '';
-        $.each(result, function(k,v) {
-          if ( k > 0 ) {
-            duplicate_ids_html += ', ';
-          }
-          duplicate_ids_html += `<a href="/${post_type}/${v.post_id}" target="_blank">${window.new_record_localized.translations.contact} #${v.post_id}</a>`;
-        });
-        $(`.duplicate-ids[data-${field_type}-index="${element_index}"]`).html(duplicate_ids_html);
-        $(`.communication-channel-error[data-${field_type}-index="${element_index}"]`).show();
-      } else {
-        $(`.communication-channel-error[data-${field_type}-index="${element_index}"]`).hide();
-        $(`.duplicate-ids[data-${field_type}-index="${element_index}"]`).html('');
-      }
-      $(`.loading-spinner[data-${field_type}-index="${element_index}"]`).attr('class','loading-spinner');
-    });
+    var data = { communication_channel: `${field_type}`, field_value: email };
+    jQuery
+      .ajax({
+        type: 'POST',
+        data: JSON.stringify(data),
+        contentType: 'application/json; charset=utf-8',
+        dataType: 'json',
+        url:
+          window.wpApiShare.root +
+          `dt-posts/v2/${post_type}/check_field_value_exists`,
+        beforeSend: (xhr) => {
+          xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce);
+        },
+      })
+      .then((result) => {
+        if (!$.isEmptyObject(result)) {
+          var duplicate_ids_html = '';
+          $.each(result, function (k, v) {
+            if (k > 0) {
+              duplicate_ids_html += ', ';
+            }
+            duplicate_ids_html += `<a href="/${post_type}/${v.post_id}" target="_blank">${window.new_record_localized.translations.contact} #${v.post_id}</a>`;
+          });
+          $(`.duplicate-ids[data-${field_type}-index="${element_index}"]`).html(
+            duplicate_ids_html,
+          );
+          $(
+            `.communication-channel-error[data-${field_type}-index="${element_index}"]`,
+          ).show();
+        } else {
+          $(
+            `.communication-channel-error[data-${field_type}-index="${element_index}"]`,
+          ).hide();
+          $(`.duplicate-ids[data-${field_type}-index="${element_index}"]`).html(
+            '',
+          );
+        }
+        $(`.loading-spinner[data-${field_type}-index="${element_index}"]`).attr(
+          'class',
+          'loading-spinner',
+        );
+      });
   }
 
-  $('.form-fields').on('change', 'input[data-field^="contact_"]', function() {
+  $('.form-fields').on('change', 'input[data-field^="contact_"]', function () {
     var post_type = $(this).data('field');
     var element_index = $(this).data(`${post_type}-index`);
-    check_field_value_exists(post_type, element_index)
+    check_field_value_exists(post_type, element_index);
   });
 
   /**
    * ============== [ BULK RECORD ADDING FUNCTIONALITY ] ==============
    */
-
 });

--- a/dt-assets/js/notifications.js
+++ b/dt-assets/js/notifications.js
@@ -1,193 +1,235 @@
 /* Functions to support the notifications system. */
 function get_new_notification_count() {
-  return window.makeRequest('post', 'notifications/get_new_notifications_count').done(data => {
-    if (data > 0) {
-      jQuery('.notification-count').text(data).show().css('display', 'inline-block')
-      return
-    }
+  return window
+    .makeRequest('post', 'notifications/get_new_notifications_count')
+    .done((data) => {
+      if (data > 0) {
+        jQuery('.notification-count')
+          .text(data)
+          .show()
+          .css('display', 'inline-block');
+        return;
+      }
 
-    jQuery('.notification-count').hide()
-  }).fail(window.handleAjaxError)
+      jQuery('.notification-count').hide();
+    })
+    .fail(window.handleAjaxError);
 }
 
-setTimeout(get_new_notification_count, 2000)
+setTimeout(get_new_notification_count, 2000);
 
-const notificationRead = notification_id => `
-  <a class="read-button-${window.SHAREDFUNCTIONS.escapeHTML( notification_id )} read-button button hollow small" style="border-radius:100px; margin: 0;"
-      onclick="mark_unread( ${window.SHAREDFUNCTIONS.escapeHTML( notification_id )} )">
+const notificationRead = (notification_id) => `
+  <a class="read-button-${window.SHAREDFUNCTIONS.escapeHTML(notification_id)} read-button button hollow small" style="border-radius:100px; margin: 0;"
+      onclick="mark_unread( ${window.SHAREDFUNCTIONS.escapeHTML(notification_id)} )">
       <!--<i class="fi-minus hollow"></i>-->
    </a>
-`
-const notificationNew = notification_id => `
-  <a class="new-button-${window.SHAREDFUNCTIONS.escapeHTML( notification_id )} new-button button small" style="border-radius:100px; margin: 0;"
-     onclick="mark_viewed( ${window.SHAREDFUNCTIONS.escapeHTML( notification_id )} )">
+`;
+const notificationNew = (notification_id) => `
+  <a class="new-button-${window.SHAREDFUNCTIONS.escapeHTML(notification_id)} new-button button small" style="border-radius:100px; margin: 0;"
+     onclick="mark_viewed( ${window.SHAREDFUNCTIONS.escapeHTML(notification_id)} )">
      <!--<i class="fi-check"></i>-->
   </a>
-`
+`;
 
-function mark_viewed (notification_id) {
-  return window.makeRequest('post', 'notifications/mark_viewed/' + notification_id).done(() => {
-    get_new_notification_count()
-    jQuery(`.row-${notification_id} .notification-row`).removeClass("unread-notification-row")
-    jQuery('.toggle-area-'+notification_id).html(notificationRead(notification_id))
-    // TODO toggle the .new-cell class off
-  }).fail(window.handleAjaxError)
+function mark_viewed(notification_id) {
+  return window
+    .makeRequest('post', 'notifications/mark_viewed/' + notification_id)
+    .done(() => {
+      get_new_notification_count();
+      jQuery(`.row-${notification_id} .notification-row`).removeClass(
+        'unread-notification-row',
+      );
+      jQuery('.toggle-area-' + notification_id).html(
+        notificationRead(notification_id),
+      );
+      // TODO toggle the .new-cell class off
+    })
+    .fail(window.handleAjaxError);
 }
 
-function mark_unread (notification_id) {
-  return window.makeRequest('post', 'notifications/mark_unread/' + notification_id).done(() => {
-    get_new_notification_count()
-    jQuery(`.row-${notification_id} .notification-row`).addClass("unread-notification-row")
-    jQuery('.toggle-area-'+notification_id).html(notificationNew(notification_id))
-    // TODO toggle the .new-cell class on
-  }).fail(window.handleAjaxError)
+function mark_unread(notification_id) {
+  return window
+    .makeRequest('post', 'notifications/mark_unread/' + notification_id)
+    .done(() => {
+      get_new_notification_count();
+      jQuery(`.row-${notification_id} .notification-row`).addClass(
+        'unread-notification-row',
+      );
+      jQuery('.toggle-area-' + notification_id).html(
+        notificationNew(notification_id),
+      );
+      // TODO toggle the .new-cell class on
+    })
+    .fail(window.handleAjaxError);
 }
 
-function mark_all_viewed () {
-  const id = window.wpApiNotifications.current_user_id
+function mark_all_viewed() {
+  const id = window.wpApiNotifications.current_user_id;
 
-  return window.makeRequest('post', 'notifications/mark_all_viewed/' + id).done(() => {
-    get_new_notification_count()
-    jQuery('.new-cell').html(notificationRead(id))
-    // TODO also change the backgrounds of the notifications to indicate their read status?
-  }).fail(window.handleAjaxError)
+  return window
+    .makeRequest('post', 'notifications/mark_all_viewed/' + id)
+    .done(() => {
+      get_new_notification_count();
+      jQuery('.new-cell').html(notificationRead(id));
+      // TODO also change the backgrounds of the notifications to indicate their read status?
+    })
+    .fail(window.handleAjaxError);
 }
 
 const notification_group_header = (record_title) => `
 <div class="cell notification-group-header">
-    ${window.SHAREDFUNCTIONS.escapeHTML( record_title )}
+    ${window.SHAREDFUNCTIONS.escapeHTML(record_title)}
 </div>
-`
+`;
 
-function notification_template (id, note, is_new, pretty_time) {
-  let button = ``
-  let label = `` // used by the mark_all_viewed()
+function notification_template(id, note, is_new, pretty_time) {
+  let button = ``;
+  let label = ``; // used by the mark_all_viewed()
 
   if (is_new === '1') {
-    button = notificationNew(id)
-    label = `new-cell` // used by the mark_all_viewed()
+    button = notificationNew(id);
+    label = `new-cell`; // used by the mark_all_viewed()
   } else {
-    button = notificationRead(id)
+    button = notificationRead(id);
   }
-
 
   return `
   <div class="row-${id} cell" id="">
-      <div class="grid-x grid-padding-x grid-padding-y bottom-border notification-row ${is_new ==='1' ? 'unread-notification-row' : ''} ">
+      <div class="grid-x grid-padding-x grid-padding-y bottom-border notification-row ${is_new === '1' ? 'unread-notification-row' : ''} ">
 
         <div class="auto cell">
            ${note}<br>
            <span><small><strong>${window.SHAREDFUNCTIONS.escapeHTML(pretty_time[0])}</strong> | ${window.SHAREDFUNCTIONS.escapeHTML(pretty_time[1])}</small></span>
         </div>
-        <div class="small-2 medium-1 cell padding-5 grid-x align-center align-middle ${window.SHAREDFUNCTIONS.escapeHTML( label )} toggle-area-${window.SHAREDFUNCTIONS.escapeHTML( id )}">
+        <div class="small-2 medium-1 cell padding-5 grid-x align-center align-middle ${window.SHAREDFUNCTIONS.escapeHTML(label)} toggle-area-${window.SHAREDFUNCTIONS.escapeHTML(id)}">
             ${button}
         </div>
       </div>
-    </div>`
+    </div>`;
 }
 
 /* Variables for get_notifications */
-let all = true
-let all_offset
-let new_offset
-let page
+let all = true;
+let all_offset;
+let new_offset;
+let page;
 
-function get_notifications (all, reset, dropdown = false, limit = 20) {
+function get_notifications(all, reset, dropdown = false, limit = 20) {
   /* Processing the offset of the query request. Using the limit variable to increment the sql offset. */
   if (all === true) {
-    new_offset = 0
+    new_offset = 0;
     if (all_offset === 0 || !all_offset) {
-      page = 0
-      all_offset = limit
-    }
-    else if (all_offset === limit) {
-      page = limit
-      all_offset = limit + limit
-    }
-    else {
-      page = all_offset
-      all_offset = all_offset + limit
+      page = 0;
+      all_offset = limit;
+    } else if (all_offset === limit) {
+      page = limit;
+      all_offset = limit + limit;
+    } else {
+      page = all_offset;
+      all_offset = all_offset + limit;
     }
   } else {
-    all_offset = 0
+    all_offset = 0;
     if (new_offset === 0 || !new_offset) {
-      page = 0
-      new_offset = limit
+      page = 0;
+      new_offset = limit;
+    } else if (new_offset === limit) {
+      page = limit;
+      new_offset = limit + limit;
+    } else {
+      page = new_offset;
+      new_offset = new_offset + limit;
     }
-    else if (new_offset === limit) {
-      page = limit
-      new_offset = limit + limit
-    }
-    else {
-      page = new_offset
-      new_offset = new_offset + limit
-    }
-
   }
   if (reset === true) {
-    page = 0
-  }else if (reset === false) {
-    page += 1
+    page = 0;
+  } else if (reset === false) {
+    page += 1;
   }
   const jQueryElementsDict = {
-    'default' : {
+    default: {
       notificationList: jQuery('.notifications-page #notification-list'),
       nextAll: jQuery('.notifications-page #next-all'),
       nextNew: jQuery('.notifications-page #next-new'),
     },
-    'dropdown': {
+    dropdown: {
       notificationList: jQuery('#notification-dropdown #notification-list'),
       nextAll: null,
       nextNew: null,
     },
-  }
+  };
 
-  const jQueryElements = jQueryElementsDict[dropdown ? 'dropdown' : 'default']
+  const jQueryElements = jQueryElementsDict[dropdown ? 'dropdown' : 'default'];
 
   // return notifications if query successful
   let mentions = include_mentions();
-  return window.makeRequest('post', 'notifications/get_notifications', { all, page, limit, mentions }).done(data => {
-    if (data) {
-      if (reset) {
-        jQueryElements.notificationList.empty()
-      }
+  return window
+    .makeRequest('post', 'notifications/get_notifications', {
+      all,
+      page,
+      limit,
+      mentions,
+    })
+    .done((data) => {
+      if (data) {
+        if (reset) {
+          jQueryElements.notificationList.empty();
+        }
 
-      const groupedData = groupNotificationsByDayAndRecord(data)
+        const groupedData = groupNotificationsByDayAndRecord(data);
 
-      groupedData.forEach((dayGroupedByRecord) => {
-        Object.entries(dayGroupedByRecord).forEach(([record_title, notifications]) => {
-          jQueryElements.notificationList.append(notification_group_header(record_title))
+        groupedData.forEach((dayGroupedByRecord) => {
+          Object.entries(dayGroupedByRecord).forEach(
+            ([record_title, notifications]) => {
+              jQueryElements.notificationList.append(
+                notification_group_header(record_title),
+              );
 
-          notifications.forEach((notification) => {
-            jQueryElements.notificationList.append(notification_template(notification.id, notification.notification_note, notification.is_new, notification.pretty_time))
-          })
-        })
-      })
-      /* jQuery.each(data, function (i, item) {
+              notifications.forEach((notification) => {
+                jQueryElements.notificationList.append(
+                  notification_template(
+                    notification.id,
+                    notification.notification_note,
+                    notification.is_new,
+                    notification.pretty_time,
+                  ),
+                );
+              });
+            },
+          );
+        });
+        /* jQuery.each(data, function (i, item) {
         jQueryElements.notificationList.append(notification_template(data[i].id, data[i].notification_note, data[i].is_new, data[i].pretty_time))
       }) */
-    } else if (
-      (all === true && (all_offset === 0 || !all_offset )) ||
-      all === false && (new_offset === 0 || !new_offset))
-    { // determines if this is the first query (offset 0) and there is nothing returned.
-      jQueryElements.notificationList.html(`<div class="cell center empty-notification-message">${window.SHAREDFUNCTIONS.escapeHTML( window.wpApiNotifications.translations["no-notifications"] )}</div>`)
-      jQueryElements.nextAll && jQueryElements.nextAll.hide()
-      jQueryElements.nextNew && jQueryElements.nextNew.hide()
-    } else { // therefore if no data is returned, but this is not the first query, then just remove the option to load more content
-      if (reset) {
-        jQueryElements.notificationList.html(`<div class="cell center empty-notification-message">${window.SHAREDFUNCTIONS.escapeHTML( window.wpApiNotifications.translations["no-unread"] )}</div>`)
-      }
+      } else if (
+        (all === true && (all_offset === 0 || !all_offset)) ||
+        (all === false && (new_offset === 0 || !new_offset))
+      ) {
+        // determines if this is the first query (offset 0) and there is nothing returned.
+        jQueryElements.notificationList.html(
+          `<div class="cell center empty-notification-message">${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiNotifications.translations['no-notifications'])}</div>`,
+        );
+        jQueryElements.nextAll && jQueryElements.nextAll.hide();
+        jQueryElements.nextNew && jQueryElements.nextNew.hide();
+      } else {
+        // therefore if no data is returned, but this is not the first query, then just remove the option to load more content
+        if (reset) {
+          jQueryElements.notificationList.html(
+            `<div class="cell center empty-notification-message">${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiNotifications.translations['no-unread'])}</div>`,
+          );
+        }
 
-      jQueryElements.nextAll && jQueryElements.nextAll.hide()
-      jQueryElements.nextNew && jQueryElements.nextNew.hide()
-    }
-  }).fail(window.handleAjaxError)
+        jQueryElements.nextAll && jQueryElements.nextAll.hide();
+        jQueryElements.nextNew && jQueryElements.nextNew.hide();
+      }
+    })
+    .fail(window.handleAjaxError);
 }
 
 function include_mentions() {
   let mentions = jQuery('#mentions');
 
-  return (mentions && mentions.is(':checked'));
+  return mentions && mentions.is(':checked');
 }
 
 jQuery('#mentions').on('click', function () {
@@ -195,53 +237,58 @@ jQuery('#mentions').on('click', function () {
 });
 
 function groupNotificationsByDayAndRecord(data) {
-
   function getDate(dateString) {
-    if (!dateString) return ''
+    if (!dateString) return '';
     return dateString.split(' ')[0];
   }
 
-  const sortedByDayAndRecord = []
-  let currentDay = ''
-  let daysNotifications = {}
-  data.forEach(notif => {
+  const sortedByDayAndRecord = [];
+  let currentDay = '';
+  let daysNotifications = {};
+  data.forEach((notif) => {
     // data is already in date order, so we can go day by day
-    const date = getDate(notif.date_notified)
-    if (date !== currentDay ) {
-      currentDay = date
-      daysNotifications = {}
-      sortedByDayAndRecord.push(daysNotifications)
+    const date = getDate(notif.date_notified);
+    if (date !== currentDay) {
+      currentDay = date;
+      daysNotifications = {};
+      sortedByDayAndRecord.push(daysNotifications);
     }
     if (!daysNotifications[notif.post_title]) {
-      daysNotifications[notif.post_title] = []
+      daysNotifications[notif.post_title] = [];
     }
-    daysNotifications[notif.post_title].push(notif)
+    daysNotifications[notif.post_title].push(notif);
   });
 
-  return sortedByDayAndRecord
+  return sortedByDayAndRecord;
 }
 
-function toggle_buttons( state ) {
-  if ( state === 'all' ) {
-    jQuery('.notifications-page #all').attr('class', 'button')
-    jQuery('.notifications-page #new').attr('class', 'button hollow')
-    jQuery('.notifications-page #next-all').show()
-    jQuery('.notifications-page #next-new').hide()
+function toggle_buttons(state) {
+  if (state === 'all') {
+    jQuery('.notifications-page #all').attr('class', 'button');
+    jQuery('.notifications-page #new').attr('class', 'button hollow');
+    jQuery('.notifications-page #next-all').show();
+    jQuery('.notifications-page #next-new').hide();
   } else {
-    jQuery('.notifications-page #all').attr('class', 'button hollow')
-    jQuery('.notifications-page #new').attr('class', 'button')
-    jQuery('.notifications-page #next-all').hide()
-    jQuery('.notifications-page #next-new').show()
+    jQuery('.notifications-page #all').attr('class', 'button hollow');
+    jQuery('.notifications-page #new').attr('class', 'button');
+    jQuery('.notifications-page #next-all').hide();
+    jQuery('.notifications-page #next-new').show();
   }
 }
 
-function toggle_dropdown_buttons( state ) {
-  if ( state === 'all' ) {
-    jQuery('#notification-dropdown #dropdown-all').attr('class', 'button')
-    jQuery('#notification-dropdown #dropdown-new').attr('class', 'button hollow')
+function toggle_dropdown_buttons(state) {
+  if (state === 'all') {
+    jQuery('#notification-dropdown #dropdown-all').attr('class', 'button');
+    jQuery('#notification-dropdown #dropdown-new').attr(
+      'class',
+      'button hollow',
+    );
   } else {
-    jQuery('#notification-dropdown #dropdown-all').attr('class', 'button hollow')
-    jQuery('#notification-dropdown #dropdown-new').attr('class', 'button')
+    jQuery('#notification-dropdown #dropdown-all').attr(
+      'class',
+      'button hollow',
+    );
+    jQuery('#notification-dropdown #dropdown-new').attr('class', 'button');
   }
 }
 

--- a/dt-assets/js/record-history.js
+++ b/dt-assets/js/record-history.js
@@ -1,5 +1,4 @@
 jQuery(document).ready(function ($) {
-
   // Global Variables
   const date_format_short = 'YYYY-MM-DD';
   const date_format_long = 'MMMM Do, YYYY, hh:mm:ss A';
@@ -8,13 +7,24 @@ jQuery(document).ready(function ($) {
   const post_settings = window.record_history_settings.post_settings;
 
   // Event Listeners
-  $(document).on('open.zf.reveal', '#record_history_modal[data-reveal]', function () {
-    init_record_history_modal();
-  });
+  $(document).on(
+    'open.zf.reveal',
+    '#record_history_modal[data-reveal]',
+    function () {
+      init_record_history_modal();
+    },
+  );
 
-  $(document).on('click', '.record-history-activity-block-controls', function () {
-    handle_revert_request($(this).find('#record_history_activity_block_timestamp_id').val(), $(this).find('#record_history_activity_block_timestamp').val());
-  });
+  $(document).on(
+    'click',
+    '.record-history-activity-block-controls',
+    function () {
+      handle_revert_request(
+        $(this).find('#record_history_activity_block_timestamp_id').val(),
+        $(this).find('#record_history_activity_block_timestamp').val(),
+      );
+    },
+  );
 
   $(document).on('click', '#record_history_all_activities_switch', function () {
     handle_show_all_activities();
@@ -29,36 +39,41 @@ jQuery(document).ready(function ($) {
     let record_history_select = $('#record_history_calendar');
 
     // Fetch initial corresponding activities, to be used in date filter select.
-    handle_activity_history_refresh({
-      revert: true,
-      result_order: 'DESC',
-      extra_meta: true
-    }, function (activities) {
+    handle_activity_history_refresh(
+      {
+        revert: true,
+        result_order: 'DESC',
+        extra_meta: true,
+      },
+      function (activities) {
+        // Package filtered dates.
+        let filtered_dates = {};
+        $.each(activities, function (idx, activity) {
+          let hist_time = window.moment.unix(parseInt(activity['hist_time']));
 
-      // Package filtered dates.
-      let filtered_dates = {};
-      $.each(activities, function (idx, activity) {
-        let hist_time = window.moment.unix(parseInt(activity['hist_time']));
+          // Default to midnight.
+          hist_time.second(0);
+          hist_time.minute(0);
+          hist_time.hour(0);
 
-        // Default to midnight.
-        hist_time.second(0);
-        hist_time.minute(0);
-        hist_time.hour(0);
+          filtered_dates[hist_time.format(date_format_pretty_short)] =
+            hist_time;
+        });
 
-        filtered_dates[hist_time.format(date_format_pretty_short)] = hist_time;
-      });
+        // Clear down any previous entries, apart from the first option.
+        record_history_select.find('option').not(':first').remove();
 
-      // Clear down any previous entries, apart from the first option.
-      record_history_select.find('option').not(':first').remove();
+        // Populate history select widget.
+        $.each(filtered_dates, function (idx, filtered_date) {
+          record_history_select.append(
+            `<option value="${filtered_date.unix()}">${idx}</option>`,
+          );
+        });
 
-      // Populate history select widget.
-      $.each(filtered_dates, function (idx, filtered_date) {
-        record_history_select.append(`<option value="${filtered_date.unix()}">${idx}</option>`);
-      });
-
-      // By default, and if selected, show all-time activities.
-      handle_activities_display(activities);
-    });
+        // By default, and if selected, show all-time activities.
+        handle_activities_display(activities);
+      },
+    );
   }
 
   function handle_filtered_date_selection() {
@@ -66,9 +81,16 @@ jQuery(document).ready(function ($) {
 
     if (record_history_select.val()) {
       let ts_start = record_history_select.val();
-      let ts_end = window.moment.unix(record_history_select.val()).add(24, 'hours').unix();
+      let ts_end = window.moment
+        .unix(record_history_select.val())
+        .add(24, 'hours')
+        .unix();
 
-      handle_selected_activity_date(ts_start, ts_end, handle_activities_display);
+      handle_selected_activity_date(
+        ts_start,
+        ts_end,
+        handle_activities_display,
+      );
       reset_show_all_activities_switch();
     }
   }
@@ -83,13 +105,15 @@ jQuery(document).ready(function ($) {
 
   function handle_show_all_activities() {
     if (is_show_all_activities_switch_checked()) {
-      handle_activity_history_refresh({
-        revert: true,
-        ts_start: 0,
-        result_order: 'DESC',
-        extra_meta: true
-
-      }, handle_activities_display);
+      handle_activity_history_refresh(
+        {
+          revert: true,
+          ts_start: 0,
+          result_order: 'DESC',
+          extra_meta: true,
+        },
+        handle_activities_display,
+      );
 
       // Default filter select widget.
       $('#record_history_calendar').val('');
@@ -97,64 +121,77 @@ jQuery(document).ready(function ($) {
   }
 
   function handle_activity_history_refresh(request_args, callback) {
-
     // Assuming a valid post, refresh activity history
     if (post && post['post_type'] && post['ID']) {
-      window.API.get_activity(post['post_type'], post['ID'], request_args).then(activities => {
-
-        // Execute callback with returned activities
-        callback(activities);
-
-      });
+      window.API.get_activity(post['post_type'], post['ID'], request_args).then(
+        (activities) => {
+          // Execute callback with returned activities
+          callback(activities);
+        },
+      );
     }
   }
 
   function handle_selected_activity_date(ts_start, ts_end, callback) {
-
     // Retrieve activities from specified starting point to current date.
-    handle_activity_history_refresh({
-      revert: true,
-      ts_start: ts_start,
-      ts_end: ts_end,
-      result_order: 'DESC',
-      extra_meta: true
-
-    }, callback);
-
+    handle_activity_history_refresh(
+      {
+        revert: true,
+        ts_start: ts_start,
+        ts_end: ts_end,
+        result_order: 'DESC',
+        extra_meta: true,
+      },
+      callback,
+    );
   }
 
   function handle_activities_display(activities) {
     let record_history_activities = $('#record_history_activities');
     record_history_activities.fadeOut('fast', function () {
-
       // Clear-down existing activities list
       record_history_activities.empty();
 
       // Iterate and display the latest list
       $.each(activities, function (idx, activity) {
-
         // Extract/Format values of interest
         let activity_heading = window.lodash.unescape(activity['object_note']);
         let field_label = '---';
-        let revert_but_tooltip = window.record_history_settings.translations.revert_but_tooltip;
-        let activity_date = window.moment.unix(parseInt(activity['hist_time'])).format(date_format_long);
-        let owner_name = (activity['name']) ? window.lodash.unescape(activity['name']):'';
-        let owner_gravatar = (activity['gravatar']) ? `<img src="${activity['gravatar']}"/>` : `<span class="mdi mdi-robot-confused-outline" style="font-size: 20px;"></span>`
+        let revert_but_tooltip =
+          window.record_history_settings.translations.revert_but_tooltip;
+        let activity_date = window.moment
+          .unix(parseInt(activity['hist_time']))
+          .format(date_format_long);
+        let owner_name = activity['name']
+          ? window.lodash.unescape(activity['name'])
+          : '';
+        let owner_gravatar = activity['gravatar']
+          ? `<img src="${activity['gravatar']}"/>`
+          : `<span class="mdi mdi-robot-confused-outline" style="font-size: 20px;"></span>`;
 
         // Enable activity heading url links.
-        let urls = activity_heading.match(/(((ftp|https?):\/\/)[\-\w@:%_\+.~#?,&\/\/=]+)/g);
-        if (urls!=null) {
+        let urls = activity_heading.match(
+          /(((ftp|https?):\/\/)[\-\w@:%_\+.~#?,&\/\/=]+)/g,
+        );
+        if (urls != null) {
           $.each(urls, function (url_idx, url) {
-
             // Identify first associated link label.
             let url_labels = activity_heading.match(/\[(.*?)\]/);
 
             // Replace raw link with converted html link.
-            if (url_labels!=null) {
+            if (url_labels != null) {
               let raw_link = url_labels[0] + '(' + url + ')';
-              activity_heading = window.lodash.replace(activity_heading, raw_link, `<a href="${window.SHAREDFUNCTIONS.escapeHTML(url)}" target="_blank">${window.SHAREDFUNCTIONS.escapeHTML(url_labels[1])}</a>`);
+              activity_heading = window.lodash.replace(
+                activity_heading,
+                raw_link,
+                `<a href="${window.SHAREDFUNCTIONS.escapeHTML(url)}" target="_blank">${window.SHAREDFUNCTIONS.escapeHTML(url_labels[1])}</a>`,
+              );
             } else {
-              activity_heading = window.lodash.replace(activity_heading, new RegExp(url, 'g'), `<a href="${window.SHAREDFUNCTIONS.escapeHTML(url)}" target="_blank">${window.SHAREDFUNCTIONS.escapeHTML(url)}</a>`);
+              activity_heading = window.lodash.replace(
+                activity_heading,
+                new RegExp(url, 'g'),
+                `<a href="${window.SHAREDFUNCTIONS.escapeHTML(url)}" target="_blank">${window.SHAREDFUNCTIONS.escapeHTML(url)}</a>`,
+              );
             }
           });
         }
@@ -162,27 +199,48 @@ jQuery(document).ready(function ($) {
         // Convert activity heading epoch timestamps to readable dates.
         if (['date', 'datetime'].includes(activity['field_type'])) {
           let timestamps = activity_heading.match(/\d{10}/g);
-          if (timestamps!=null) {
+          if (timestamps != null) {
             $.each(timestamps, function (ts_idx, ts) {
               if (activity['field_type'] === 'date') {
-                activity_heading = window.lodash.replace(activity_heading, new RegExp(`\{?${ts}\}?`, 'g'), window.moment.unix(parseInt(ts)).format(date_format_pretty_short));
+                activity_heading = window.lodash.replace(
+                  activity_heading,
+                  new RegExp(`\{?${ts}\}?`, 'g'),
+                  window.moment
+                    .unix(parseInt(ts))
+                    .format(date_format_pretty_short),
+                );
               }
               if (activity['field_type'] === 'datetime') {
-                activity_heading = window.lodash.replace(activity_heading, new RegExp(`\{?${ts}\}?`, 'g'), window.SHAREDFUNCTIONS.formatDate(ts, true));
+                activity_heading = window.lodash.replace(
+                  activity_heading,
+                  new RegExp(`\{?${ts}\}?`, 'g'),
+                  window.SHAREDFUNCTIONS.formatDate(ts, true),
+                );
               }
             });
           }
         }
 
         // Field label to be sourced accordingly, based on incoming field type.
-        if (window.lodash.includes(['connection to', 'connection from'], activity['field_type'])) {
+        if (
+          window.lodash.includes(
+            ['connection to', 'connection from'],
+            activity['field_type'],
+          )
+        ) {
           field_label = 'connection';
-
-        } else if (window.lodash.isEmpty(activity['field_type']) && window.lodash.startsWith(activity['meta_key'], 'contact_')) {
+        } else if (
+          window.lodash.isEmpty(activity['field_type']) &&
+          window.lodash.startsWith(activity['meta_key'], 'contact_')
+        ) {
           let meta_key = activity['meta_key'];
-          field_label = meta_key.substring(0, meta_key.indexOf('_', 'contact_'.length));
-
-        } else if (!window.lodash.isEmpty(post_settings['fields'][activity['meta_key']])) {
+          field_label = meta_key.substring(
+            0,
+            meta_key.indexOf('_', 'contact_'.length),
+          );
+        } else if (
+          !window.lodash.isEmpty(post_settings['fields'][activity['meta_key']])
+        ) {
           field_label = post_settings['fields'][activity['meta_key']]['name'];
         }
 
@@ -207,24 +265,28 @@ jQuery(document).ready(function ($) {
             </div>`;
 
         record_history_activities.append(html);
-
       });
 
       // Inform user if no activities found!
       if (window.lodash.isEmpty(activities)) {
         record_history_activities.empty();
-        record_history_activities.append(`<div style="text-align: center;"><span style="font-size: 50px;"><i class="mdi mdi-clock-remove-outline"/></span></div>`);
+        record_history_activities.append(
+          `<div style="text-align: center;"><span style="font-size: 50px;"><i class="mdi mdi-clock-remove-outline"/></span></div>`,
+        );
       }
 
       // Display the latest shape
       record_history_activities.fadeIn('fast');
-
     });
   }
 
   function handle_revert_request(start_id, timestamp) {
-    let timestamp_formatted = window.moment.unix(parseInt(timestamp)).format(date_format_long);
-    let confirm_text = window.SHAREDFUNCTIONS.escapeHTML(window.record_history_settings.translations.revert_confirm_text).replace('%s', timestamp_formatted);
+    let timestamp_formatted = window.moment
+      .unix(parseInt(timestamp))
+      .format(date_format_long);
+    let confirm_text = window.SHAREDFUNCTIONS.escapeHTML(
+      window.record_history_settings.translations.revert_confirm_text,
+    ).replace('%s', timestamp_formatted);
     if (confirm(confirm_text)) {
       const progress_spinner = $('#record_history_progress_spinner');
       $(progress_spinner).addClass('active');
@@ -235,28 +297,35 @@ jQuery(document).ready(function ($) {
           ts_start_id: start_id,
           ts_start: timestamp,
           result_order: 'DESC',
-          extra_meta: false
+          extra_meta: false,
+        })
+          .then((result) => {
+            $(progress_spinner).removeClass('active');
 
-        }).then(result => {
-          $(progress_spinner).removeClass('active');
+            // Refresh record view
+            window.location =
+              window.record_history_settings.site_url +
+              post['post_type'] +
+              '/' +
+              post['ID'];
+          })
+          .fail((failure) => {
+            console.log(failure);
+            $(progress_spinner).removeClass('active');
 
-          // Refresh record view
-          window.location = window.record_history_settings.site_url + post['post_type'] + '/' + post['ID'];
+            // Display detected exception text before returning back to post type record.
+            if (failure['responseText']) {
+              alert(failure['responseText']);
+            }
 
-        }).fail(failure => {
-          console.log(failure);
-          $(progress_spinner).removeClass('active');
-
-          // Display detected exception text before returning back to post type record.
-          if (failure['responseText']) {
-            alert(failure['responseText']);
-          }
-
-          // Refresh record view
-          window.location = window.record_history_settings.site_url + post['post_type'] + '/' + post['ID'];
-        });
+            // Refresh record view
+            window.location =
+              window.record_history_settings.site_url +
+              post['post_type'] +
+              '/' +
+              post['ID'];
+          });
       }
     }
   }
-
 });

--- a/dt-assets/js/request-record-access.js
+++ b/dt-assets/js/request-record-access.js
@@ -1,41 +1,42 @@
 jQuery(document).ready(function ($) {
-
-  let rest_api = window.API
+  let rest_api = window.API;
   let postId = window.detailsSettings.post_id;
   let postType = window.detailsSettings.post_type;
   let currentUserId = window.detailsSettings.current_user_id;
 
   // Open the request record access modal
-  $(document).on("click", '.open-request-record-access-button-modal', function () {
-    $('#request-record-access-modal').foundation('open');
-  })
+  $(document).on(
+    'click',
+    '.open-request-record-access-button-modal',
+    function () {
+      $('#request-record-access-modal').foundation('open');
+    },
+  );
 
   // Handle request submissions
-  $(document).on("submit", '.request-record-access-form', function (e) {
+  $(document).on('submit', '.request-record-access-form', function (e) {
     e.preventDefault();
 
     $('#request-record-access-modal-button').toggleClass('loading');
 
     // Post request
-    rest_api.request_record_access(postType, postId, currentUserId).then(data => {
-      $('#request-record-access-modal-button').toggleClass('loading');
-      $('#request-record-access-modal').foundation('close');
+    rest_api
+      .request_record_access(postType, postId, currentUserId)
+      .then((data) => {
+        $('#request-record-access-modal-button').toggleClass('loading');
+        $('#request-record-access-modal').foundation('close');
 
-     window.location = window.wpApiShare.site_url + '/' + postType
+        window.location = window.wpApiShare.site_url + '/' + postType;
+      })
+      .catch((err) => {
+        // Capture any request exceptions
+        console.log('error');
+        console.log(err);
 
-    }).catch(err => {
+        $('#request-record-access-error').append(err.responseText);
 
-      // Capture any request exceptions
-      console.log("error")
-      console.log(err)
-
-      $('#request-record-access-error').append(err.responseText)
-
-      $('#request-record-access-modal-button').toggleClass('loading');
-      $('#request-record-access-modal').foundation('close');
-    })
-  })
-
-})
-
-
+        $('#request-record-access-modal-button').toggleClass('loading');
+        $('#request-record-access-modal').foundation('close');
+      });
+  });
+});

--- a/dt-assets/js/settings.js
+++ b/dt-assets/js/settings.js
@@ -1,35 +1,35 @@
-jQuery(document).ready(function() {
-  window.current_user_lookup = window.wpApiSettingsPage.current_user_id
-  load_locations()
+jQuery(document).ready(function () {
+  window.current_user_lookup = window.wpApiSettingsPage.current_user_id;
+  load_locations();
+});
 
-})
-
-function app_switch (app_key = null) {
-  let a = jQuery('#app_link_' + app_key)
-  a.empty().html(`<span class="loading-spinner active"></span>`)
-  window.makeRequest('post', 'users/app_switch', { app_key })
-    .done(function(data) {
+function app_switch(app_key = null) {
+  let a = jQuery('#app_link_' + app_key);
+  a.empty().html(`<span class="loading-spinner active"></span>`);
+  window
+    .makeRequest('post', 'users/app_switch', { app_key })
+    .done(function (data) {
       if ('removed' === data) {
-        jQuery('#app_link_' + app_key).empty()
+        jQuery('#app_link_' + app_key).empty();
       } else {
-        let u = a.data('url-base')
+        let u = a.data('url-base');
         a.empty().html(
           `<a class="button small"  href="${u}${data}" title="${window.wpApiSettingsPage.translations.link}"><i class="fi-link"></i></a>
-            <button class="button small copy_to_clipboard" data-value="${u}${data}" title="${window.wpApiSettingsPage.translations.copy}"><i class="fi-page-copy"></i></button>`
-        )
-        load_user_app_copy_to_clipboard_listener()
+            <button class="button small copy_to_clipboard" data-value="${u}${data}" title="${window.wpApiSettingsPage.translations.copy}"><i class="fi-page-copy"></i></button>`,
+        );
+        load_user_app_copy_to_clipboard_listener();
       }
     })
     .fail(function (err) {
-      console.log("error");
+      console.log('error');
       console.log(err);
-      a.empty().html(`error`)
+      a.empty().html(`error`);
     });
 }
 
 function load_user_app_copy_to_clipboard_listener() {
-  jQuery('.copy_to_clipboard').on('click', function(){
-    let str = jQuery(this).data('value')
+  jQuery('.copy_to_clipboard').on('click', function () {
+    let str = jQuery(this).data('value');
     const el = document.createElement('textarea');
     el.value = str;
     el.setAttribute('readonly', '');
@@ -47,10 +47,10 @@ function load_user_app_copy_to_clipboard_listener() {
       document.getSelection().removeAllRanges();
       document.getSelection().addRange(selected);
     }
-    alert('Copied')
-  })
+    alert('Copied');
+  });
 }
-load_user_app_copy_to_clipboard_listener()
+load_user_app_copy_to_clipboard_listener();
 
 /**
  * Password reset
@@ -59,297 +59,352 @@ load_user_app_copy_to_clipboard_listener()
  * @param type
  * @returns {*}
  */
-function switch_preference (preference_key, type = null) {
-    return window.makeRequest('post', 'users/switch_preference', { preference_key, type})
+function switch_preference(preference_key, type = null) {
+  return window.makeRequest('post', 'users/switch_preference', {
+    preference_key,
+    type,
+  });
 }
 
 function change_password() {
-    let translation = window.wpApiSettingsPage.translations
-    // test matching passwords
-    const p1 = jQuery('#password1')
-    const p2 = jQuery('#password2')
-    const message = jQuery('#password-message')
+  let translation = window.wpApiSettingsPage.translations;
+  // test matching passwords
+  const p1 = jQuery('#password1');
+  const p2 = jQuery('#password2');
+  const message = jQuery('#password-message');
 
-    message.empty()
+  message.empty();
 
-    if (p1.val() !== p2.val()) {
-        message.append(translation.pass_does_not_match)
-        return
-    }
+  if (p1.val() !== p2.val()) {
+    message.append(translation.pass_does_not_match);
+    return;
+  }
 
-    window.makeRequest('post', 'users/change_password', { password: p1 }).done(data => {
-        console.log( data )
-        message.html(translation.changed)
-    }).fail(window.handleAjaxError)
+  window
+    .makeRequest('post', 'users/change_password', { password: p1 })
+    .done((data) => {
+      console.log(data);
+      message.html(translation.changed);
+    })
+    .fail(window.handleAjaxError);
 }
 
 function load_locations() {
-  window.makeRequest( "GET", `user/my` )
-    .done(data=>{
-
-
-      if ( typeof window.dtMapbox !== "undefined" ) {
-        window.dtMapbox.post_type = 'user'
-        window.write_results_box()
-
+  window
+    .makeRequest('GET', `user/my`)
+    .done((data) => {
+      if (typeof window.dtMapbox !== 'undefined') {
+        window.dtMapbox.post_type = 'user';
+        window.write_results_box();
       } else {
         //locations
-        let typeahead = window.Typeahead['.js-typeahead-location_grid']
+        let typeahead = window.Typeahead['.js-typeahead-location_grid'];
         if (typeahead) {
           typeahead.items = [];
-          typeahead.comparedItems =[];
+          typeahead.comparedItems = [];
           typeahead.label.container.empty();
-          typeahead.adjustInputSize()
+          typeahead.adjustInputSize();
         }
-        if ( typeof data.locations.location_grid !== "undefined" ) {
-          data.locations.location_grid.forEach(location => {
-            typeahead.addMultiselectItemLayout({ID: location.id.toString(), name: location.label})
-          })
+        if (typeof data.locations.location_grid !== 'undefined') {
+          data.locations.location_grid.forEach((location) => {
+            typeahead.addMultiselectItemLayout({
+              ID: location.id.toString(),
+              name: location.label,
+            });
+          });
         }
-
       }
-    }).catch((e)=>{
-    console.log( 'error in locations')
-    console.log( e)
-  })
+    })
+    .catch((e) => {
+      console.log('error in locations');
+      console.log(e);
+    });
 }
 
-if ( typeof window.dtMapbox === "undefined" ) {
-  let typeaheadTotals = {}
-  if (!window.Typeahead['.js-typeahead-location_grid'] ){
+if (typeof window.dtMapbox === 'undefined') {
+  let typeaheadTotals = {};
+  if (!window.Typeahead['.js-typeahead-location_grid']) {
     jQuery.typeahead({
       input: '.js-typeahead-location_grid',
       minLength: 0,
       accent: true,
       searchOnFocus: true,
       maxItem: 20,
-      dropdownFilter: [{
-        key: 'group',
-        value: 'focus',
-        template: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.regions_of_focus),
-        all: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.all_locations),
-      }],
+      dropdownFilter: [
+        {
+          key: 'group',
+          value: 'focus',
+          template: window.SHAREDFUNCTIONS.escapeHTML(
+            window.wpApiShare.translations.regions_of_focus,
+          ),
+          all: window.SHAREDFUNCTIONS.escapeHTML(
+            window.wpApiShare.translations.all_locations,
+          ),
+        },
+      ],
       source: {
         focus: {
-          display: "name",
+          display: 'name',
           ajax: {
-            url: window.wpApiShare.root + 'dt/v1/mapping_module/search_location_grid_by_name',
+            url:
+              window.wpApiShare.root +
+              'dt/v1/mapping_module/search_location_grid_by_name',
             data: {
-              s: "{{query}}",
+              s: '{{query}}',
               filter: function () {
-                return window.lodash.get(window.Typeahead['.js-typeahead-location_grid'].filters.dropdown, 'value', 'all')
-              }
+                return window.lodash.get(
+                  window.Typeahead['.js-typeahead-location_grid'].filters
+                    .dropdown,
+                  'value',
+                  'all',
+                );
+              },
             },
             beforeSend: function (xhr) {
               xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce);
             },
             callback: {
               done: function (data) {
-                if (typeof window.typeaheadTotals !== "undefined") {
-                  window.typeaheadTotals.field = data.total
+                if (typeof window.typeaheadTotals !== 'undefined') {
+                  window.typeaheadTotals.field = data.total;
                 }
-                return data.location_grid
-              }
-            }
-          }
-        }
+                return data.location_grid;
+              },
+            },
+          },
+        },
       },
-      display: "name",
-      templateValue: "{{name}}",
+      display: 'name',
+      templateValue: '{{name}}',
       dynamic: true,
       multiselect: {
-        matchOn: ["ID"],
+        matchOn: ['ID'],
         data: function () {
           return [];
-        }, callback: {
+        },
+        callback: {
           onCancel: function (node, item) {
-            delete_location_grid( item.ID)
-          }
-        }
+            delete_location_grid(item.ID);
+          },
+        },
       },
       callback: {
-        onClick: function(node, a, item, event){
-          add_location_grid( item.ID)
+        onClick: function (node, a, item, event) {
+          add_location_grid(item.ID);
         },
-        onReady(){
-          this.filters.dropdown = {key: "group", value: "focus", template: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.regions_of_focus)}
+        onReady() {
+          this.filters.dropdown = {
+            key: 'group',
+            value: 'focus',
+            template: window.SHAREDFUNCTIONS.escapeHTML(
+              window.wpApiShare.translations.regions_of_focus,
+            ),
+          };
           this.container
-            .removeClass("filter")
-            .find("." + this.options.selector.filterButton)
-            .html(window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.regions_of_focus));
+            .removeClass('filter')
+            .find('.' + this.options.selector.filterButton)
+            .html(
+              window.SHAREDFUNCTIONS.escapeHTML(
+                window.wpApiShare.translations.regions_of_focus,
+              ),
+            );
         },
         onResult: function (node, query, result, resultCount) {
-          resultCount = typeaheadTotals.location_grid
-          let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+          resultCount = typeaheadTotals.location_grid;
+          let text = window.TYPEAHEADS.typeaheadHelpText(
+            resultCount,
+            query,
+            result,
+          );
           jQuery('#location_grid-result-container').html(text);
         },
         onHideLayout: function () {
-          jQuery('#location_grid-result-container').html("");
-        }
-      }
+          jQuery('#location_grid-result-container').html('');
+        },
+      },
     });
   }
 }
-let add_location_grid = ( value )=>{
-  let data =  {
-    grid_id: value
-  }
-  return window.makeRequest( "POST", `users/user_location`, data )
-}
-let delete_location_grid = ( value )=>{
-  let data =  {
-    grid_id: value
-  }
-  return window.makeRequest( "DELETE", `users/user_location`, data )
-}
+let add_location_grid = (value) => {
+  let data = {
+    grid_id: value,
+  };
+  return window.makeRequest('POST', `users/user_location`, data);
+};
+let delete_location_grid = (value) => {
+  let data = {
+    grid_id: value,
+  };
+  return window.makeRequest('DELETE', `users/user_location`, data);
+};
 
-
-let update_user = ( key, value )=>{
-  let data =  {
-    [key]: value
-  }
-  return window.makeRequest( "POST", `user/update`, data , 'dt/v1/' )
-}
+let update_user = (key, value) => {
+  let data = {
+    [key]: value,
+  };
+  return window.makeRequest('POST', `user/update`, data, 'dt/v1/');
+};
 
 /**
  * Set availability dates
  */
-let dateFields = [ "start_date", "end_date" ]
-  dateFields.forEach(key=>{
-    let datePicker = jQuery(`#${key}.date-picker`)
-    datePicker.datepicker({
-      onSelect: function (date) {
-        let start_date = jQuery('#start_date').val()
-        let end_date = jQuery('#end_date').val()
-        if ( start_date && end_date && ( window.moment(start_date) < window.moment(end_date) )){
-          jQuery('#add_unavailable_dates').removeAttr("disabled");
-        } else {
-          jQuery('#add_unavailable_dates').attr("disabled", true);
-        }
-      },
-      dateFormat: 'yy-mm-dd',
-      changeMonth: true,
-      changeYear: true,
-      yearRange: "-20:+10",
-    })
-  })
+let dateFields = ['start_date', 'end_date'];
+dateFields.forEach((key) => {
+  let datePicker = jQuery(`#${key}.date-picker`);
+  datePicker.datepicker({
+    onSelect: function (date) {
+      let start_date = jQuery('#start_date').val();
+      let end_date = jQuery('#end_date').val();
+      if (
+        start_date &&
+        end_date &&
+        window.moment(start_date) < window.moment(end_date)
+      ) {
+        jQuery('#add_unavailable_dates').removeAttr('disabled');
+      } else {
+        jQuery('#add_unavailable_dates').attr('disabled', true);
+      }
+    },
+    dateFormat: 'yy-mm-dd',
+    changeMonth: true,
+    changeYear: true,
+    yearRange: '-20:+10',
+  });
+});
 
 jQuery('#add_unavailable_dates').on('click', function () {
-  let start_date = jQuery('#start_date').val()
-  let end_date = jQuery('#end_date').val()
-  jQuery('#add_unavailable_dates_spinner').addClass('active')
-  update_user( 'add_unavailability', {start_date, end_date}).then((resp)=>{
-    jQuery('#add_unavailable_dates_spinner').removeClass('active')
-    jQuery('#start_date').val('')
-    jQuery('#end_date').val('')
-    display_dates_unavailable(resp)
-  })
-})
-let display_dates_unavailable = (list = [], first_run )=>{
-  let date_unavailable_table = jQuery('#unavailable-list')
-  let rows = ``
-  list = window.lodash.orderBy( list, [ "start_date" ], "desc")
-  list.forEach(range=>{
+  let start_date = jQuery('#start_date').val();
+  let end_date = jQuery('#end_date').val();
+  jQuery('#add_unavailable_dates_spinner').addClass('active');
+  update_user('add_unavailability', { start_date, end_date }).then((resp) => {
+    jQuery('#add_unavailable_dates_spinner').removeClass('active');
+    jQuery('#start_date').val('');
+    jQuery('#end_date').val('');
+    display_dates_unavailable(resp);
+  });
+});
+let display_dates_unavailable = (list = [], first_run) => {
+  let date_unavailable_table = jQuery('#unavailable-list');
+  let rows = ``;
+  list = window.lodash.orderBy(list, ['start_date'], 'desc');
+  list.forEach((range) => {
     rows += `<tr>
         <td>${window.SHAREDFUNCTIONS.escapeHTML(range.start_date)}</td>
         <td>${window.SHAREDFUNCTIONS.escapeHTML(range.end_date)}</td>
         <td>
             <button class="button hollow tiny alert remove_dates_unavailable" data-id="${window.SHAREDFUNCTIONS.escapeHTML(range.id)}" style="margin-bottom: 0">
-            <i class="fi-x"></i> ${window.SHAREDFUNCTIONS.escapeHTML( window.wpApiSettingsPage.translations.delete )}</button>
+            <i class="fi-x"></i> ${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiSettingsPage.translations.delete)}</button>
         </td>
-      </tr>`
-  })
-  if ( rows || ( !rows && !first_run ) ){
-    date_unavailable_table.html(rows)
+      </tr>`;
+  });
+  if (rows || (!rows && !first_run)) {
+    date_unavailable_table.html(rows);
   }
-}
-display_dates_unavailable( window.wpApiSettingsPage.custom_data.availability, true )
-jQuery( document).on( 'click', '.remove_dates_unavailable', function () {
+};
+display_dates_unavailable(
+  window.wpApiSettingsPage.custom_data.availability,
+  true,
+);
+jQuery(document).on('click', '.remove_dates_unavailable', function () {
   let id = jQuery(this).data('id');
-  update_user( 'remove_unavailability', id).then((resp)=>{
-    display_dates_unavailable(resp)
-  })
-})
+  update_user('remove_unavailability', id).then((resp) => {
+    display_dates_unavailable(resp);
+  });
+});
 
-let status_buttons = jQuery('.status-button')
-let color_workload_buttons = (name) =>{
-  status_buttons.css('background-color', "")
-  status_buttons.addClass("hollow")
-  if ( name ){
-    let selected = jQuery(`.status-button[name=${name}]`)
-    selected.removeClass("hollow")
-    selected.css('background-color', window.lodash.get(window.wpApiSettingsPage, `workload_status_options.${name}.color`))
-    selected.blur()
+let status_buttons = jQuery('.status-button');
+let color_workload_buttons = (name) => {
+  status_buttons.css('background-color', '');
+  status_buttons.addClass('hollow');
+  if (name) {
+    let selected = jQuery(`.status-button[name=${name}]`);
+    selected.removeClass('hollow');
+    selected.css(
+      'background-color',
+      window.lodash.get(
+        window.wpApiSettingsPage,
+        `workload_status_options.${name}.color`,
+      ),
+    );
+    selected.blur();
   }
-}
-color_workload_buttons(window.wpApiSettingsPage.workload_status )
-status_buttons.on( 'click', function () {
-  jQuery("#workload-spinner").addClass("active")
-  let name = jQuery(this).attr('name')
-  color_workload_buttons(name)
-  update_user( 'workload_status', name )
-  .then(()=>{
-    jQuery("#workload-spinner").removeClass("active")
-  }).fail(()=>{
-    status_buttons.css('background-color', "")
-    jQuery("#workload-spinner").removeClass("active")
-    status_buttons.addClass("hollow")
-  })
-})
+};
+color_workload_buttons(window.wpApiSettingsPage.workload_status);
+status_buttons.on('click', function () {
+  jQuery('#workload-spinner').addClass('active');
+  let name = jQuery(this).attr('name');
+  color_workload_buttons(name);
+  update_user('workload_status', name)
+    .then(() => {
+      jQuery('#workload-spinner').removeClass('active');
+    })
+    .fail(() => {
+      status_buttons.css('background-color', '');
+      jQuery('#workload-spinner').removeClass('active');
+      status_buttons.addClass('hollow');
+    });
+});
 
-
-jQuery('button.dt_multi_select').on('click',function () {
-  let fieldKey = jQuery(this).data("field-key")
-  let optionKey = jQuery(this).attr('id')
-  jQuery(`#${fieldKey}-spinner`).addClass("active")
-  let field = jQuery(`[data-field-key="${fieldKey}"]#${optionKey}`)
-  field.addClass("submitting-select-button")
-  let action = "add"
-  let update_request = null
-  if (field.hasClass("selected-select-button")){
-    action = "delete"
-    update_request = update_user( 'remove_' + fieldKey, optionKey )
+jQuery('button.dt_multi_select').on('click', function () {
+  let fieldKey = jQuery(this).data('field-key');
+  let optionKey = jQuery(this).attr('id');
+  jQuery(`#${fieldKey}-spinner`).addClass('active');
+  let field = jQuery(`[data-field-key="${fieldKey}"]#${optionKey}`);
+  field.addClass('submitting-select-button');
+  let action = 'add';
+  let update_request = null;
+  if (field.hasClass('selected-select-button')) {
+    action = 'delete';
+    update_request = update_user('remove_' + fieldKey, optionKey);
   } else {
-    field.removeClass("empty-select-button")
-    field.addClass("selected-select-button")
-    update_request = update_user( 'add_' + fieldKey, optionKey )
+    field.removeClass('empty-select-button');
+    field.addClass('selected-select-button');
+    update_request = update_user('add_' + fieldKey, optionKey);
   }
-  update_request.then(()=>{
-    field.removeClass("submitting-select-button selected-select-button")
-    field.blur();
-    field.addClass( action === "delete" ? "empty-select-button" : "selected-select-button");
-    jQuery(`#${fieldKey}-spinner`).removeClass("active")
-  }).catch(err=>{
-    field.removeClass("submitting-select-button selected-select-button")
-    field.addClass( action === "add" ? "empty-select-button" : "selected-select-button")
-    window.handleAjaxError(err)
-  })
-})
-jQuery('select.select-field').change(e => {
-  const id = jQuery(e.currentTarget).attr('id')
-  const val = jQuery(e.currentTarget).val()
-  jQuery(`#${id}-spinner`).addClass("active")
-  update_user(id, val).then(()=>{
-    jQuery(`#${id}-spinner`).removeClass("active")
-  }).catch(window.handleAjaxError)
-})
+  update_request
+    .then(() => {
+      field.removeClass('submitting-select-button selected-select-button');
+      field.blur();
+      field.addClass(
+        action === 'delete' ? 'empty-select-button' : 'selected-select-button',
+      );
+      jQuery(`#${fieldKey}-spinner`).removeClass('active');
+    })
+    .catch((err) => {
+      field.removeClass('submitting-select-button selected-select-button');
+      field.addClass(
+        action === 'add' ? 'empty-select-button' : 'selected-select-button',
+      );
+      window.handleAjaxError(err);
+    });
+});
+jQuery('select.select-field').change((e) => {
+  const id = jQuery(e.currentTarget).attr('id');
+  const val = jQuery(e.currentTarget).val();
+  jQuery(`#${id}-spinner`).addClass('active');
+  update_user(id, val)
+    .then(() => {
+      jQuery(`#${id}-spinner`).removeClass('active');
+    })
+    .catch(window.handleAjaxError);
+});
 jQuery('input[name="email-preference"]').on('change', (e) => {
-  const optionId = e.target.id.replace('-preference', '')
-  const loadingSpinner = jQuery('#email-preference-spinner')
-  loadingSpinner.addClass('active')
+  const optionId = e.target.id.replace('-preference', '');
+  const loadingSpinner = jQuery('#email-preference-spinner');
+  loadingSpinner.addClass('active');
   update_user('email-preference', optionId)
-  .then(() => {
-    loadingSpinner.removeClass('active')
-  })
-  .fail(() => {
-    loadingSpinner.removeClass('active')
-  })
-})
+    .then(() => {
+      loadingSpinner.removeClass('active');
+    })
+    .fail(() => {
+      loadingSpinner.removeClass('active');
+    });
+});
 
 /**
  * People groups
  */
-if ( jQuery('.js-typeahead-people_groups').length) {
+if (jQuery('.js-typeahead-people_groups').length) {
   jQuery.typeahead({
     input: '.js-typeahead-people_groups',
     minLength: 0,
@@ -357,44 +412,48 @@ if ( jQuery('.js-typeahead-people_groups').length) {
     searchOnFocus: true,
     maxItem: 20,
     template: window.TYPEAHEADS.contactListRowTemplate,
-    source: window.TYPEAHEADS.typeaheadPostsSource("peoplegroups"),
-    display: ["name", "label"],
+    source: window.TYPEAHEADS.typeaheadPostsSource('peoplegroups'),
+    display: ['name', 'label'],
     templateValue: function () {
       if (this.items[this.items.length - 1].label) {
-        return "{{label}}"
+        return '{{label}}';
       } else {
-        return "{{name}}"
+        return '{{name}}';
       }
     },
     dynamic: true,
     multiselect: {
-      matchOn: ["ID"],
+      matchOn: ['ID'],
       data: function () {
-        return window.wpApiSettingsPage.user_people_groups.map(g => {
-          return {ID: g.ID, name: g.post_title};
-        })
+        return window.wpApiSettingsPage.user_people_groups.map((g) => {
+          return { ID: g.ID, name: g.post_title };
+        });
       },
       callback: {
         onCancel: function (node, item) {
-          update_user('remove_people_groups', item.ID)
-        }
+          update_user('remove_people_groups', item.ID);
+        },
       },
     },
     callback: {
       onClick: function (node, a, item, event) {
-        update_user('add_people_groups', item.ID)
-        this.addMultiselectItemLayout(item)
-        event.preventDefault()
+        update_user('add_people_groups', item.ID);
+        this.addMultiselectItemLayout(item);
+        event.preventDefault();
         this.hideLayout();
         this.resetInput();
       },
       onResult: function (node, query, result, resultCount) {
-        let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+        let text = window.TYPEAHEADS.typeaheadHelpText(
+          resultCount,
+          query,
+          result,
+        );
         jQuery('#people_groups-result-container').html(text);
       },
       onHideLayout: function () {
-        jQuery('#people_groups-result-container').html("");
-      }
-    }
-  })
+        jQuery('#people_groups-result-container').html('');
+      },
+    },
+  });
 }

--- a/dt-assets/js/shared-functions.js
+++ b/dt-assets/js/shared-functions.js
@@ -2,43 +2,42 @@
 
 jQuery(document).ready(function ($) {
   // Adds an active state to the top bar navigation
-  let ref = "";
+  let ref = '';
   if (wpApiShare && wpApiShare.site_url) {
-    ref = window.location.href.replace(wpApiShare.site_url + "/", "");
+    ref = window.location.href.replace(wpApiShare.site_url + '/', '');
   } else {
     ref = window.location.pathname;
   }
-  let page = `${ref.replace(wpApiShare.site_url, "").split("/")[0] + ""}`;
-  $(`div.top-bar-left ul.menu [href^="${wpApiShare.site_url + "/" + page}"]`)
+  let page = `${ref.replace(wpApiShare.site_url, '').split('/')[0] + ''}`;
+  $(`div.top-bar-left ul.menu [href^="${wpApiShare.site_url + '/' + page}"]`)
     .parent()
-    .addClass("active");
+    .addClass('active');
 
-  let collapsed_tiles = window.SHAREDFUNCTIONS.get_json_cookie(
-    "collapsed_tiles"
-  );
+  let collapsed_tiles =
+    window.SHAREDFUNCTIONS.get_json_cookie('collapsed_tiles');
   // expand and collapse tiles, only when a section chevron icon is clicked for that given tile.
-  $(".section-header .section-chevron").on("click", function () {
-    let tile = $(this).closest(".bordered-box");
-    tile.toggleClass("collapsed");
-    let tile_id = tile.attr("id");
-    if (tile_id && tile_id.includes("-tile")) {
+  $('.section-header .section-chevron').on('click', function () {
+    let tile = $(this).closest('.bordered-box');
+    tile.toggleClass('collapsed');
+    let tile_id = tile.attr('id');
+    if (tile_id && tile_id.includes('-tile')) {
       if (collapsed_tiles.includes(tile_id)) {
         collapsed_tiles = window.lodash.pull(collapsed_tiles, tile_id);
       } else {
         collapsed_tiles.push(tile_id);
       }
       window.SHAREDFUNCTIONS.save_json_cookie(
-        "collapsed_tiles",
+        'collapsed_tiles',
         collapsed_tiles,
-        wpApiShare.post_type
+        wpApiShare.post_type,
       );
     }
-    $(".grid").masonry("layout");
+    $('.grid').masonry('layout');
   });
-  $(".bordered-box").each((index, item) => {
-    let id = $(item).attr("id");
-    if (id && id.includes("-tile") && collapsed_tiles.includes(id)) {
-      $(item).addClass("collapsed");
+  $('.bordered-box').each((index, item) => {
+    let id = $(item).attr('id');
+    if (id && id.includes('-tile') && collapsed_tiles.includes(id)) {
+      $(item).addClass('collapsed');
     }
   });
 });
@@ -51,23 +50,23 @@ jQuery(document).ready(function ($) {
  * @param base, when using a custom D.T endpoint that does not start with dt/v1
  * @returns {jQuery}
  */
-function makeRequest(type, url, data, base = "dt/v1/") {
+function makeRequest(type, url, data, base = 'dt/v1/') {
   //make sure base has a trailing slash if url does not start with one
-  if ( !base.endsWith('/') && !url.startsWith('/')){
-    base += '/'
+  if (!base.endsWith('/') && !url.startsWith('/')) {
+    base += '/';
   }
   const options = {
     type: type,
-    contentType: "application/json; charset=utf-8",
-    dataType: "json",
-    url: url.startsWith("http") ? url : `${wpApiShare.root}${base}${url}`,
+    contentType: 'application/json; charset=utf-8',
+    dataType: 'json',
+    url: url.startsWith('http') ? url : `${wpApiShare.root}${base}${url}`,
     beforeSend: (xhr) => {
-      xhr.setRequestHeader("X-WP-Nonce", wpApiShare.nonce);
+      xhr.setRequestHeader('X-WP-Nonce', wpApiShare.nonce);
     },
   };
 
   if (data && !window.lodash.isEmpty(data)) {
-    options.data = type === "GET" ? data : JSON.stringify(data);
+    options.data = type === 'GET' ? data : JSON.stringify(data);
   }
 
   return jQuery.ajax(options);
@@ -76,42 +75,42 @@ function makeRequest(type, url, data, base = "dt/v1/") {
 function makeRequestOnPosts(type, url, data) {
   const options = {
     type: type,
-    contentType: "application/json; charset=utf-8",
-    dataType: "json",
-    url: url.startsWith("http") ? url : `${wpApiShare.root}dt-posts/v2/${url}`,
+    contentType: 'application/json; charset=utf-8',
+    dataType: 'json',
+    url: url.startsWith('http') ? url : `${wpApiShare.root}dt-posts/v2/${url}`,
     beforeSend: (xhr) => {
-      xhr.setRequestHeader("X-WP-Nonce", wpApiShare.nonce);
+      xhr.setRequestHeader('X-WP-Nonce', wpApiShare.nonce);
     },
   };
   if (data && !window.lodash.isEmpty(data)) {
-    options.data = type === "GET" ? data : JSON.stringify(data);
+    options.data = type === 'GET' ? data : JSON.stringify(data);
   }
   return jQuery.ajax(options);
 }
 
 window.API = {
   get_post: (post_type, postId) =>
-    makeRequestOnPosts("GET", `${post_type}/${postId}`),
+    makeRequestOnPosts('GET', `${post_type}/${postId}`),
 
   create_post: (post_type, fields) =>
-    makeRequestOnPosts("POST", `${post_type}`, fields),
+    makeRequestOnPosts('POST', `${post_type}`, fields),
 
   update_post: (post_type, postId, postData) =>
-    makeRequestOnPosts("POST", `${post_type}/${postId}`, postData),
+    makeRequestOnPosts('POST', `${post_type}/${postId}`, postData),
 
   delete_post: (post_type, postId) =>
-    makeRequestOnPosts("DELETE", `${post_type}/${postId}`),
+    makeRequestOnPosts('DELETE', `${post_type}/${postId}`),
 
-  post_comment: (post_type, postId, comment, comment_type = "comment") =>
-    makeRequestOnPosts("POST", `${post_type}/${postId}/comments`, {
+  post_comment: (post_type, postId, comment, comment_type = 'comment') =>
+    makeRequestOnPosts('POST', `${post_type}/${postId}/comments`, {
       comment,
       comment_type,
     }),
 
   delete_comment: (post_type, postId, comment_ID) =>
     makeRequestOnPosts(
-      "DELETE",
-      `${post_type}/${postId}/comments/${comment_ID}`
+      'DELETE',
+      `${post_type}/${postId}/comments/${comment_ID}`,
     ),
 
   update_comment: (
@@ -119,108 +118,118 @@ window.API = {
     postId,
     comment_ID,
     comment_content,
-    commentType = "comment"
+    commentType = 'comment',
   ) =>
     makeRequestOnPosts(
-      "POST",
+      'POST',
       `${post_type}/${postId}/comments/${comment_ID}`,
-      { comment: comment_content, comment_type: commentType }
+      { comment: comment_content, comment_type: commentType },
     ),
 
   get_comments: (post_type, postId) =>
-    makeRequestOnPosts("GET", `${post_type}/${postId}/comments`),
+    makeRequestOnPosts('GET', `${post_type}/${postId}/comments`),
 
   toggle_comment_reaction: (postType, postId, commentId, reaction) => {
     makeRequestOnPosts(
-      "POST",
+      'POST',
       `${postType}/${postId}/comments/${commentId}/react`,
-      { reaction: reaction }
-    )
+      { reaction: reaction },
+    );
   },
 
   get_activity: (post_type, postId, data = {}) =>
-    makeRequestOnPosts("GET", `${post_type}/${postId}/activity`, data),
+    makeRequestOnPosts('GET', `${post_type}/${postId}/activity`, data),
 
   revert_activity_history: (post_type, post_id, data = {}) =>
-    makeRequestOnPosts("POST", `${post_type}/${post_id}/revert_activity_history`, data),
+    makeRequestOnPosts(
+      'POST',
+      `${post_type}/${post_id}/revert_activity_history`,
+      data,
+    ),
 
   get_single_activity: (post_type, postId, activityId) =>
-    makeRequestOnPosts("GET", `${post_type}/${postId}/activity/${activityId}`),
+    makeRequestOnPosts('GET', `${post_type}/${postId}/activity/${activityId}`),
 
   get_shared: (post_type, postId) =>
-    makeRequestOnPosts("GET", `${post_type}/${postId}/shares`),
+    makeRequestOnPosts('GET', `${post_type}/${postId}/shares`),
 
   add_shared: (post_type, postId, userId) =>
-    makeRequestOnPosts("POST", `${post_type}/${postId}/shares`, {
+    makeRequestOnPosts('POST', `${post_type}/${postId}/shares`, {
       user_id: userId,
     }),
 
   remove_shared: (post_type, postId, userId) =>
-    makeRequestOnPosts("DELETE", `${post_type}/${postId}/shares`, {
+    makeRequestOnPosts('DELETE', `${post_type}/${postId}/shares`, {
       user_id: userId,
     }),
 
   save_field_api: (post_type, postId, postData) =>
-    makeRequestOnPosts("POST", `${post_type}/${postId}`, postData),
+    makeRequestOnPosts('POST', `${post_type}/${postId}`, postData),
 
   revert_activity: (post_type, postId, activityId) =>
-    makeRequestOnPosts("GET", `${post_type}/${postId}/revert/${activityId}`),
+    makeRequestOnPosts('GET', `${post_type}/${postId}/revert/${activityId}`),
 
-  search_users: (query) => makeRequest("GET", `users/get_users?s=${query}`),
+  search_users: (query) => makeRequest('GET', `users/get_users?s=${query}`),
 
-  get_filters: () => makeRequest("GET", "users/get_filters"),
+  get_filters: () => makeRequest('GET', 'users/get_filters'),
 
   save_filters: (post_type, filter) =>
-    makeRequest("POST", "users/save_filters", { filter, post_type }),
+    makeRequest('POST', 'users/save_filters', { filter, post_type }),
 
   delete_filter: (post_type, id) =>
-    makeRequest("DELETE", "users/save_filters", { id, post_type }),
+    makeRequest('DELETE', 'users/save_filters', { id, post_type }),
 
   get_duplicates_on_post: (post_type, postId, args) =>
-    makeRequestOnPosts("GET", `${post_type}/${postId}/all_duplicates`, args),
+    makeRequestOnPosts('GET', `${post_type}/${postId}/all_duplicates`, args),
 
-  create_user: (user) => makeRequest("POST", "users/create", user),
+  create_user: (user) => makeRequest('POST', 'users/create', user),
 
   transfer_contact: (contactId, siteId) =>
-    makeRequestOnPosts("POST", "contacts/transfer", {
+    makeRequestOnPosts('POST', 'contacts/transfer', {
       contact_id: contactId,
       site_post_id: siteId,
     }),
 
   transfer_contact_summary_update: (contactId, update) =>
-    makeRequestOnPosts("POST", "contacts/transfer/summary/send-update", {
+    makeRequestOnPosts('POST', 'contacts/transfer/summary/send-update', {
       contact_id: contactId,
       update: update,
     }),
 
   request_record_access: (post_type, postId, userId) =>
-    makeRequestOnPosts("POST", `${post_type}/${postId}/request_record_access`, {
+    makeRequestOnPosts('POST', `${post_type}/${postId}/request_record_access`, {
       user_id: userId,
     }),
 
-  advanced_search: (search_query, post_type, offset, filters) => makeRequest("GET", `advanced_search`, {
-    query: search_query,
-    post_type: post_type,
-    offset: offset,
-    post: filters['post'],
-    comment: filters['comment'],
-    meta: filters['meta'],
-    status: filters['status']
-  }, 'dt-posts/v2/posts/search/'),
+  advanced_search: (search_query, post_type, offset, filters) =>
+    makeRequest(
+      'GET',
+      `advanced_search`,
+      {
+        query: search_query,
+        post_type: post_type,
+        offset: offset,
+        post: filters['post'],
+        comment: filters['comment'],
+        meta: filters['meta'],
+        status: filters['status'],
+      },
+      'dt-posts/v2/posts/search/',
+    ),
 
   split_by: (post_type, field_id, filters) =>
-    makeRequestOnPosts("POST", `${post_type}/split_by`, {
-      'field_id': field_id,
-      'filters': filters
-    })
+    makeRequestOnPosts('POST', `${post_type}/split_by`, {
+      field_id: field_id,
+      filters: filters,
+    }),
 };
 
 function handleAjaxError(err) {
   if (
-    window.lodash.get(err, "statusText") !== "abortPromise" &&
+    window.lodash.get(err, 'statusText') !== 'abortPromise' &&
     err.responseText
   ) {
-    console.trace("error");
+    console.trace('error');
     console.log(err);
     // jQuery("#errors").append(err.responseText)
   }
@@ -228,15 +237,22 @@ function handleAjaxError(err) {
 
 jQuery(document)
   .ajaxComplete((event, xhr, settings) => {
-    if ( xhr && xhr.responseJSON && settings.type === "POST" ) {
+    if (xhr && xhr.responseJSON && settings.type === 'POST') {
       // Event that a contact record has been updated, check to make sure the post type that is being updated is the same as the current page post type.
-      if ( xhr.responseJSON.ID && xhr.responseJSON.post_type &&  xhr.responseJSON.post_type === window.detailsSettings?.post_type ) {
+      if (
+        xhr.responseJSON.ID &&
+        xhr.responseJSON.post_type &&
+        xhr.responseJSON.post_type === window.detailsSettings?.post_type
+      ) {
         let request = settings.data ? JSON.parse(settings.data) : {};
-        jQuery(document).trigger("dt_record_updated", [xhr.responseJSON, request]);
+        jQuery(document).trigger('dt_record_updated', [
+          xhr.responseJSON,
+          request,
+        ]);
       }
     }
 
-    if (window.lodash.get(xhr, "responseJSON.data.status") === 401) {
+    if (window.lodash.get(xhr, 'responseJSON.data.status') === 401) {
       window.location.reload();
     }
   })
@@ -244,48 +260,52 @@ jQuery(document)
     handleAjaxError(xhr);
   });
 
-jQuery(document).on("click", ".help-button", function () {
-  jQuery("#help-modal").foundation("open");
-  let section = jQuery(this).data("section");
-  jQuery(".help-section").hide();
+jQuery(document).on('click', '.help-button', function () {
+  jQuery('#help-modal').foundation('open');
+  let section = jQuery(this).data('section');
+  jQuery('.help-section').hide();
   jQuery(`#${section}`).show();
 });
-jQuery(document).on("click", ".help-button-tile", function () {
-  jQuery("#help-modal-field").foundation("open");
-  let section = jQuery(this).data("tile");
-  jQuery(".help-section").hide();
+jQuery(document).on('click', '.help-button-tile', function () {
+  jQuery('#help-modal-field').foundation('open');
+  let section = jQuery(this).data('tile');
+  jQuery('.help-section').hide();
   let tile = window.wpApiShare.tiles[section];
   if (tile && window.post_type_fields) {
     if (tile.label) {
       let tile_label = window.SHAREDFUNCTIONS.escapeHTML(tile.label);
-      if ( window.wpApiShare.can_manage_dt ){
-        let edit_link = `${window.wpApiShare.site_url}/wp-admin/admin.php?page=dt_customizations&post_type=${window.wpApiShare.post_type}&tile=${section}`
+      if (window.wpApiShare.can_manage_dt) {
+        let edit_link = `${window.wpApiShare.site_url}/wp-admin/admin.php?page=dt_customizations&post_type=${window.wpApiShare.post_type}&tile=${section}`;
         tile_label += ` <span style="font-size: 10px"><a href="${window.SHAREDFUNCTIONS.escapeHTML(edit_link)}" target="_blank">${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.edit)}</a></span>`;
       }
-      jQuery("#help-modal-field-title").html(tile_label);
+      jQuery('#help-modal-field-title').html(tile_label);
     }
     if (tile.description) {
-      jQuery("#help-modal-field-description").html(window.SHAREDFUNCTIONS.escapeHTML(tile.description));
-      window.SHAREDFUNCTIONS.make_links_clickable('#help-modal-field-description' )
+      jQuery('#help-modal-field-description').html(
+        window.SHAREDFUNCTIONS.escapeHTML(tile.description),
+      );
+      window.SHAREDFUNCTIONS.make_links_clickable(
+        '#help-modal-field-description',
+      );
     } else {
-      jQuery("#help-modal-field-description").empty()
+      jQuery('#help-modal-field-description').empty();
     }
-    let order = window.wpApiShare.tiles[section]["order"] || [];
+    let order = window.wpApiShare.tiles[section]['order'] || [];
     window.lodash.forOwn(window.post_type_fields, (field, field_key) => {
-      if ( field.tile === section && !order.includes(field_key)){
+      if (field.tile === section && !order.includes(field_key)) {
         order.push(field_key);
       }
-    })
+    });
     let html = ``;
-    order.forEach( field_key=>{
-      let field = window.post_type_fields[field_key]
-      if ( field && field.tile === section && !field.hidden ) {
+    order.forEach((field_key) => {
+      let field = window.post_type_fields[field_key];
+      if (field && field.tile === section && !field.hidden) {
         let field_name = `<h2>${window.SHAREDFUNCTIONS.escapeHTML(field.name)}</h2>`;
-        if ( window.wpApiShare.can_manage_dt ){
-          let edit_link = `${window.wpApiShare.site_url}/wp-admin/admin.php?page=dt_customizations&post_type=${window.wpApiShare.post_type}&tile=${field.tile}#${field_key}`
+        if (window.wpApiShare.can_manage_dt) {
+          let edit_link = `${window.wpApiShare.site_url}/wp-admin/admin.php?page=dt_customizations&post_type=${window.wpApiShare.post_type}&tile=${field.tile}#${field_key}`;
           field_name = `<h2>${window.SHAREDFUNCTIONS.escapeHTML(field.name)} <span style="font-size: 10px"><a href="${window.SHAREDFUNCTIONS.escapeHTML(edit_link)}" target="_blank">${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.edit)}</a></span></h2>`;
         }
-        html += field_name
+        html += field_name;
         html += `<p>${window.SHAREDFUNCTIONS.escapeHTML(field.description)}</p>`;
 
         if (window.lodash.isObject(field.default)) {
@@ -293,22 +313,24 @@ jQuery(document).on("click", ".help-button-tile", function () {
           let first_field_option = true;
           window.lodash.forOwn(field.default, (field_options, field_key) => {
             if (Object.prototype.hasOwnProperty.call(field_options, 'icon')) {
-              if ( first_field_option ) {
+              if (first_field_option) {
                 list_html += `<ul class="help-modal-icon">`;
                 first_field_option = false;
               }
               list_html += `<li><img src="${window.SHAREDFUNCTIONS.escapeHTML(field_options.icon)}">`;
             } else {
-              if ( first_field_option ) {
+              if (first_field_option) {
                 list_html += `<ul>`;
                 first_field_option = false;
               }
               list_html += `<li>`;
             }
             list_html += `<strong>${window.SHAREDFUNCTIONS.escapeHTML(
-              field_options.label
+              field_options.label,
             )}</strong> ${window.SHAREDFUNCTIONS.escapeHTML(
-              !field_options.description ? "" : "- " + field_options.description
+              !field_options.description
+                ? ''
+                : '- ' + field_options.description,
             )}</li>`;
           });
           list_html += `</ul>`;
@@ -316,37 +338,43 @@ jQuery(document).on("click", ".help-button-tile", function () {
         }
       }
     });
-    jQuery("#help-modal-field-body").html(html);
+    jQuery('#help-modal-field-body').html(html);
   }
   /* #apps for example was the tile id, so this is the new more unique id to show relevant help text */
   jQuery(`#tile-help-section-${section}`).show();
   jQuery(`#${section}`).show();
 });
-jQuery(document).on("click", ".help-button-field", function () {
-  jQuery("#help-modal-field").foundation("open");
-  let section = jQuery(this).data("section").replace("-help-text", "");
-  jQuery(".help-section").hide();
+jQuery(document).on('click', '.help-button-field', function () {
+  jQuery('#help-modal-field').foundation('open');
+  let section = jQuery(this).data('section').replace('-help-text', '');
+  jQuery('.help-section').hide();
 
   if (window.post_type_fields && window.post_type_fields[section]) {
     let field = window.post_type_fields[section];
-    jQuery("#help-modal-field-title").html(window.SHAREDFUNCTIONS.escapeHTML(field.name));
+    jQuery('#help-modal-field-title').html(
+      window.SHAREDFUNCTIONS.escapeHTML(field.name),
+    );
     if (field.description) {
-      jQuery("#help-modal-field-description").html(window.SHAREDFUNCTIONS.escapeHTML(field.description));
-      window.SHAREDFUNCTIONS.make_links_clickable('#help-modal-field-description' )
+      jQuery('#help-modal-field-description').html(
+        window.SHAREDFUNCTIONS.escapeHTML(field.description),
+      );
+      window.SHAREDFUNCTIONS.make_links_clickable(
+        '#help-modal-field-description',
+      );
     } else {
-      jQuery("#help-modal-field-description").empty()
+      jQuery('#help-modal-field-description').empty();
     }
     if (window.lodash.isObject(field.default)) {
       let html = `<ul>`;
       window.lodash.forOwn(field.default, (field_options, field_key) => {
         html += `<li><strong>${window.SHAREDFUNCTIONS.escapeHTML(
-          field_options.label
+          field_options.label,
         )}</strong> ${window.SHAREDFUNCTIONS.escapeHTML(
-          !field_options.description ? "" : "- " + field_options.description
+          !field_options.description ? '' : '- ' + field_options.description,
         )}</li>`;
       });
       html += `</ul>`;
-      jQuery("#help-modal-field-body").html(html);
+      jQuery('#help-modal-field-body').html(html);
     }
   }
   jQuery(`#${section}`).show();
@@ -356,19 +384,19 @@ window.TYPEAHEADS = {
   typeaheadSource: function (field, url) {
     return {
       contacts: {
-        display: ["name", "ID"],
-        template: "<span>{{name}}</span>",
+        display: ['name', 'ID'],
+        template: '<span>{{name}}</span>',
         ajax: {
           url: wpApiShare.root + url,
           data: {
-            s: "{{query}}",
+            s: '{{query}}',
           },
           beforeSend: function (xhr) {
-            xhr.setRequestHeader("X-WP-Nonce", wpApiShare.nonce);
+            xhr.setRequestHeader('X-WP-Nonce', wpApiShare.nonce);
           },
           callback: {
             done: function (data) {
-              if (typeof window.typeaheadTotals !== "undefined") {
+              if (typeof window.typeaheadTotals !== 'undefined') {
                 window.typeaheadTotals.field = data.total;
               }
               return data.posts;
@@ -378,21 +406,21 @@ window.TYPEAHEADS = {
       },
     };
   },
-  typeaheadUserSource : function (field, url) {
+  typeaheadUserSource: function (field, url) {
     let payload = {
-      s: "{{query}}"
+      s: '{{query}}',
     };
-    if ( window.detailsSettings && window.detailsSettings.post_type ) {
+    if (window.detailsSettings && window.detailsSettings.post_type) {
       payload['post_type'] = window.detailsSettings.post_type;
     }
     return {
       users: {
-        display: ["name", "user"],
+        display: ['name', 'user'],
         ajax: {
-          url: wpApiShare.root + "dt/v1/users/get_users",
+          url: wpApiShare.root + 'dt/v1/users/get_users',
           data: payload,
           beforeSend: function (xhr) {
-            xhr.setRequestHeader("X-WP-Nonce", wpApiShare.nonce);
+            xhr.setRequestHeader('X-WP-Nonce', wpApiShare.nonce);
           },
           callback: {
             done: function (data) {
@@ -406,14 +434,14 @@ window.TYPEAHEADS = {
   typeaheadContactsSource: function () {
     return {
       contacts: {
-        display: ["name", "ID"],
+        display: ['name', 'ID'],
         ajax: {
-          url: wpApiShare.root + "dt-posts/v2/contacts/compact",
+          url: wpApiShare.root + 'dt-posts/v2/contacts/compact',
           data: {
-            s: "{{query}}",
+            s: '{{query}}',
           },
           beforeSend: function (xhr) {
-            xhr.setRequestHeader("X-WP-Nonce", wpApiShare.nonce);
+            xhr.setRequestHeader('X-WP-Nonce', wpApiShare.nonce);
           },
           callback: {
             done: function (data) {
@@ -427,12 +455,12 @@ window.TYPEAHEADS = {
   typeaheadPostsSource: function (post_type, args = {}) {
     return {
       contacts: {
-        display: [ "name", "ID", "label" ],
+        display: ['name', 'ID', 'label'],
         ajax: {
           url: wpApiShare.root + `dt-posts/v2/${post_type}/compact`,
-          data: Object.assign({ s: "{{query}}" }, args),
+          data: Object.assign({ s: '{{query}}' }, args),
           beforeSend: function (xhr) {
-            xhr.setRequestHeader("X-WP-Nonce", wpApiShare.nonce);
+            xhr.setRequestHeader('X-WP-Nonce', wpApiShare.nonce);
           },
           callback: {
             done: function (data) {
@@ -444,37 +472,42 @@ window.TYPEAHEADS = {
     };
   },
   typeaheadHelpText: function (resultCount, query, result) {
-    let text = "";
+    let text = '';
     if (result.length > 0 && query) {
       text = wpApiShare.translations.showing_x_items_matching
         .replace(
-          "%1$s",
-          `<strong>${window.SHAREDFUNCTIONS.escapeHTML(result.length)}</strong>`
+          '%1$s',
+          `<strong>${window.SHAREDFUNCTIONS.escapeHTML(result.length)}</strong>`,
         )
-        .replace("%2$s", `<strong>${window.SHAREDFUNCTIONS.escapeHTML(query)}</strong>`);
+        .replace(
+          '%2$s',
+          `<strong>${window.SHAREDFUNCTIONS.escapeHTML(query)}</strong>`,
+        );
     } else if (result.length > 0) {
       text = wpApiShare.translations.showing_x_items.replace(
-        "%s",
-        `<strong>${window.SHAREDFUNCTIONS.escapeHTML(result.length)}</strong>`
+        '%s',
+        `<strong>${window.SHAREDFUNCTIONS.escapeHTML(result.length)}</strong>`,
       );
     } else {
       text = wpApiShare.translations.no_records_found.replace(
         '"{{query}}"',
-        `<strong>${window.SHAREDFUNCTIONS.escapeHTML(query)}</strong>`
+        `<strong>${window.SHAREDFUNCTIONS.escapeHTML(query)}</strong>`,
       );
     }
     return text;
   },
   contactListRowTemplate: function (query, item) {
-    let status_color = `<span class="vertical-line" ${ item.status ? `style="border-left: 3px solid ${window.SHAREDFUNCTIONS.escapeHTML(item.status.color)}"` : '' }></span>`
-    let status_label = item.status ? `[ <span><i>${ window.SHAREDFUNCTIONS.escapeHTML(item.status.label).toLowerCase() } </i></span> ]` : '';
+    let status_color = `<span class="vertical-line" ${item.status ? `style="border-left: 3px solid ${window.SHAREDFUNCTIONS.escapeHTML(item.status.color)}"` : ''}></span>`;
+    let status_label = item.status
+      ? `[ <span><i>${window.SHAREDFUNCTIONS.escapeHTML(item.status.label).toLowerCase()} </i></span> ]`
+      : '';
     let img = item.user
       ? `<img style="margin: 0 5px;" class="dt-blue-icon" src="${wpApiShare.template_dir}/dt-assets/images/profile.svg?v=2">`
-      : "";
-    let statusStyle = item.status === "closed" ? 'style="color:gray"' : "";
-      return `<span style="display: inline-block; vertical-align: middle;" dir="auto" ${statusStyle}>
+      : '';
+    let statusStyle = item.status === 'closed' ? 'style="color:gray"' : '';
+    return `<span style="display: inline-block; vertical-align: middle;" dir="auto" ${statusStyle}>
         ${status_color}
-        ${window.SHAREDFUNCTIONS.escapeHTML((item.label ? item.label : item.name))}
+        ${window.SHAREDFUNCTIONS.escapeHTML(item.label ? item.label : item.name)}
         <span dir="auto">(#${window.SHAREDFUNCTIONS.escapeHTML(item.ID)})</span>
         ${status_label}
         <span class="typeahead-user-row" style="width:20px">${img}</span>
@@ -482,7 +515,7 @@ window.TYPEAHEADS = {
   },
   share(post_type, id) {
     return jQuery.typeahead({
-      input: ".js-typeahead-share",
+      input: '.js-typeahead-share',
       minLength: 0,
       maxItem: 0,
       accent: true,
@@ -490,39 +523,45 @@ window.TYPEAHEADS = {
       template: function (query, item) {
         return `<div class="" dir="auto">
           <div>
-              <span class="avatar"><img style="vertical-align: text-bottom" src="${window.SHAREDFUNCTIONS.escapeHTML( item.avatar )}"/></span>
-              {{name}} (#${window.SHAREDFUNCTIONS.escapeHTML( item.ID )})
+              <span class="avatar"><img style="vertical-align: text-bottom" src="${window.SHAREDFUNCTIONS.escapeHTML(item.avatar)}"/></span>
+              {{name}} (#${window.SHAREDFUNCTIONS.escapeHTML(item.ID)})
           </div>
-        </div>`
+        </div>`;
       },
       source: this.typeaheadUserSource(),
-      emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.no_records_found),
-      display: "name",
-      templateValue: "{{name}}",
+      emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(
+        window.wpApiShare.translations.no_records_found,
+      ),
+      display: 'name',
+      templateValue: '{{name}}',
       dynamic: true,
       multiselect: {
-        matchOn: ["ID"],
+        matchOn: ['ID'],
         data: function () {
           var deferred = jQuery.Deferred();
           return window.API.get_shared(post_type, id).then((sharedResult) => {
             return deferred.resolve(
               sharedResult.map((g) => {
-                return { ID: g.user_id, name: g.display_name, avatar: g.avatar };
-              })
+                return {
+                  ID: g.user_id,
+                  name: g.display_name,
+                  avatar: g.avatar,
+                };
+              }),
             );
           });
         },
         callback: {
           onCancel: function (node, item) {
-            jQuery("#share-result-container").html("");
+            jQuery('#share-result-container').html('');
             window.API.remove_shared(post_type, id, item.ID).catch((err) => {
-              window.Typeahead[".js-typeahead-share"].addMultiselectItemLayout({
+              window.Typeahead['.js-typeahead-share'].addMultiselectItemLayout({
                 ID: item.ID,
                 name: item.name,
-                avatar: item.avatar
+                avatar: item.avatar,
               });
-              jQuery("#share-result-container").html(
-                window.lodash.get(err, "responseJSON.message")
+              jQuery('#share-result-container').html(
+                window.lodash.get(err, 'responseJSON.message'),
               );
             });
           },
@@ -537,13 +576,13 @@ window.TYPEAHEADS = {
             let text = window.TYPEAHEADS.typeaheadHelpText(
               resultCount,
               query,
-              result
+              result,
             );
-            jQuery("#share-result-container").html(text);
+            jQuery('#share-result-container').html(text);
           }
         },
         onHideLayout: function () {
-          jQuery("#share-result-container").html("");
+          jQuery('#share-result-container').html('');
         },
       },
     });
@@ -556,8 +595,8 @@ window.TYPEAHEADS = {
       maxItem: 20,
       template: this.contactListRowTemplate,
       source: this.typeaheadContactsSource(),
-      display: "name",
-      templateValue: "{{name}}",
+      display: 'name',
+      templateValue: '{{name}}',
       dynamic: true,
     };
   },
@@ -565,33 +604,33 @@ window.TYPEAHEADS = {
 
 window.SHAREDFUNCTIONS = {
   getCookie(cname) {
-    let name = cname + "=";
+    let name = cname + '=';
     let decodedCookie = decodeURIComponent(document.cookie);
-    let ca = decodedCookie.split(";");
+    let ca = decodedCookie.split(';');
     for (let i = 0; i < ca.length; i++) {
       let c = ca[i];
-      while (c.charAt(0) == " ") {
+      while (c.charAt(0) == ' ') {
         c = c.substring(1);
       }
       if (c.indexOf(name) == 0) {
         return c.substring(name.length, c.length);
       }
     }
-    return "";
+    return '';
   },
-  setCookie(cname, cvalue, path = '', exdays = 0 ) {
-    let cookie = `${cname}=${cvalue};`
-    if ( Number.isInteger( exdays ) && exdays > 0 ) {
+  setCookie(cname, cvalue, path = '', exdays = 0) {
+    let cookie = `${cname}=${cvalue};`;
+    if (Number.isInteger(exdays) && exdays > 0) {
       var d = new Date();
-      d.setTime(d.getTime() + (exdays * 24 * 60 * 60 * 1000));
-      cookie += "expires="+d.toUTCString()+";";
+      d.setTime(d.getTime() + exdays * 24 * 60 * 60 * 1000);
+      cookie += 'expires=' + d.toUTCString() + ';';
     }
     if (path) {
       let newPath = window.location.pathname.split(path)[0] + path;
-      newPath = newPath.replace(/^\/?([^\/]+(?:\/[^\/]+)*)\/?$/, "/$1"); // add leading and remove trailing slashes
-      cookie += "path=" + newPath + ";"
+      newPath = newPath.replace(/^\/?([^\/]+(?:\/[^\/]+)*)\/?$/, '/$1'); // add leading and remove trailing slashes
+      cookie += 'path=' + newPath + ';';
     }
-    document.cookie = cookie
+    document.cookie = cookie;
   },
   get_json_cookie(cname, default_val = []) {
     let cookie = this.getCookie(cname);
@@ -601,13 +640,13 @@ window.SHAREDFUNCTIONS = {
     return default_val;
   },
   save_json_cookie(cname, json, path = '', exdays = 0) {
-    this.setCookie(cname, JSON.stringify(json), path, exdays)
+    this.setCookie(cname, JSON.stringify(json), path, exdays);
   },
   get_json_from_local_storage(key, default_val = {}, path) {
-    if ( path ){
+    if (path) {
       key = path + '_' + key;
     }
-    if ( localStorage ){
+    if (localStorage) {
       let json = localStorage.getItem(key);
       try {
         default_val = JSON.parse(json);
@@ -616,125 +655,145 @@ window.SHAREDFUNCTIONS = {
     return default_val;
   },
   save_json_to_local_storage(key, json, path) {
-    if ( path ){
+    if (path) {
       key = path + '_' + key;
     }
-    if ( localStorage ){
-      window.localStorage.setItem(key, JSON.stringify(json))
+    if (localStorage) {
+      window.localStorage.setItem(key, JSON.stringify(json));
     }
   },
   createCustomFilter(field, value) {
-    return ({
+    return {
       fields: [
         {
           [field]: value,
-        }
-      ]
-    })
+        },
+      ],
+    };
   },
   create_url_for_list_query(postType, query, labels) {
     const encodedQuery = window.SHAREDFUNCTIONS.encodeJSON(query);
     const encodedLabels = window.SHAREDFUNCTIONS.encodeJSON(labels);
-    return window.wpApiShare.site_url + `/${postType}?query=${encodedQuery}&labels=${encodedLabels}`;
+    return (
+      window.wpApiShare.site_url +
+      `/${postType}?query=${encodedQuery}&labels=${encodedLabels}`
+    );
   },
   encodeJSON(json) {
-    return this.b64encode(JSON.stringify(json))
+    return this.b64encode(JSON.stringify(json));
   },
   decodeJSON(encodedJSON) {
     try {
-      return JSON.parse(this.b64decode(encodedJSON))
+      return JSON.parse(this.b64decode(encodedJSON));
     } catch (error) {
-      return null
+      return null;
     }
   },
   b64encode(string) {
-    return Base64.encode(string)
+    return Base64.encode(string);
   },
   b64decode(string) {
-    return Base64.decode(string)
+    return Base64.decode(string);
   },
   get_langcode() {
-    let langcode = document.querySelector("html").getAttribute("lang")
-      ? document.querySelector("html").getAttribute("lang").replace("_", "-")
-      : "en"; // get the language attribute from the HTML or default to english if it doesn't exists.
-      return langcode;
+    let langcode = document.querySelector('html').getAttribute('lang')
+      ? document.querySelector('html').getAttribute('lang').replace('_', '-')
+      : 'en'; // get the language attribute from the HTML or default to english if it doesn't exists.
+    return langcode;
   },
-  get_days_of_the_week_initials(format = 'narrow'){
+  get_days_of_the_week_initials(format = 'narrow') {
     let langcode = window.SHAREDFUNCTIONS.get_langcode();
-    let now = new Date()
-    const int_format = new Intl.DateTimeFormat(langcode, {weekday:format}).format;
-    return [...Array(7).keys()].map((day) => int_format(new Date().getTime() - (now.getDay() - day) * 86400000));
+    let now = new Date();
+    const int_format = new Intl.DateTimeFormat(langcode, { weekday: format })
+      .format;
+    return [...Array(7).keys()].map((day) =>
+      int_format(new Date().getTime() - (now.getDay() - day) * 86400000),
+    );
   },
-  get_months_labels(format = 'long'){
+  get_months_labels(format = 'long') {
     let langcode = window.SHAREDFUNCTIONS.get_langcode();
-    const int_format = new Intl.DateTimeFormat(langcode, {month:format}).format;
-    return [...Array(12).keys()].map((month) => int_format(new Date( Date.UTC(2021, month, 1))));
+    const int_format = new Intl.DateTimeFormat(langcode, { month: format })
+      .format;
+    return [...Array(12).keys()].map((month) =>
+      int_format(new Date(Date.UTC(2021, month, 1))),
+    );
   },
-  formatDate(date, with_time = false, short_month = false, local_timezone = false) {
+  formatDate(
+    date,
+    with_time = false,
+    short_month = false,
+    local_timezone = false,
+  ) {
     let langcode = window.SHAREDFUNCTIONS.get_langcode();
-    if (langcode === "fa-IR") {
+    if (langcode === 'fa-IR') {
       //This is a check so that we use the gergorian (Western) calendar if the users locale is Farsi. This is the calendar used primarily by Farsi speakers outside of Iran, and is easily understood by those inside.
       langcode = `${langcode}-u-ca-gregory`;
     }
-    const options = { year: "numeric", month: "long", day: "numeric" };
+    const options = { year: 'numeric', month: 'long', day: 'numeric' };
     if (with_time) {
-      options.hour = "numeric";
-      options.minute = "numeric";
+      options.hour = 'numeric';
+      options.minute = 'numeric';
     }
     if (!(with_time || local_timezone)) {
-      options.timeZone = "UTC";
+      options.timeZone = 'UTC';
     }
     if (short_month) {
-      options.month = "short"
+      options.month = 'short';
     }
 
-    if ( isNaN(date) ){
-      return false
+    if (isNaN(date)) {
+      return false;
     }
     const formattedDate = new Intl.DateTimeFormat(langcode, options).format(
-      date * 1000
+      date * 1000,
     );
 
     return formattedDate;
   },
   /*
-  * Allow links and @ mentions to be displayed in comments section
-  */
+   * Allow links and @ mentions to be displayed in comments section
+   */
   formatComment(comment) {
-    if(comment){
-      let mentionRegex = /\@\[(.*?)\]\((.+?)\)/g
-      comment = comment.replace(mentionRegex, (match, text, id)=>{
+    if (comment) {
+      let mentionRegex = /\@\[(.*?)\]\((.+?)\)/g;
+      comment = comment.replace(mentionRegex, (match, text, id) => {
         /* dir=auto means that @ will be put to the left of the name if the
-          * mentioned name is LTR, and to the right if the mentioned name is
-          * RTL, instead of letting the surrounding dir determine the placement
-          * of @ */
-        return `<a dir="auto">@${text}</a>`
-      })
-      let urlRegex = /((href=('|"))|(\[|\()?|(http(s)?:((\/)|(\\))*.))*(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//\\=]*)/g
-      comment = comment.replace(urlRegex, (match)=>{
-        let url = match
-        if(match.indexOf("@") === -1 && match.indexOf("[") === -1 && match.indexOf("(") === -1 && match.indexOf("href") === -1) {
-          if (match.indexOf("http") === 0 && match.indexOf("www.") === -1) {
-            url = match
+         * mentioned name is LTR, and to the right if the mentioned name is
+         * RTL, instead of letting the surrounding dir determine the placement
+         * of @ */
+        return `<a dir="auto">@${text}</a>`;
+      });
+      let urlRegex =
+        /((href=('|"))|(\[|\()?|(http(s)?:((\/)|(\\))*.))*(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//\\=]*)/g;
+      comment = comment.replace(urlRegex, (match) => {
+        let url = match;
+        if (
+          match.indexOf('@') === -1 &&
+          match.indexOf('[') === -1 &&
+          match.indexOf('(') === -1 &&
+          match.indexOf('href') === -1
+        ) {
+          if (match.indexOf('http') === 0 && match.indexOf('www.') === -1) {
+            url = match;
+          } else if (match.indexOf('http') === -1) {
+            url = 'http://' + match;
           }
-          else if (match.indexOf("http") === -1) {
-            url = "http://" + match
-          }
-          return `<a href="${url}" rel="noopener noreferrer" target="_blank">${match}</a>`
+          return `<a href="${url}" rel="noopener noreferrer" target="_blank">${match}</a>`;
         }
-        return match
-      })
+        return match;
+      });
       let linkRegex = /\[(.*?)\]\((.+?)\)/g; //format [text](link)
-      comment = comment.replace(linkRegex, (match, text, url)=>{
-        if (text.includes("http") && !url.includes("http")){
-          [url, text] = [text, url]
+      comment = comment.replace(linkRegex, (match, text, url) => {
+        if (text.includes('http') && !url.includes('http')) {
+          [url, text] = [text, url];
         }
-        url = url.includes('http') ? url : `${window.wpApiShare.site_url}/${window.wpApiShare.post_type}/${url}`
-        return `<a href="${url}">${text}</a>`
-      })
-
+        url = url.includes('http')
+          ? url
+          : `${window.wpApiShare.site_url}/${window.wpApiShare.post_type}/${url}`;
+        return `<a href="${url}">${text}</a>`;
+      });
     }
-    return comment
+    return comment;
   },
   convertArabicToEnglishNumbers(string) {
     return string
@@ -746,8 +805,8 @@ window.SHAREDFUNCTIONS = {
       });
   },
   get_url_param(name) {
-    let results = new RegExp("[?&]" + name + "=([^&#]*)").exec(
-      window.location.search
+    let results = new RegExp('[?&]' + name + '=([^&#]*)').exec(
+      window.location.search,
     );
     return results !== null ? results[1] || 0 : false;
   },
@@ -757,155 +816,173 @@ window.SHAREDFUNCTIONS = {
    * @param obj Must be a simple map of key, value pairs. E.g. a translation mapping.
    */
   escapeObject(obj) {
-    return Object.fromEntries(Object.entries(obj).map(([key, value]) => {
-        return [ key, window.SHAREDFUNCTIONS.escapeHTML(value)]
-    }))
+    return Object.fromEntries(
+      Object.entries(obj).map(([key, value]) => {
+        return [key, window.SHAREDFUNCTIONS.escapeHTML(value)];
+      }),
+    );
   },
   escapeHTML(str) {
-    if (typeof str === "undefined") return '';
-    if (typeof str !== "string") return str;
-    return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
+    if (typeof str === 'undefined') return '';
+    if (typeof str !== 'string') return str;
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;');
   },
-  make_links_clickable( selector ){
+  make_links_clickable(selector) {
     //make text links clickable in a section
-    let elem_text = jQuery(selector).html()
-    if ( !elem_text ) return
-    let urlRegex = /((href=('|"))|(\[|\()?|(http(s)?:((\/)|(\\))*.))*(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,8}\b([-a-zA-Z0-9@:%_\+.~#?&//\\=]*)/g
-    elem_text = elem_text.replace(urlRegex, (match)=>{
-      let url = match
-      if(match.indexOf("@") === -1 && match.indexOf("[") === -1 && match.indexOf("(") === -1 && match.indexOf("href") === -1) {
-        if (match.indexOf("http") === 0 && match.indexOf("www.") === -1) {
-          url = match
+    let elem_text = jQuery(selector).html();
+    if (!elem_text) return;
+    let urlRegex =
+      /((href=('|"))|(\[|\()?|(http(s)?:((\/)|(\\))*.))*(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,8}\b([-a-zA-Z0-9@:%_\+.~#?&//\\=]*)/g;
+    elem_text = elem_text.replace(urlRegex, (match) => {
+      let url = match;
+      if (
+        match.indexOf('@') === -1 &&
+        match.indexOf('[') === -1 &&
+        match.indexOf('(') === -1 &&
+        match.indexOf('href') === -1
+      ) {
+        if (match.indexOf('http') === 0 && match.indexOf('www.') === -1) {
+          url = match;
+        } else if (
+          match.indexOf('http') === -1 &&
+          match.indexOf('www.') === 0
+        ) {
+          url = 'http://' + match;
+        } else if (match.indexOf('www.') === -1) {
+          url = 'http://www.' + match;
         }
-        else if (match.indexOf("http") === -1 && match.indexOf("www.") === 0) {
-          url = "http://" + match
-        }
-        else if (match.indexOf("www.") === -1) {
-          url = "http://www." + match
-        }
-        return `<a href="${url}" rel="noopener noreferrer" target="_blank">${match}</a>`
+        return `<a href="${url}" rel="noopener noreferrer" target="_blank">${match}</a>`;
       }
-      return match
-    })
-    jQuery(selector).html(elem_text)
+      return match;
+    });
+    jQuery(selector).html(elem_text);
   },
   addLink(e) {
-    let fieldKey = e.target.dataset['fieldKey']
-    let linkType = e.target.dataset['linkType']
-    let onlyOneOption = e.target.dataset['onlyOneOption']
+    let fieldKey = e.target.dataset['fieldKey'];
+    let linkType = e.target.dataset['linkType'];
+    let onlyOneOption = e.target.dataset['onlyOneOption'];
 
-    const linkList = document.querySelector(`.link-list-${fieldKey} .link-section--${linkType}`)
+    const linkList = document.querySelector(
+      `.link-list-${fieldKey} .link-section--${linkType}`,
+    );
 
-    const template = document.querySelector(`#link-template-${fieldKey}-${linkType}`).querySelector('.input-group')
+    const template = document
+      .querySelector(`#link-template-${fieldKey}-${linkType}`)
+      .querySelector('.input-group');
 
     const newInputGroup = jQuery(template).clone(true);
-    const newInput = newInputGroup[0].querySelector('input')
-    jQuery(linkList).append(newInputGroup)
-    newInput.focus()
+    const newInput = newInputGroup[0].querySelector('input');
+    jQuery(linkList).append(newInputGroup);
+    newInput.focus();
 
-    if ( onlyOneOption !== '' ) {
-      linkList.querySelector('.section-subheader').style.display = 'block'
+    if (onlyOneOption !== '') {
+      linkList.querySelector('.section-subheader').style.display = 'block';
     }
 
-    jQuery(".grid").masonry("layout"); //resize or reorder tile
-  }
+    jQuery('.grid').masonry('layout'); //resize or reorder tile
+  },
 };
 
 let date_ranges = {
-  "All time": [window.moment(0), window.moment().endOf("year")],
-  [window.moment().format("MMMM YYYY")]: [
-    window.moment().startOf("month"),
-    window.moment().endOf("month"),
+  'All time': [window.moment(0), window.moment().endOf('year')],
+  [window.moment().format('MMMM YYYY')]: [
+    window.moment().startOf('month'),
+    window.moment().endOf('month'),
   ],
-  [window.moment().subtract(1, "month").format("MMMM YYYY")]: [
-    window.moment().subtract(1, "month").startOf("month"),
-    window.moment().subtract(1, "month").endOf("month"),
+  [window.moment().subtract(1, 'month').format('MMMM YYYY')]: [
+    window.moment().subtract(1, 'month').startOf('month'),
+    window.moment().subtract(1, 'month').endOf('month'),
   ],
-  [window.moment().format("YYYY")]: [
-    window.moment().startOf("year"),
-    window.moment().endOf("year"),
+  [window.moment().format('YYYY')]: [
+    window.moment().startOf('year'),
+    window.moment().endOf('year'),
   ],
-  [window.moment().subtract(1, "year").format("YYYY")]: [
-    window.moment().subtract(1, "year").startOf("year"),
-    window.moment().subtract(1, "year").endOf("year"),
+  [window.moment().subtract(1, 'year').format('YYYY')]: [
+    window.moment().subtract(1, 'year').startOf('year'),
+    window.moment().subtract(1, 'year').endOf('year'),
   ],
-  [window.moment().subtract(2, "year").format("YYYY")]: [
-    window.moment().subtract(2, "year").startOf("year"),
-    window.moment().subtract(2, "year").endOf("year"),
+  [window.moment().subtract(2, 'year').format('YYYY')]: [
+    window.moment().subtract(2, 'year').startOf('year'),
+    window.moment().subtract(2, 'year').endOf('year'),
   ],
 };
 
 window.METRICS = {
   setupDatePicker: function (endpoint_url, callback, startDate, endDate) {
-    jQuery(".date_range_picker").daterangepicker(
+    jQuery('.date_range_picker').daterangepicker(
       {
         showDropdowns: true,
         ranges: date_ranges,
         linkedCalendars: false,
         locale: {
-          format: "YYYY-MM-DD",
+          format: 'YYYY-MM-DD',
         },
         startDate: startDate || window.moment(0),
-        endDate: endDate || window.moment().endOf("year").format("YYYY-MM-DD"),
+        endDate: endDate || window.moment().endOf('year').format('YYYY-MM-DD'),
       },
       function (start, end, label) {
-        jQuery(".loading-spinner").addClass("active");
+        jQuery('.loading-spinner').addClass('active');
         jQuery
           .ajax({
-            type: "GET",
-            contentType: "application/json; charset=utf-8",
-            dataType: "json",
+            type: 'GET',
+            contentType: 'application/json; charset=utf-8',
+            dataType: 'json',
             url: `${endpoint_url}?start=${start.format(
-              "YYYY-MM-DD"
-            )}&end=${end.format("YYYY-MM-DD")}`,
+              'YYYY-MM-DD',
+            )}&end=${end.format('YYYY-MM-DD')}`,
             beforeSend: function (xhr) {
-              xhr.setRequestHeader("X-WP-Nonce", wpApiShare.nonce);
+              xhr.setRequestHeader('X-WP-Nonce', wpApiShare.nonce);
             },
           })
           .done(function (data) {
-            jQuery(".loading-spinner").removeClass("active");
-            if (label === "Custom Range") {
+            jQuery('.loading-spinner').removeClass('active');
+            if (label === 'Custom Range') {
               label =
-                start.format("MMMM D, YYYY") +
-                " - " +
-                end.format("MMMM D, YYYY");
+                start.format('MMMM D, YYYY') +
+                ' - ' +
+                end.format('MMMM D, YYYY');
             }
             callback(data, label, start, end);
           })
           .fail(function (err) {
-            console.log("error");
+            console.log('error');
             console.log(err);
             // jQuery("#errors").append(err.responseText)
           });
         // console.log('New date range selected: ' + start.format('YYYY-MM-DD') + ' to ' + end.format('YYYY-MM-DD') + ' (predefined range: ' + label + ')');
-      }
+      },
     );
   },
   setupDatePickerWithoutEndpoint: function (callback, startDate, endDate) {
-    jQuery(".date_range_picker").daterangepicker(
+    jQuery('.date_range_picker').daterangepicker(
       {
         showDropdowns: true,
         ranges: date_ranges,
         linkedCalendars: false,
         locale: {
-          format: "YYYY-MM-DD",
+          format: 'YYYY-MM-DD',
         },
         startDate: startDate || window.moment(0),
-        endDate: endDate || window.moment().endOf("year").format("YYYY-MM-DD"),
+        endDate: endDate || window.moment().endOf('year').format('YYYY-MM-DD'),
       },
       function (start, end, label) {
         callback(start, end, label);
-      }
+      },
     );
-  }
+  },
 };
 
 /**
  * use the class .copy_to_clipboard to copy the contents of data-value="" to the clipboard.
  */
-jQuery(document).ready(function(){
-  jQuery('.copy_to_clipboard').on('click', function(){
-    let str = jQuery(this).data('value')
+jQuery(document).ready(function () {
+  jQuery('.copy_to_clipboard').on('click', function () {
+    let str = jQuery(this).data('value');
     const el = document.createElement('textarea');
     el.value = str;
     el.setAttribute('readonly', '');
@@ -923,35 +1000,35 @@ jQuery(document).ready(function(){
       document.getSelection().removeAllRanges();
       document.getSelection().addRange(selected);
     }
-    alert('Copied')
-  })
-})
+    alert('Copied');
+  });
+});
 
 /**
  * Magic Link Support
  */
 window.sha256 = (ascii) => {
   function rightRotate(value, amount) {
-    return (value>>>amount) | (value<<(32 - amount));
+    return (value >>> amount) | (value << (32 - amount));
   }
 
   var mathPow = Math.pow;
   var maxWord = mathPow(2, 32);
-  var lengthProperty = 'length'
+  var lengthProperty = 'length';
   var i, j; // Used as a counter across the whole file
-  var result = ''
+  var result = '';
 
   var words = [];
-  var asciiBitLength = ascii[lengthProperty]*8;
+  var asciiBitLength = ascii[lengthProperty] * 8;
 
   //* caching results is optional - remove/add slash from front of this line to toggle
   // Initial hash value: first 32 bits of the fractional parts of the square roots of the first 8 primes
   // (we actually calculate the first 64, but extra values are just ignored)
   // eslint-disable-next-line no-undef
-  var hash = sha256.h = sha256.h || [];
+  var hash = (sha256.h = sha256.h || []);
   // Round constants: first 32 bits of the fractional parts of the cube roots of the first 64 primes
   // eslint-disable-next-line no-undef
-  var k = sha256.k = sha256.k || [];
+  var k = (sha256.k = sha256.k || []);
   var primeCounter = k[lengthProperty];
   /*/
   var hash = [], k = [];
@@ -964,24 +1041,24 @@ window.sha256 = (ascii) => {
       for (i = 0; i < 313; i += candidate) {
         isComposite[i] = candidate;
       }
-      hash[primeCounter] = (mathPow(candidate, .5)*maxWord)|0;
-      k[primeCounter++] = (mathPow(candidate, 1/3)*maxWord)|0;
+      hash[primeCounter] = (mathPow(candidate, 0.5) * maxWord) | 0;
+      k[primeCounter++] = (mathPow(candidate, 1 / 3) * maxWord) | 0;
     }
   }
 
-  ascii += '\x80' // Append Ƈ' bit (plus zero padding)
-  while (ascii[lengthProperty]%64 - 56) ascii += '\x00' // More zero padding
+  ascii += '\x80'; // Append Ƈ' bit (plus zero padding)
+  while ((ascii[lengthProperty] % 64) - 56) ascii += '\x00'; // More zero padding
   for (i = 0; i < ascii[lengthProperty]; i++) {
     j = ascii.charCodeAt(i);
-    if (j>>8) return; // ASCII check: only accept characters in range 0-255
-    words[i>>2] |= j << ((3 - i)%4)*8;
+    if (j >> 8) return; // ASCII check: only accept characters in range 0-255
+    words[i >> 2] |= j << (((3 - i) % 4) * 8);
   }
-  words[words[lengthProperty]] = ((asciiBitLength/maxWord)|0);
-  words[words[lengthProperty]] = (asciiBitLength)
+  words[words[lengthProperty]] = (asciiBitLength / maxWord) | 0;
+  words[words[lengthProperty]] = asciiBitLength;
 
   // process each chunk
-  for (j = 0; j < words[lengthProperty];) {
-    var w = words.slice(j, j += 16); // The message is expanded into 64 words as part of the iteration
+  for (j = 0; j < words[lengthProperty]; ) {
+    var w = words.slice(j, (j += 16)); // The message is expanded into 64 words as part of the iteration
     var oldHash = hash;
     // This is now the undefinedworking hash", often labelled as variables a...g
     // (we have to truncate as well, otherwise extra entries at the end accumulate
@@ -991,189 +1068,186 @@ window.sha256 = (ascii) => {
       var i2 = i + j;
       // Expand the message into 64 words
       // Used below if
-      var w15 = w[i - 15], w2 = w[i - 2];
+      var w15 = w[i - 15],
+        w2 = w[i - 2];
 
       // Iterate
-      var a = hash[0], e = hash[4];
-      var temp1 = hash[7]
-        + (rightRotate(e, 6) ^ rightRotate(e, 11) ^ rightRotate(e, 25)) // S1
-        + ((e&hash[5])^((~e)&hash[6])) // ch
-        + k[i]
+      var a = hash[0],
+        e = hash[4];
+      var temp1 =
+        hash[7] +
+        (rightRotate(e, 6) ^ rightRotate(e, 11) ^ rightRotate(e, 25)) + // S1
+        ((e & hash[5]) ^ (~e & hash[6])) + // ch
+        k[i] +
         // Expand the message schedule if needed
-        + (w[i] = (i < 16) ? w[i] : (
-            w[i - 16]
-            + (rightRotate(w15, 7) ^ rightRotate(w15, 18) ^ (w15>>>3)) // s0
-            + w[i - 7]
-            + (rightRotate(w2, 17) ^ rightRotate(w2, 19) ^ (w2>>>10)) // s1
-          )|0
-        );
+        (w[i] =
+          i < 16
+            ? w[i]
+            : (w[i - 16] +
+                (rightRotate(w15, 7) ^ rightRotate(w15, 18) ^ (w15 >>> 3)) + // s0
+                w[i - 7] +
+                (rightRotate(w2, 17) ^ rightRotate(w2, 19) ^ (w2 >>> 10))) | // s1
+              0);
       // This is only used once, so *could* be moved below, but it only saves 4 bytes and makes things unreadble
-      var temp2 = (rightRotate(a, 2) ^ rightRotate(a, 13) ^ rightRotate(a, 22)) // S0
-        + ((a&hash[1])^(a&hash[2])^(hash[1]&hash[2])); // maj
+      var temp2 =
+        (rightRotate(a, 2) ^ rightRotate(a, 13) ^ rightRotate(a, 22)) + // S0
+        ((a & hash[1]) ^ (a & hash[2]) ^ (hash[1] & hash[2])); // maj
 
-      hash = [(temp1 + temp2)|0].concat(hash); // We don't bother trimming off the extra ones, they're harmless as long as we're truncating when we do the slice()
-      hash[4] = (hash[4] + temp1)|0;
+      hash = [(temp1 + temp2) | 0].concat(hash); // We don't bother trimming off the extra ones, they're harmless as long as we're truncating when we do the slice()
+      hash[4] = (hash[4] + temp1) | 0;
     }
 
     for (i = 0; i < 8; i++) {
-      hash[i] = (hash[i] + oldHash[i])|0;
+      hash[i] = (hash[i] + oldHash[i]) | 0;
     }
   }
 
   for (i = 0; i < 8; i++) {
     for (j = 3; j + 1; j--) {
-      var b = (hash[i]>>(j*8))&255;
-      result += ((b < 16) ? 0 : '') + b.toString(16);
+      var b = (hash[i] >> (j * 8)) & 255;
+      result += (b < 16 ? 0 : '') + b.toString(16);
     }
   }
   return result;
 };
-window.make_magic_link = ( site, root, type, hash, action ) => {
-  let link = site + '/' + root + '/' + type + '/' + hash + '/'
-  if ( action ) {
-    link = link + action
+window.make_magic_link = (site, root, type, hash, action) => {
+  let link = site + '/' + root + '/' + type + '/' + hash + '/';
+  if (action) {
+    link = link + action;
   }
-  return link
-}
+  return link;
+};
 
 /**
-*
-*  Base64 encode / decode
-*  http://www.webtoolkit.info/javascript-base64.html
-**/
+ *
+ *  Base64 encode / decode
+ *  http://www.webtoolkit.info/javascript-base64.html
+ **/
 
 var Base64 = {
-
   // private property
-  _keyStr : "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
+  _keyStr: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=',
 
   // public method for encoding
-  encode : function (input) {
-      var output = "";
-      var chr1, chr2, chr3, enc1, enc2, enc3, enc4;
-      var i = 0;
+  encode: function (input) {
+    var output = '';
+    var chr1, chr2, chr3, enc1, enc2, enc3, enc4;
+    var i = 0;
 
-      input = Base64._utf8_encode(input);
+    input = Base64._utf8_encode(input);
 
-      while (i < input.length) {
+    while (i < input.length) {
+      chr1 = input.charCodeAt(i++);
+      chr2 = input.charCodeAt(i++);
+      chr3 = input.charCodeAt(i++);
 
-          chr1 = input.charCodeAt(i++);
-          chr2 = input.charCodeAt(i++);
-          chr3 = input.charCodeAt(i++);
+      enc1 = chr1 >> 2;
+      enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
+      enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
+      enc4 = chr3 & 63;
 
-          enc1 = chr1 >> 2;
-          enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
-          enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
-          enc4 = chr3 & 63;
-
-          if (isNaN(chr2)) {
-              enc3 = enc4 = 64;
-          } else if (isNaN(chr3)) {
-              enc4 = 64;
-          }
-
-          output = output +
-          this._keyStr.charAt(enc1) + this._keyStr.charAt(enc2) +
-          this._keyStr.charAt(enc3) + this._keyStr.charAt(enc4);
-
+      if (isNaN(chr2)) {
+        enc3 = enc4 = 64;
+      } else if (isNaN(chr3)) {
+        enc4 = 64;
       }
 
-      return output;
+      output =
+        output +
+        this._keyStr.charAt(enc1) +
+        this._keyStr.charAt(enc2) +
+        this._keyStr.charAt(enc3) +
+        this._keyStr.charAt(enc4);
+    }
+
+    return output;
   },
 
   // public method for decoding
-  decode : function (input) {
-      var output = "";
-      var chr1, chr2, chr3;
-      var enc1, enc2, enc3, enc4;
-      var i = 0;
+  decode: function (input) {
+    var output = '';
+    var chr1, chr2, chr3;
+    var enc1, enc2, enc3, enc4;
+    var i = 0;
 
-      input = input.replace(/[^A-Za-z0-9\+\/\=]/g, "");
+    input = input.replace(/[^A-Za-z0-9\+\/\=]/g, '');
 
-      while (i < input.length) {
+    while (i < input.length) {
+      enc1 = this._keyStr.indexOf(input.charAt(i++));
+      enc2 = this._keyStr.indexOf(input.charAt(i++));
+      enc3 = this._keyStr.indexOf(input.charAt(i++));
+      enc4 = this._keyStr.indexOf(input.charAt(i++));
 
-          enc1 = this._keyStr.indexOf(input.charAt(i++));
-          enc2 = this._keyStr.indexOf(input.charAt(i++));
-          enc3 = this._keyStr.indexOf(input.charAt(i++));
-          enc4 = this._keyStr.indexOf(input.charAt(i++));
+      chr1 = (enc1 << 2) | (enc2 >> 4);
+      chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
+      chr3 = ((enc3 & 3) << 6) | enc4;
 
-          chr1 = (enc1 << 2) | (enc2 >> 4);
-          chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
-          chr3 = ((enc3 & 3) << 6) | enc4;
+      output = output + String.fromCharCode(chr1);
 
-          output = output + String.fromCharCode(chr1);
-
-          if (enc3 != 64) {
-              output = output + String.fromCharCode(chr2);
-          }
-          if (enc4 != 64) {
-              output = output + String.fromCharCode(chr3);
-          }
-
+      if (enc3 != 64) {
+        output = output + String.fromCharCode(chr2);
       }
+      if (enc4 != 64) {
+        output = output + String.fromCharCode(chr3);
+      }
+    }
 
-      output = Base64._utf8_decode(output);
+    output = Base64._utf8_decode(output);
 
-      return output;
-
+    return output;
   },
 
   // private method for UTF-8 encoding
-  _utf8_encode : function (string) {
-      string = string.replace(/\r\n/g,"\n");
-      var utftext = "";
+  _utf8_encode: function (string) {
+    string = string.replace(/\r\n/g, '\n');
+    var utftext = '';
 
-      for (var n = 0; n < string.length; n++) {
+    for (var n = 0; n < string.length; n++) {
+      var c = string.charCodeAt(n);
 
-          var c = string.charCodeAt(n);
-
-          if (c < 128) {
-              utftext += String.fromCharCode(c);
-          }
-          else if((c > 127) && (c < 2048)) {
-              utftext += String.fromCharCode((c >> 6) | 192);
-              utftext += String.fromCharCode((c & 63) | 128);
-          }
-          else {
-              utftext += String.fromCharCode((c >> 12) | 224);
-              utftext += String.fromCharCode(((c >> 6) & 63) | 128);
-              utftext += String.fromCharCode((c & 63) | 128);
-          }
-
+      if (c < 128) {
+        utftext += String.fromCharCode(c);
+      } else if (c > 127 && c < 2048) {
+        utftext += String.fromCharCode((c >> 6) | 192);
+        utftext += String.fromCharCode((c & 63) | 128);
+      } else {
+        utftext += String.fromCharCode((c >> 12) | 224);
+        utftext += String.fromCharCode(((c >> 6) & 63) | 128);
+        utftext += String.fromCharCode((c & 63) | 128);
       }
+    }
 
-      return utftext;
+    return utftext;
   },
 
   // private method for UTF-8 decoding
-  _utf8_decode : function (utftext) {
-      let string = "";
-      let i = 0;
-      let c = 0, c2 = 0, c3 = 0;
+  _utf8_decode: function (utftext) {
+    let string = '';
+    let i = 0;
+    let c = 0,
+      c2 = 0,
+      c3 = 0;
 
-      while ( i < utftext.length ) {
+    while (i < utftext.length) {
+      c = utftext.charCodeAt(i);
 
-          c = utftext.charCodeAt(i);
-
-          if (c < 128) {
-              string += String.fromCharCode(c);
-              i++;
-          }
-          else if((c > 191) && (c < 224)) {
-              c2 = utftext.charCodeAt(i+1);
-              string += String.fromCharCode(((c & 31) << 6) | (c2 & 63));
-              i += 2;
-          }
-          else {
-              c2 = utftext.charCodeAt(i+1);
-              c3 = utftext.charCodeAt(i+2);
-              string += String.fromCharCode(((c & 15) << 12) | ((c2 & 63) << 6) | (c3 & 63));
-              i += 3;
-          }
-
+      if (c < 128) {
+        string += String.fromCharCode(c);
+        i++;
+      } else if (c > 191 && c < 224) {
+        c2 = utftext.charCodeAt(i + 1);
+        string += String.fromCharCode(((c & 31) << 6) | (c2 & 63));
+        i += 2;
+      } else {
+        c2 = utftext.charCodeAt(i + 1);
+        c3 = utftext.charCodeAt(i + 2);
+        string += String.fromCharCode(
+          ((c & 15) << 12) | ((c2 & 63) << 6) | (c3 & 63),
+        );
+        i += 3;
       }
+    }
 
-      return string;
-  }
-
-}
+    return string;
+  },
+};

--- a/dt-assets/js/view-duplicates.js
+++ b/dt-assets/js/view-duplicates.js
@@ -1,28 +1,41 @@
-jQuery(document).on("click", '.dismiss-all', function () {
-  jQuery(this).addClass('loading')
-  let id = jQuery(this).data('id')
-  window.makeRequestOnPosts('POST', `contacts/${id}/dismiss-duplicates`, {'id': 'all'}).then(() => {
-    jQuery(`#contact_${id}`).remove()
-    jQuery(this).removeClass('loading')
-  })
-})
+jQuery(document).on('click', '.dismiss-all', function () {
+  jQuery(this).addClass('loading');
+  let id = jQuery(this).data('id');
+  window
+    .makeRequestOnPosts('POST', `contacts/${id}/dismiss-duplicates`, {
+      id: 'all',
+    })
+    .then(() => {
+      jQuery(`#contact_${id}`).remove();
+      jQuery(this).removeClass('loading');
+    });
+});
 
 let get_duplicates = (limit = 0) => {
-  window.makeRequest("GET", "contacts/all-duplicates", {limit: limit}, "dt-posts/v2/").then(response => {
-    let html = ``
-    response.posts_with_matches.forEach(post => {
-      let inner_html = ``
-      window.lodash.forOwn(post.dups, (dup_values, dup_key) => {
-        inner_html += `<div style="display: flex"><div style="flex-basis: 100px"><strong>${window.SHAREDFUNCTIONS.escapeHTML(dup_key)}</strong></div><div>`;
-        dup_values.forEach(dup => {
-          inner_html += `<a target="_blank" href="contacts/${window.SHAREDFUNCTIONS.escapeHTML(dup.ID)}" style="margin: 0 10px 0 5px">
-            ${window.SHAREDFUNCTIONS.escapeHTML(dup.post_title)}: ${dup.field==="post_title" ? "":window.SHAREDFUNCTIONS.escapeHTML(dup.value)} (#${window.SHAREDFUNCTIONS.escapeHTML(dup.ID)})
+  window
+    .makeRequest(
+      'GET',
+      'contacts/all-duplicates',
+      { limit: limit },
+      'dt-posts/v2/',
+    )
+    .then((response) => {
+      let html = ``;
+      response.posts_with_matches.forEach((post) => {
+        let inner_html = ``;
+        window.lodash.forOwn(post.dups, (dup_values, dup_key) => {
+          inner_html += `<div style="display: flex"><div style="flex-basis: 100px"><strong>${window.SHAREDFUNCTIONS.escapeHTML(dup_key)}</strong></div><div>`;
+          dup_values.forEach((dup) => {
+            inner_html += `<a target="_blank" href="contacts/${window.SHAREDFUNCTIONS.escapeHTML(dup.ID)}" style="margin: 0 10px 0 5px">
+            ${window.SHAREDFUNCTIONS.escapeHTML(dup.post_title)}: ${dup.field === 'post_title' ? '' : window.SHAREDFUNCTIONS.escapeHTML(dup.value)} (#${window.SHAREDFUNCTIONS.escapeHTML(dup.ID)})
           </a>`;
-        })
-        inner_html += `</div></div>`
-      })
-      let channels = post.info.map(info => info.value ? info.value:null).join(", ")
-      html += `
+          });
+          inner_html += `</div></div>`;
+        });
+        let channels = post.info
+          .map((info) => (info.value ? info.value : null))
+          .join(', ');
+        html += `
         <div class="bordered-box cell" id="contact_${window.SHAREDFUNCTIONS.escapeHTML(post.ID)}">
           <a style="color: #3f729b; font-size: 1.5rem;" target="_blank" href="contacts/${window.SHAREDFUNCTIONS.escapeHTML(post.ID)}">
             ${window.SHAREDFUNCTIONS.escapeHTML(post.post_title)} (#${window.SHAREDFUNCTIONS.escapeHTML(post.ID)})
@@ -33,22 +46,22 @@ let get_duplicates = (limit = 0) => {
           <div>${inner_html}</div>
 
           <button class="button hollow dismiss-all loader" data-id="${window.SHAREDFUNCTIONS.escapeHTML(post.ID)}"  style="margin-top:20px">
-            ${window.SHAREDFUNCTIONS.escapeHTML(window.view_duplicates_settings.translations.dismiss_all.replace('%s', post.post_title ))}
+            ${window.SHAREDFUNCTIONS.escapeHTML(window.view_duplicates_settings.translations.dismiss_all.replace('%s', post.post_title))}
           </button>
         </div>
-      `
-    })
-    jQuery('#duplicates-content').append(html)
-    jQuery('#scanned_number').html(window.SHAREDFUNCTIONS.escapeHTML(response.scanned))
-    let found = jQuery('#duplicates-content .bordered-box').length
-    jQuery('#found_text').html(window.SHAREDFUNCTIONS.escapeHTML(found));
-    if (found < 100 && !response.reached_the_end) {
-      get_duplicates(response.scanned)
-    } else {
-      jQuery('.loading-spinner').removeClass("active")
-    }
-  })
-
-}
-get_duplicates(0)
-
+      `;
+      });
+      jQuery('#duplicates-content').append(html);
+      jQuery('#scanned_number').html(
+        window.SHAREDFUNCTIONS.escapeHTML(response.scanned),
+      );
+      let found = jQuery('#duplicates-content .bordered-box').length;
+      jQuery('#found_text').html(window.SHAREDFUNCTIONS.escapeHTML(found));
+      if (found < 100 && !response.reached_the_end) {
+        get_duplicates(response.scanned);
+      } else {
+        jQuery('.loading-spinner').removeClass('active');
+      }
+    });
+};
+get_duplicates(0);

--- a/dt-contacts/contacts.js
+++ b/dt-contacts/contacts.js
@@ -1,270 +1,337 @@
-jQuery(document).ready(function($) {
-  let post_id        = window.detailsSettings.post_id
-  let post_type      = window.detailsSettings.post_type
-  let post           = window.detailsSettings.post_fields
+jQuery(document).ready(function ($) {
+  let post_id = window.detailsSettings.post_id;
+  let post_type = window.detailsSettings.post_type;
+  let post = window.detailsSettings.post_fields;
 
   /**
    * User-select
    */
-  if ( !post.corresponds_to_user && $('.js-typeahead-user-select').length) {
+  if (!post.corresponds_to_user && $('.js-typeahead-user-select').length) {
     $.typeahead({
       input: '.js-typeahead-user-select',
       minLength: 0,
       accent: true,
       searchOnFocus: true,
       source: window.TYPEAHEADS.typeaheadUserSource(),
-      templateValue: "{{name}}",
+      templateValue: '{{name}}',
       template: function (query, item) {
         return `<span class="row">
           <span class="avatar"><img src="{{avatar}}"/> </span>
-          <span>${window.SHAREDFUNCTIONS.escapeHTML( item.name )}</span>
-        </span>`
+          <span>${window.SHAREDFUNCTIONS.escapeHTML(item.name)}</span>
+        </span>`;
       },
       dynamic: true,
       hint: true,
-      emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.no_records_found),
+      emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(
+        window.wpApiShare.translations.no_records_found,
+      ),
       callback: {
         onClick: function (node, a, item) {
-          jQuery.ajax({
-            type: "GET",
-            data: {"user_id": item.ID},
-            contentType: "application/json; charset=utf-8",
-            dataType: "json",
-            url: window.wpApiShare.root + 'dt/v1/users/contact-id',
-            beforeSend: function (xhr) {
-              xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce);
-            }
-          }).then(user_contact_id => {
-            $('.confirm-merge-with-user').show()
-            $('#confirm-merge-with-user-dupe-id').val(user_contact_id)
-          })
+          jQuery
+            .ajax({
+              type: 'GET',
+              data: { user_id: item.ID },
+              contentType: 'application/json; charset=utf-8',
+              dataType: 'json',
+              url: window.wpApiShare.root + 'dt/v1/users/contact-id',
+              beforeSend: function (xhr) {
+                xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce);
+              },
+            })
+            .then((user_contact_id) => {
+              $('.confirm-merge-with-user').show();
+              $('#confirm-merge-with-user-dupe-id').val(user_contact_id);
+            });
         },
         onResult: function (node, query, result, resultCount) {
-          let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+          let text = window.TYPEAHEADS.typeaheadHelpText(
+            resultCount,
+            query,
+            result,
+          );
           $('#user-select-result-container').html(text);
         },
         onHideLayout: function () {
-          $('.user-select-result-container').html("");
+          $('.user-select-result-container').html('');
         },
       },
     });
-    let user_select_input = $(`.js-typeahead-user-select`)
+    let user_select_input = $(`.js-typeahead-user-select`);
     $('.search_user-select').on('click', function () {
-      user_select_input.val("")
-      user_select_input.trigger('input.typeahead')
-      user_select_input.focus()
-    })
+      user_select_input.val('');
+      user_select_input.trigger('input.typeahead');
+      user_select_input.focus();
+    });
   }
 
-  $("#create-user-return").on("click", function (e) {
+  $('#create-user-return').on('click', function (e) {
     e.preventDefault();
-    $(this).toggleClass("loading")
+    $(this).toggleClass('loading');
     let $inputs = $('#create-user-form :input');
     let values = {};
-    $inputs.each(function() {
-        values[this.name] = $(this).val();
+    $inputs.each(function () {
+      values[this.name] = $(this).val();
     });
-    values["corresponds_to_contact"] = post_id;
-    window.API.create_user(values).then(()=>{
-      $(this).removeClass("loading")
-      $(`#make-user-from-contact-modal`).foundation('close')
-      location.reload();
-    }).catch(err=>{
-      $(this).removeClass("loading")
-      $('#create-user-errors').html(window.lodash.get(err, "responseJSON.message", "Something went wrong"))
-    })
+    values['corresponds_to_contact'] = post_id;
+    window.API.create_user(values)
+      .then(() => {
+        $(this).removeClass('loading');
+        $(`#make-user-from-contact-modal`).foundation('close');
+        location.reload();
+      })
+      .catch((err) => {
+        $(this).removeClass('loading');
+        $('#create-user-errors').html(
+          window.lodash.get(
+            err,
+            'responseJSON.message',
+            'Something went wrong',
+          ),
+        );
+      });
     return false;
-  })
-
+  });
 
   /**
    * Duplicates
    */
-  window.makeRequestOnPosts( "GET", `${post_type}/${post_id}/duplicates` ).then(response => {
-    if ( response.ids && response.ids.length > 0 ){
-      $('.details-title-section').html(`
+  window
+    .makeRequestOnPosts('GET', `${post_type}/${post_id}/duplicates`)
+    .then((response) => {
+      if (response.ids && response.ids.length > 0) {
+        $('.details-title-section').html(`
         <button class="button hollow center-items duplicates-detected-button" id="duplicates-detected-notice">
-          <img style="height:20px" src="${window.SHAREDFUNCTIONS.escapeHTML( window.wpApiShare.template_dir )}/dt-assets/images/broken.svg"/>
+          <img style="height:20px" src="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.template_dir)}/dt-assets/images/broken.svg"/>
           <strong>${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.duplicates_detected)}</strong>
         </button>
-      `)
-    }
-  })
-  let merge_dupe_edit_modal =  $('#merge-dupe-edit-modal')
-  $(document).on( 'click', '#duplicates-detected-notice', function(){
+      `);
+      }
+    });
+  let merge_dupe_edit_modal = $('#merge-dupe-edit-modal');
+  $(document).on('click', '#duplicates-detected-notice', function () {
     merge_dupe_edit_modal.foundation('open');
-  })
+  });
 
   let possible_duplicates = [];
-  let openedOnce = false
-  merge_dupe_edit_modal.on("open.zf.reveal", function () {
-    if ( !openedOnce ){
-
+  let openedOnce = false;
+  merge_dupe_edit_modal.on('open.zf.reveal', function () {
+    if (!openedOnce) {
       let original_contact_html = `<div class="merge-modal-contact-row">
         <h5>
         <a href="${window.wpApiShare.site_url}/${post_type}/${window.SHAREDFUNCTIONS.escapeHTML(post_id)}" class="merge-modal-contact-name" target=_blank>
-        ${ window.SHAREDFUNCTIONS.escapeHTML(post.name) }
-        <span class="merge-modal-contact-info"> #${post_id} (${window.lodash.get(post, "overall_status.label") ||""}) </span>
+        ${window.SHAREDFUNCTIONS.escapeHTML(post.name)}
+        <span class="merge-modal-contact-info"> #${post_id} (${window.lodash.get(post, 'overall_status.label') || ''}) </span>
         </a>
-        </h5>`
-      window.lodash.forOwn(window.detailsSettings.post_settings.fields, (field_settings, field_key)=>{
-        if ( field_settings.type === "communication_channel" && post[field_key] ){
-          post[field_key].forEach( contact_info=>{
-            if ( contact_info.value !== '' ){
-              original_contact_html +=`<img src='${window.SHAREDFUNCTIONS.escapeHTML(field_settings.icon)}'><span style="margin-right: 15px;">&nbsp;${window.SHAREDFUNCTIONS.escapeHTML(contact_info.value)}</span>`
-            }
-          })
-        }
-      })
-      original_contact_html += `</div>`
+        </h5>`;
+      window.lodash.forOwn(
+        window.detailsSettings.post_settings.fields,
+        (field_settings, field_key) => {
+          if (
+            field_settings.type === 'communication_channel' &&
+            post[field_key]
+          ) {
+            post[field_key].forEach((contact_info) => {
+              if (contact_info.value !== '') {
+                original_contact_html += `<img src='${window.SHAREDFUNCTIONS.escapeHTML(field_settings.icon)}'><span style="margin-right: 15px;">&nbsp;${window.SHAREDFUNCTIONS.escapeHTML(contact_info.value)}</span>`;
+              }
+            });
+          }
+        },
+      );
+      original_contact_html += `</div>`;
       $('#original-contact').append(original_contact_html);
 
-      window.API.get_duplicates_on_post("contacts", post_id).done(dups_with_data=> {
-        possible_duplicates = dups_with_data
-        $("#duplicates-spinner").removeClass("active")
-        loadDuplicates();
-      })
+      window.API.get_duplicates_on_post('contacts', post_id).done(
+        (dups_with_data) => {
+          possible_duplicates = dups_with_data;
+          $('#duplicates-spinner').removeClass('active');
+          loadDuplicates();
+        },
+      );
 
       openedOnce = true;
     }
-  })
+  });
   function loadDuplicates() {
-    let dups_with_data = possible_duplicates
+    let dups_with_data = possible_duplicates;
     if (dups_with_data) {
       let $duplicates = $('#duplicates_list');
-      $duplicates.html("");
+      $duplicates.html('');
 
-      let already_dismissed = window.lodash.get(post, 'duplicate_data.override', []).map(id=>parseInt(id))
+      let already_dismissed = window.lodash
+        .get(post, 'duplicate_data.override', [])
+        .map((id) => parseInt(id));
 
-      let html = ``
-      dups_with_data.sort((a, b) => a.points > b.points ? -1:1).forEach((dupe) => {
-        if (!already_dismissed.includes(parseInt(dupe.ID))) {
-          html += dup_row(dupe)
-        }
-      })
-      if ( html ){
+      let html = ``;
+      dups_with_data
+        .sort((a, b) => (a.points > b.points ? -1 : 1))
+        .forEach((dupe) => {
+          if (!already_dismissed.includes(parseInt(dupe.ID))) {
+            html += dup_row(dupe);
+          }
+        });
+      if (html) {
         $duplicates.append(html);
       } else {
-        $('#no_dups_message').show()
+        $('#no_dups_message').show();
       }
       let dismissed_html = ``;
-      dups_with_data.sort((a, b) => a.points > b.points ? -1:1).forEach((dupe) => {
-        if (already_dismissed.includes(parseInt(dupe.ID))) {
-          dismissed_html += dup_row(dupe, true)
-        }
-      })
+      dups_with_data
+        .sort((a, b) => (a.points > b.points ? -1 : 1))
+        .forEach((dupe) => {
+          if (already_dismissed.includes(parseInt(dupe.ID))) {
+            dismissed_html += dup_row(dupe, true);
+          }
+        });
       if (dismissed_html) {
-        dismissed_html = `<h4 class="merge-modal-subheading">${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.dismissed_duplicates)}</h4>`
-          + dismissed_html
+        dismissed_html =
+          `<h4 class="merge-modal-subheading">${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.dismissed_duplicates)}</h4>` +
+          dismissed_html;
         $duplicates.append(dismissed_html);
       }
     }
   }
-  let dup_row = (dupe, dismissed_row = false)=>{
+  let dup_row = (dupe, dismissed_row = false) => {
     let html = ``;
-    let dups_on_fields = window.lodash.uniq(dupe.fields.map(field=>{
-      return window.lodash.get(window.detailsSettings.post_settings, `fields[${field.field}].name`)
-    }))
-    let matched_values = dupe.fields.map(f=>f.value)
+    let dups_on_fields = window.lodash.uniq(
+      dupe.fields.map((field) => {
+        return window.lodash.get(
+          window.detailsSettings.post_settings,
+          `fields[${field.field}].name`,
+        );
+      }),
+    );
+    let matched_values = dupe.fields.map((f) => f.value);
     html += `<div class="merge-modal-contact-row">
       <h5>
       <a href="${window.wpApiShare.site_url}/${post_type}/${window.SHAREDFUNCTIONS.escapeHTML(dupe.ID)}" class="merge-modal-contact-name" target=_blank>
-      ${ window.SHAREDFUNCTIONS.escapeHTML(dupe.post.name) }
-      <span class="merge-modal-contact-info"> #${dupe.ID} (${window.lodash.get(dupe.post, "overall_status.label") ||""}) </span>
+      ${window.SHAREDFUNCTIONS.escapeHTML(dupe.post.name)}
+      <span class="merge-modal-contact-info"> #${dupe.ID} (${window.lodash.get(dupe.post, 'overall_status.label') || ''}) </span>
       </a>
-    </h5>`
-    html += `${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.duplicates_on).replace('%s', '<strong>' + window.SHAREDFUNCTIONS.escapeHTML(dups_on_fields.join( ', ')) + '</strong>' )}<br />`
+    </h5>`;
+    html += `${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.duplicates_on).replace('%s', '<strong>' + window.SHAREDFUNCTIONS.escapeHTML(dups_on_fields.join(', ')) + '</strong>')}<br />`;
 
-    window.lodash.forOwn(window.detailsSettings.post_settings.fields, (field_settings, field_key)=>{
-      if ( field_settings.type === "communication_channel" && dupe.post[field_key] ){
-        dupe.post[field_key].forEach( contact_info=>{
-          if ( contact_info.value !== '' ){
-            html +=`<img src='${window.SHAREDFUNCTIONS.escapeHTML(field_settings.icon)}'><span style="margin-right: 15px; ${matched_values.includes(contact_info.value) ? 'font-weight:bold;' : ''}">&nbsp;${window.SHAREDFUNCTIONS.escapeHTML(contact_info.value)}</span>`
-          }
-        })
-      }
-    })
-    html += `<br>`
-    if (dupe.post.overall_status?.key === 'closed' && dupe.post.reason_closed && window.detailsSettings.post_settings.fields.reason_closed) {
-      html += `${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.post_settings.fields.reason_closed?.name)}: <strong>${window.SHAREDFUNCTIONS.escapeHTML(dupe.post.reason_closed.label)}</strong>`
-      html += `<br>`
+    window.lodash.forOwn(
+      window.detailsSettings.post_settings.fields,
+      (field_settings, field_key) => {
+        if (
+          field_settings.type === 'communication_channel' &&
+          dupe.post[field_key]
+        ) {
+          dupe.post[field_key].forEach((contact_info) => {
+            if (contact_info.value !== '') {
+              html += `<img src='${window.SHAREDFUNCTIONS.escapeHTML(field_settings.icon)}'><span style="margin-right: 15px; ${matched_values.includes(contact_info.value) ? 'font-weight:bold;' : ''}">&nbsp;${window.SHAREDFUNCTIONS.escapeHTML(contact_info.value)}</span>`;
+            }
+          });
+        }
+      },
+    );
+    html += `<br>`;
+    if (
+      dupe.post.overall_status?.key === 'closed' &&
+      dupe.post.reason_closed &&
+      window.detailsSettings.post_settings.fields.reason_closed
+    ) {
+      html += `${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.post_settings.fields.reason_closed?.name)}: <strong>${window.SHAREDFUNCTIONS.escapeHTML(dupe.post.reason_closed.label)}</strong>`;
+      html += `<br>`;
     }
-    if ( !dismissed_row ){
-      html += `<button class='mergelinks dismiss-duplicate merge-modal-button' data-id='${window.SHAREDFUNCTIONS.escapeHTML(dupe.ID)}'><a>${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.dismiss)}</a></button>`
+    if (!dismissed_row) {
+      html += `<button class='mergelinks dismiss-duplicate merge-modal-button' data-id='${window.SHAREDFUNCTIONS.escapeHTML(dupe.ID)}'><a>${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.dismiss)}</a></button>`;
     }
     html += `
        <button type='submit' class="merge-post merge-modal-button" data-dup-id="${window.SHAREDFUNCTIONS.escapeHTML(dupe.ID)}">
           <a>${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.translations.merge)}</a>
       </button>
-    `
+    `;
 
-    html += `</div>`
+    html += `</div>`;
     return html;
-  }
+  };
 
-  $(document).on( "click", ".merge-post", function () {
-    let dup_id = $(this).data('dup-id')
-    window.location = `${window.wpApiShare.site_url}/${post_type}/mergedetails?dupeid=${dup_id}&currentid=${post_id}`
-  })
+  $(document).on('click', '.merge-post', function () {
+    let dup_id = $(this).data('dup-id');
+    window.location = `${window.wpApiShare.site_url}/${post_type}/mergedetails?dupeid=${dup_id}&currentid=${post_id}`;
+  });
 
-  $(document).on( "click", ".dismiss-duplicate", function () {
+  $(document).on('click', '.dismiss-duplicate', function () {
     let id = $(this).data('id');
-    window.makeRequestOnPosts('POST', `${post_type}/${post_id}/dismiss-duplicates`, {'id':id}).then(resp=>{
-      post.duplicate_data = resp;
-      loadDuplicates();
-      adjust_duplicates_detected_notice_display(post.ID);
-    })
-  })
-  $('#dismiss_all_duplicates').on( 'click', function () {
-    window.makeRequestOnPosts('POST', `${post_type}/${post.ID}/dismiss-duplicates`, {'id':'all'}).then(resp=> {
-      post.duplicate_data = resp;
-      loadDuplicates();
-      adjust_duplicates_detected_notice_display(post.ID);
-    })
-  })
+    window
+      .makeRequestOnPosts(
+        'POST',
+        `${post_type}/${post_id}/dismiss-duplicates`,
+        { id: id },
+      )
+      .then((resp) => {
+        post.duplicate_data = resp;
+        loadDuplicates();
+        adjust_duplicates_detected_notice_display(post.ID);
+      });
+  });
+  $('#dismiss_all_duplicates').on('click', function () {
+    window
+      .makeRequestOnPosts(
+        'POST',
+        `${post_type}/${post.ID}/dismiss-duplicates`,
+        { id: 'all' },
+      )
+      .then((resp) => {
+        post.duplicate_data = resp;
+        loadDuplicates();
+        adjust_duplicates_detected_notice_display(post.ID);
+      });
+  });
 
   function adjust_duplicates_detected_notice_display(orig_post_id) {
-    window.makeRequestOnPosts("GET", `contacts/${orig_post_id}/duplicates`).then(response => {
-      if (response.ids && response.ids.length === 0) {
-        $('#duplicates-detected-notice').hide();
-      }
-    });
+    window
+      .makeRequestOnPosts('GET', `contacts/${orig_post_id}/duplicates`)
+      .then((response) => {
+        if (response.ids && response.ids.length === 0) {
+          $('#duplicates-detected-notice').hide();
+        }
+      });
   }
 
   //open duplicates modal if 'open-duplicates' param is is url
-  let open_duplicates = window.SHAREDFUNCTIONS.get_url_param("open-duplicates")
-  if ( open_duplicates === '1' ){
+  let open_duplicates = window.SHAREDFUNCTIONS.get_url_param('open-duplicates');
+  if (open_duplicates === '1') {
     merge_dupe_edit_modal.foundation('open');
   }
 
   /**
    * Transfer Contact
    */
-  $('#transfer_confirm_button').on('click',function() {
-    $(this).addClass('loading')
-    let siteId = $('#transfer_contact').val()
-    if ( ! siteId ) {
+  $('#transfer_confirm_button').on('click', function () {
+    $(this).addClass('loading');
+    let siteId = $('#transfer_contact').val();
+    if (!siteId) {
       return;
     }
-    window.API.transfer_contact( post_id, siteId )
-    .then(data=>{
-      if ( data ) {
-        location.reload();
-      }
-    }).catch(err=>{
-      console.error(err)
-      // try a second time.
-      window.API.transfer_contact( post_id, siteId )
-      .then(data=>{
-        if ( data ) {
+    window.API.transfer_contact(post_id, siteId)
+      .then((data) => {
+        if (data) {
           location.reload();
         }
-      }).catch(err=> {
-        $(this).removeClass('loading')
-        jQuery('#transfer_spinner').empty().append(err.responseJSON.message).append('&nbsp;' + window.detailsSettings.translations.transfer_error)
-        console.error(err)
       })
-    })
+      .catch((err) => {
+        console.error(err);
+        // try a second time.
+        window.API.transfer_contact(post_id, siteId)
+          .then((data) => {
+            if (data) {
+              location.reload();
+            }
+          })
+          .catch((err) => {
+            $(this).removeClass('loading');
+            jQuery('#transfer_spinner')
+              .empty()
+              .append(err.responseJSON.message)
+              .append(
+                '&nbsp;' + window.detailsSettings.translations.transfer_error,
+              );
+            console.error(err);
+          });
+      });
   });
 
   /**
@@ -281,25 +348,27 @@ jQuery(document).ready(function($) {
     }
 
     window.API.transfer_contact_summary_update(post_id, update)
-      .then(data => {
+      .then((data) => {
         $(this).removeClass('loading');
         transfer_contact_summary_update_results(data);
-
-      }).catch(err => {
-      console.error(err)
-      // try a second time.
-      window.API.transfer_contact_summary_update(post_id, update)
-        .then(data => {
-          $(this).removeClass('loading');
-          transfer_contact_summary_update_results(data);
-
-        }).catch(err => {
+      })
+      .catch((err) => {
         console.error(err);
-        $(this).removeClass('loading');
-        $('#transfer_contact_summary_update_message').fadeOut('fast').html(window.detailsSettings.translations.transfer_update_error).fadeIn('fast');
-
+        // try a second time.
+        window.API.transfer_contact_summary_update(post_id, update)
+          .then((data) => {
+            $(this).removeClass('loading');
+            transfer_contact_summary_update_results(data);
+          })
+          .catch((err) => {
+            console.error(err);
+            $(this).removeClass('loading');
+            $('#transfer_contact_summary_update_message')
+              .fadeOut('fast')
+              .html(window.detailsSettings.translations.transfer_update_error)
+              .fadeIn('fast');
+          });
       });
-    });
 
     // Clear comments textarea
     comments.val('');
@@ -309,10 +378,15 @@ jQuery(document).ready(function($) {
     let message = $('#transfer_contact_summary_update_message');
 
     if (data['success']) {
-      message.fadeOut('fast').html(window.detailsSettings.translations.transfer_update_success).fadeIn('fast');
+      message
+        .fadeOut('fast')
+        .html(window.detailsSettings.translations.transfer_update_success)
+        .fadeIn('fast');
     } else {
-      message.fadeOut('fast').html(window.detailsSettings.translations.transfer_update_error).fadeIn('fast');
+      message
+        .fadeOut('fast')
+        .html(window.detailsSettings.translations.transfer_update_error)
+        .fadeIn('fast');
     }
   }
-
-})
+});

--- a/dt-contacts/contacts_access.js
+++ b/dt-contacts/contacts_access.js
@@ -1,258 +1,311 @@
-let post_id = window.detailsSettings.post_id
-let post_type = window.detailsSettings.post_type
-let post = window.detailsSettings.post_fields
-
+let post_id = window.detailsSettings.post_id;
+let post_type = window.detailsSettings.post_type;
+let post = window.detailsSettings.post_fields;
 
 function setStatus(contact, openModal) {
-  let statusSelect = jQuery('#overall_status')
-  let status = window.lodash.get(contact, "overall_status.key")
-  let reasonLabel = window.lodash.get(contact, `reason_${status}.label`)
-  let statusColor = window.lodash.get(window.detailsSettings,
-    `post_settings.fields.overall_status.default.${status}.color`
-  )
-  statusSelect.val(status)
+  let statusSelect = jQuery('#overall_status');
+  let status = window.lodash.get(contact, 'overall_status.key');
+  let reasonLabel = window.lodash.get(contact, `reason_${status}.label`);
+  let statusColor = window.lodash.get(
+    window.detailsSettings,
+    `post_settings.fields.overall_status.default.${status}.color`,
+  );
+  statusSelect.val(status);
 
-  if (openModal){
-    if (status === "paused"){
+  if (openModal) {
+    if (status === 'paused') {
       jQuery('#paused-contact-modal').foundation('open');
-    } else if (status === "closed"){
+    } else if (status === 'closed') {
       jQuery('#closed-contact-modal').foundation('open');
-    } else if (status === 'unassignable'){
+    } else if (status === 'unassignable') {
       jQuery('#unassignable-contact-modal').foundation('open');
     }
   }
 
-  if (statusColor){
-    statusSelect.css("background-color", statusColor)
+  if (statusColor) {
+    statusSelect.css('background-color', statusColor);
   } else {
-    statusSelect.css("background-color", "#366184")
+    statusSelect.css('background-color', '#366184');
   }
 
-  if (["paused", "closed", "unassignable"].includes(status)){
-    jQuery('#reason').text(`(${reasonLabel})`)
-    jQuery(`#edit-reason`).show()
+  if (['paused', 'closed', 'unassignable'].includes(status)) {
+    jQuery('#reason').text(`(${reasonLabel})`);
+    jQuery(`#edit-reason`).show();
   } else {
-    jQuery('#reason').text(``)
-    jQuery(`#edit-reason`).hide()
+    jQuery('#reason').text(``);
+    jQuery(`#edit-reason`).hide();
   }
 }
 
 function updateCriticalPath(key) {
-  jQuery('#seeker_path').val(key)
-  let seekerPathKeys = window.lodash.keys(post.seeker_path.default)
-  let percentage = (window.lodash.indexOf(seekerPathKeys, key) || 0) / (seekerPathKeys.length-1) * 100
-  jQuery('#seeker-progress').css("width", `${percentage}%`)
+  jQuery('#seeker_path').val(key);
+  let seekerPathKeys = window.lodash.keys(post.seeker_path.default);
+  let percentage =
+    ((window.lodash.indexOf(seekerPathKeys, key) || 0) /
+      (seekerPathKeys.length - 1)) *
+    100;
+  jQuery('#seeker-progress').css('width', `${percentage}%`);
 }
 
-
-jQuery(document).ready(function($) {
-
-
-  $( document ).on( 'dt_record_updated', function (e, response, request ){
-    post = response
-    window.lodash.forOwn(request, (val, key)=>{
-      if (key.indexOf("quick_button")>-1){
-        if (window.lodash.get(response, "seeker_path.key")){
-          updateCriticalPath(response.seeker_path.key)
+jQuery(document).ready(function ($) {
+  $(document).on('dt_record_updated', function (e, response, request) {
+    post = response;
+    window.lodash.forOwn(request, (val, key) => {
+      if (key.indexOf('quick_button') > -1) {
+        if (window.lodash.get(response, 'seeker_path.key')) {
+          updateCriticalPath(response.seeker_path.key);
         }
       }
-      if (key === "overall_status" || key === "assigned_to"){
-        setStatus(response)
+      if (key === 'overall_status' || key === 'assigned_to') {
+        setStatus(response);
       }
-    })
-  })
-  $('#content')[0].addEventListener('comment_posted', function (e) {
-    if ( $('.update-needed').prop("checked") === true ){
-      window.API.get_post("contacts",  post_id ).then(resp=>{
-        post = resp
-        window.record_updated(window.lodash.get(resp, "requires_update") === true )
-      }).catch(err => { console.error(err) })
-    }
-  }, false);
+    });
+  });
+  $('#content')[0].addEventListener(
+    'comment_posted',
+    function (e) {
+      if ($('.update-needed').prop('checked') === true) {
+        window.API.get_post('contacts', post_id)
+          .then((resp) => {
+            post = resp;
+            window.record_updated(
+              window.lodash.get(resp, 'requires_update') === true,
+            );
+          })
+          .catch((err) => {
+            console.error(err);
+          });
+      }
+    },
+    false,
+  );
 
-  $( document ).on( 'select-field-updated', function (e, newContact, id, val) {
+  $(document).on('select-field-updated', function (e, newContact, id, val) {
     if (id === 'seeker_path') {
       // updateCriticalPath(newContact.seeker_path.key)
       // refresh_quick_action_buttons(newContact)
     } else if (id === 'reason_unassignable') {
-      setStatus(newContact)
+      setStatus(newContact);
     } else if (id === 'overall_status') {
-      setStatus(newContact, true)
+      setStatus(newContact, true);
     }
-  })
-   //confirm setting a reason for a status.
-  let confirmButton = $(".confirm-reason-button")
-  confirmButton.on("click", function () {
-    let field = $(this).data('field')
-    let select = $(`#reason-${field}-options`)
-    $(this).toggleClass('loading')
-    let data = {overall_status:field}
-    data[`reason_${field}`] = select.val()
-    window.API.update_post('contacts', post_id, data).then(contactData=>{
-      $(this).toggleClass('loading')
-      $(`#${field}-contact-modal`).foundation('close')
-      setStatus(contactData)
-    }).catch(err => { console.error(err) })
-  })
+  });
+  //confirm setting a reason for a status.
+  let confirmButton = $('.confirm-reason-button');
+  confirmButton.on('click', function () {
+    let field = $(this).data('field');
+    let select = $(`#reason-${field}-options`);
+    $(this).toggleClass('loading');
+    let data = { overall_status: field };
+    data[`reason_${field}`] = select.val();
+    window.API.update_post('contacts', post_id, data)
+      .then((contactData) => {
+        $(this).toggleClass('loading');
+        $(`#${field}-contact-modal`).foundation('close');
+        setStatus(contactData);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  });
 
   $('#edit-reason').on('click', function () {
-    setStatus(post, true)
-  })
+    setStatus(post, true);
+  });
   /**
    * Accept or decline a contact
    */
   $('.accept-decline').on('click', function () {
-    let action = $(this).data("action")
-    let data = {accept:action === "accept"}
-    window.makeRequestOnPosts( "POST", `contacts/${post_id}/accept`, data)
-    .then(function (resp) {
-      setStatus(resp)
-      jQuery('#accept-contact').hide()
-    }).catch(err=>{
-      console.log('error')
-      console.log(err.responseText)
-    })
-  })
+    let action = $(this).data('action');
+    let data = { accept: action === 'accept' };
+    window
+      .makeRequestOnPosts('POST', `contacts/${post_id}/accept`, data)
+      .then(function (resp) {
+        setStatus(resp);
+        jQuery('#accept-contact').hide();
+      })
+      .catch((err) => {
+        console.log('error');
+        console.log(err.responseText);
+      });
+  });
 
   let dispatch_users = [];
-  let selected_role = "multiplier";
-  let dispatch_users_promise = null
-  let list_filters = $('#user-list-filters')
-  let defined_list_section = $('#defined-lists')
-  let populated_list = $('.populated-list')
+  let selected_role = 'multiplier';
+  let dispatch_users_promise = null;
+  let list_filters = $('#user-list-filters');
+  let defined_list_section = $('#defined-lists');
+  let populated_list = $('.populated-list');
 
-  jQuery('.advanced_user_select').on('click', function (){
+  jQuery('.advanced_user_select').on('click', function () {
     $('#assigned_to_user_modal').foundation('open');
-    if ( dispatch_users_promise === null ){
-      $('#assigned_to_user_modal #dispatch-tile-loader').addClass('active')
-      dispatch_users_promise = window.makeRequest( 'GET', 'assignment-list', {location_ids: (post.location_grid||[]).map(l=>l.id), 'post_id': post_id, 'post_type': post_type}, 'dt-posts/v2/contacts' )
-      dispatch_users_promise.then(response=>{
-        $('#assigned_to_user_modal #dispatch-tile-loader').removeClass('active')
-        dispatch_users = response
-        $('.users-select-panel').show()
-        show_assignment_tab( selected_role )
-      })
+    if (dispatch_users_promise === null) {
+      $('#assigned_to_user_modal #dispatch-tile-loader').addClass('active');
+      dispatch_users_promise = window.makeRequest(
+        'GET',
+        'assignment-list',
+        {
+          location_ids: (post.location_grid || []).map((l) => l.id),
+          post_id: post_id,
+          post_type: post_type,
+        },
+        'dt-posts/v2/contacts',
+      );
+      dispatch_users_promise.then((response) => {
+        $('#assigned_to_user_modal #dispatch-tile-loader').removeClass(
+          'active',
+        );
+        dispatch_users = response;
+        $('.users-select-panel').show();
+        show_assignment_tab(selected_role);
+      });
     } else {
-      $('.users-select-panel').show()
-      show_assignment_tab( selected_role )
+      $('.users-select-panel').show();
+      show_assignment_tab(selected_role);
     }
-  })
+  });
 
   //change tab
   $('#assign-role-tabs a').on('click', function () {
-    selected_role = $(this).data('field')
-    $('#search-users-filtered').attr("placeholder", $(this).text().trim())
-    show_assignment_tab( selected_role )
-  })
+    selected_role = $(this).data('field');
+    $('#search-users-filtered').attr('placeholder', $(this).text().trim());
+    show_assignment_tab(selected_role);
+  });
 
-  function show_assignment_tab( tab = 'multiplier' ){
-    const contact_languages = (window.lodash.get(window.detailsSettings, "post_fields.languages"))
+  function show_assignment_tab(tab = 'multiplier') {
+    const contact_languages = window.lodash.get(
+      window.detailsSettings,
+      'post_fields.languages',
+    )
       ? window.detailsSettings.post_fields.languages
-      : []
-    const contact_gender = (window.lodash.get(window.detailsSettings, "post_fields.gender"))
+      : [];
+    const contact_gender = window.lodash.get(
+      window.detailsSettings,
+      'post_fields.gender',
+    )
       ? window.detailsSettings.post_fields.gender
-      : { key: null, label: "" }
+      : { key: null, label: '' };
 
-    let filters = `<a data-id="all" style="color: black; font-weight: bold">${window.SHAREDFUNCTIONS.escapeHTML(window.dt_contacts_access.translations.all)}</a> | `
+    let filters = `<a data-id="all" style="color: black; font-weight: bold">${window.SHAREDFUNCTIONS.escapeHTML(window.dt_contacts_access.translations.all)}</a> | `;
 
-    defined_list_section.show()
-    let users_with_role = dispatch_users.filter(u => u.roles.includes(tab))
+    defined_list_section.show();
+    let users_with_role = dispatch_users.filter((u) => u.roles.includes(tab));
     let filter_options = {
       all: users_with_role.sort((a, b) => {
         if (a.weight && b.weight) {
           if (a.weight === b.weight) {
             return 0;
           } else {
-            return (a.weight > b.weight) ? -1 : 1;
+            return a.weight > b.weight ? -1 : 1;
           }
         } else {
           return a.name.localeCompare(b.name);
         }
       }),
-      ready: users_with_role.filter(m=>m.status==='active'),
-      recent: users_with_role.concat().sort((a,b)=>b.last_assignment-a.last_assignment),
-      language: users_with_role.filter(({ languages }) => languages.some(language => contact_languages.includes(language))),
-      gender: users_with_role.filter(m => contact_gender.label !== "" && m.gender === contact_gender.key),
-      location: users_with_role.concat().filter(m=>m.location!==null).sort((a,b)=>a.location-b.location)
-    }
-    populate_users_list( users_with_role )
-    filters += `<a data-id="ready">${window.SHAREDFUNCTIONS.escapeHTML(window.dt_contacts_access.translations.ready)}</a> | `
-    filters += `<a data-id="recent">${window.SHAREDFUNCTIONS.escapeHTML(window.dt_contacts_access.translations.recent)}</a> | `
-    filters += `<a data-id="language">${window.SHAREDFUNCTIONS.escapeHTML(window.dt_contacts_access.translations.language)}</a> | `
-    filters += `<a data-id="gender">${window.SHAREDFUNCTIONS.escapeHTML(window.dt_contacts_access.translations.gender)}</a> | `
-    filters += `<a data-id="location">${window.SHAREDFUNCTIONS.escapeHTML(window.dt_contacts_access.translations.location)}</a>`
-    list_filters.html(filters)
-
+      ready: users_with_role.filter((m) => m.status === 'active'),
+      recent: users_with_role
+        .concat()
+        .sort((a, b) => b.last_assignment - a.last_assignment),
+      language: users_with_role.filter(({ languages }) =>
+        languages.some((language) => contact_languages.includes(language)),
+      ),
+      gender: users_with_role.filter(
+        (m) => contact_gender.label !== '' && m.gender === contact_gender.key,
+      ),
+      location: users_with_role
+        .concat()
+        .filter((m) => m.location !== null)
+        .sort((a, b) => a.location - b.location),
+    };
+    populate_users_list(users_with_role);
+    filters += `<a data-id="ready">${window.SHAREDFUNCTIONS.escapeHTML(window.dt_contacts_access.translations.ready)}</a> | `;
+    filters += `<a data-id="recent">${window.SHAREDFUNCTIONS.escapeHTML(window.dt_contacts_access.translations.recent)}</a> | `;
+    filters += `<a data-id="language">${window.SHAREDFUNCTIONS.escapeHTML(window.dt_contacts_access.translations.language)}</a> | `;
+    filters += `<a data-id="gender">${window.SHAREDFUNCTIONS.escapeHTML(window.dt_contacts_access.translations.gender)}</a> | `;
+    filters += `<a data-id="location">${window.SHAREDFUNCTIONS.escapeHTML(window.dt_contacts_access.translations.location)}</a>`;
+    list_filters.html(filters);
 
     $('#user-list-filters a').on('click', function () {
-      $( '#user-list-filters a' ).css("color","").css("font-weight","")
-      $(this).css("color", "black").css("font-weight", "bold")
-      let key = $(this).data('id')
-      populate_users_list( filter_options[key] || [], key )
-    })
+      $('#user-list-filters a').css('color', '').css('font-weight', '');
+      $(this).css('color', 'black').css('font-weight', 'bold');
+      let key = $(this).data('id');
+      populate_users_list(filter_options[key] || [], key);
+    });
   }
 
   function populate_users_list(users, tab = 'all') {
     let user_rows = '';
-    users.forEach( m => {
+    users.forEach((m) => {
       user_rows += `<div class="assigned-to-row" dir="auto">
         <span>
-          <span class="avatar"><img style="vertical-align: text-bottom" src="${window.SHAREDFUNCTIONS.escapeHTML( m.avatar )}"/></span>
+          <span class="avatar"><img style="vertical-align: text-bottom" src="${window.SHAREDFUNCTIONS.escapeHTML(m.avatar)}"/></span>
           ${window.SHAREDFUNCTIONS.escapeHTML(m.name)}
         </span>
-        ${ m.status_color ? `<span class="status-square" style="background-color: ${ window.SHAREDFUNCTIONS.escapeHTML(m.status_color) }">&nbsp;</span>` : '' }
-        ${ m.update_needed ? `
+        ${m.status_color ? `<span class="status-square" style="background-color: ${window.SHAREDFUNCTIONS.escapeHTML(m.status_color)}">&nbsp;</span>` : ''}
+        ${
+          m.update_needed
+            ? `
           <span>
             <img style="height: 12px;" src="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.template_dir)}/dt-assets/images/broken.svg"/>
-            <span style="font-size: 14px">${ window.SHAREDFUNCTIONS.escapeHTML(m.update_needed) }</span>
-          </span>` : ''
-      }
-        ${ m.best_location_match ? `<span>(${ window.SHAREDFUNCTIONS.escapeHTML(m.best_location_match) })</span>` : ''
-
-      }
+            <span style="font-size: 14px">${window.SHAREDFUNCTIONS.escapeHTML(m.update_needed)}</span>
+          </span>`
+            : ''
+        }
+        ${
+          m.best_location_match
+            ? `<span>(${window.SHAREDFUNCTIONS.escapeHTML(m.best_location_match)})</span>`
+            : ''
+        }
         <div style="flex-grow: 1"></div>
-        <button class="button hollow tiny trigger-assignment" data-id="${ window.SHAREDFUNCTIONS.escapeHTML(m.ID) }" style="margin-bottom: 3px">
+        <button class="button hollow tiny trigger-assignment" data-id="${window.SHAREDFUNCTIONS.escapeHTML(m.ID)}" style="margin-bottom: 3px">
            ${window.SHAREDFUNCTIONS.escapeHTML(window.dt_contacts_access.translations.assign)}
         </button>
       </div>
-      `
-    })
-    if ( user_rows.length === 0 ){
-      user_rows = `<p style="padding:1rem">${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.no_records_found.replace("{{query}}", window.dt_contacts_access.translations[tab]))}</p>`
+      `;
+    });
+    if (user_rows.length === 0) {
+      user_rows = `<p style="padding:1rem">${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.no_records_found.replace('{{query}}', window.dt_contacts_access.translations[tab]))}</p>`;
     }
-    populated_list.html(user_rows)
-
+    populated_list.html(user_rows);
   }
 
   $(document).on('click', '.trigger-assignment', function () {
-    let user_id = $(this).data('id')
-    $('#dispatch-tile-loader').addClass('active')
-    let status = selected_role === "dispatcher" ? "unassigned" : "assigned"
-    window.API.update_post(
-      'contacts',
-      window.detailsSettings.post_fields.ID,
-      {
-        assigned_to: 'user-' + user_id,
-        overall_status: status
-      }
-    ).then(function (response) {
-      $('#dispatch-tile-loader').removeClass('active')
-      setStatus(response)
-      $(`.js-typeahead-assigned_to`).val(window.SHAREDFUNCTIONS.escapeHTML(response.assigned_to.display)).blur()
+    let user_id = $(this).data('id');
+    $('#dispatch-tile-loader').addClass('active');
+    let status = selected_role === 'dispatcher' ? 'unassigned' : 'assigned';
+    window.API.update_post('contacts', window.detailsSettings.post_fields.ID, {
+      assigned_to: 'user-' + user_id,
+      overall_status: status,
+    }).then(function (response) {
+      $('#dispatch-tile-loader').removeClass('active');
+      setStatus(response);
+      $(`.js-typeahead-assigned_to`)
+        .val(window.SHAREDFUNCTIONS.escapeHTML(response.assigned_to.display))
+        .blur();
       $('#assigned_to_user_modal').foundation('close');
-    })
-  })
+    });
+  });
 
   /**
    * search name in list
    */
   $('#search-users-filtered').on('input', function () {
-    $( '#user-list-filters a' ).css("color","").css("font-weight","")
-    let search_text = $(this).val().normalize('NFD').replace(/[\u0300-\u036f]/g, "").toLowerCase()
-    let users_with_role = dispatch_users.filter(u => u.roles.includes(selected_role) )
-    let match_name = users_with_role.filter(u =>
-      u.name.normalize('NFD').replace(/[\u0300-\u036f]/g, "").toLowerCase().includes( search_text )
-    )
-    populate_users_list(match_name)
-  })
-})
+    $('#user-list-filters a').css('color', '').css('font-weight', '');
+    let search_text = $(this)
+      .val()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase();
+    let users_with_role = dispatch_users.filter((u) =>
+      u.roles.includes(selected_role),
+    );
+    let match_name = users_with_role.filter((u) =>
+      u.name
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .includes(search_text),
+    );
+    populate_users_list(match_name);
+  });
+});

--- a/dt-contacts/contacts_dmm.js
+++ b/dt-contacts/contacts_dmm.js
@@ -1,29 +1,28 @@
-jQuery(document).ready(function($) {
+jQuery(document).ready(function ($) {
+  let post_id = window.detailsSettings.post_id;
+  let post_type = window.detailsSettings.post_type;
+  let post = window.detailsSettings.post_fields;
 
-  let post_id = window.detailsSettings.post_id
-  let post_type = window.detailsSettings.post_type
-  let post = window.detailsSettings.post_fields
+  $('.quick-action-menu').on('click', function () {
+    let fieldKey = $(this).data('id');
 
+    let data = {};
+    let numberIndicator = $(`span.${fieldKey}`);
+    let newNumber = parseInt(numberIndicator.first().text() || '0') + 1;
+    data[fieldKey] = newNumber;
+    window.API.update_post('contacts', post_id, data)
+      .then(() => {
+        window.record_updated(false);
+      })
+      .catch((err) => {
+        console.log('error');
+        console.log(err);
+      });
 
-  $('.quick-action-menu').on("click", function () {
-    let fieldKey = $(this).data("id")
-
-    let data = {}
-    let numberIndicator = $(`span.${fieldKey}`)
-    let newNumber = parseInt(numberIndicator.first().text() || "0" ) + 1
-    data[fieldKey] = newNumber
-    window.API.update_post('contacts', post_id, data).then(()=>{
-      window.record_updated(false)
-    })
-    .catch(err=>{
-      console.log("error")
-      console.log(err)
-    })
-
-    if (fieldKey.indexOf("quick_button")>-1){
-      numberIndicator.text(newNumber)
+    if (fieldKey.indexOf('quick_button') > -1) {
+      numberIndicator.text(newNumber);
     }
-  })
+  });
 
   // Baptism date
   let modalBaptismDatePicker = $('input#modal-baptism-date-picker');
@@ -31,18 +30,26 @@ jQuery(document).ready(function($) {
     constrainInput: false,
     dateFormat: 'yy-mm-dd',
     onSelect: function (date) {
-      window.API.update_post('contacts', post_id, { baptism_date: date }).then((resp)=>{
-        if (this.value) {
-          this.value = window.SHAREDFUNCTIONS.formatDate(resp["baptism_date"]["timestamp"]);
-        }
-      }).catch(window.handleAjaxError)
+      window.API.update_post('contacts', post_id, { baptism_date: date })
+        .then((resp) => {
+          if (this.value) {
+            this.value = window.SHAREDFUNCTIONS.formatDate(
+              resp['baptism_date']['timestamp'],
+            );
+          }
+        })
+        .catch(window.handleAjaxError);
     },
     changeMonth: true,
     changeYear: true,
-    yearRange: "-20:+10",
-  })
-  let openBaptismModal = function( newContact ){
-    if ( !post.baptism_date || !(post.milestones || []).includes('milestone_baptized') || (post.baptized_by || []).length === 0 ){
+    yearRange: '-20:+10',
+  });
+  let openBaptismModal = function (newContact) {
+    if (
+      !post.baptism_date ||
+      !(post.milestones || []).includes('milestone_baptized') ||
+      (post.baptized_by || []).length === 0
+    ) {
       $('#baptism-modal').foundation('open');
       if (!window.Typeahead['.js-typeahead-modal_baptized_by']) {
         $.typeahead({
@@ -51,82 +58,116 @@ jQuery(document).ready(function($) {
           accent: true,
           searchOnFocus: true,
           source: window.TYPEAHEADS.typeaheadContactsSource(),
-          templateValue: "{{name}}",
+          templateValue: '{{name}}',
           template: window.TYPEAHEADS.contactListRowTemplate,
           matcher: function (item) {
-            return parseInt(item.ID) !== parseInt(post.ID)
+            return parseInt(item.ID) !== parseInt(post.ID);
           },
           dynamic: true,
           hint: true,
-          emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.no_records_found),
+          emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(
+            window.wpApiShare.translations.no_records_found,
+          ),
           multiselect: {
-            matchOn: ["ID"],
+            matchOn: ['ID'],
             data: function () {
-              return (post["baptized_by"] || [] ).map(g=>{
-                return {ID:g.ID, name:g.post_title}
-              })
-            }, callback: {
-              onCancel: function (node, item) {
-                window.API.update_post('contacts', post_id, {"baptized_by": {values:[{value:item.ID, delete:true}]}})
-                .catch(err => { console.error(err) })
-              }
+              return (post['baptized_by'] || []).map((g) => {
+                return { ID: g.ID, name: g.post_title };
+              });
             },
-            href: window.SHAREDFUNCTIONS.escapeHTML( window.wpApiShare.site_url ) + "/contacts/{{ID}}"
+            callback: {
+              onCancel: function (node, item) {
+                window.API.update_post('contacts', post_id, {
+                  baptized_by: { values: [{ value: item.ID, delete: true }] },
+                }).catch((err) => {
+                  console.error(err);
+                });
+              },
+            },
+            href:
+              window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url) +
+              '/contacts/{{ID}}',
           },
           callback: {
             onClick: function (node, a, item) {
-              window.API.update_post('contacts', post_id, {"baptized_by": {values:[{"value":item.ID}]}})
-              .catch(err => { console.error(err) })
-              this.addMultiselectItemLayout(item)
-              event.preventDefault()
+              window.API.update_post('contacts', post_id, {
+                baptized_by: { values: [{ value: item.ID }] },
+              }).catch((err) => {
+                console.error(err);
+              });
+              this.addMultiselectItemLayout(item);
+              event.preventDefault();
               this.hideLayout();
               this.resetInput();
             },
             onResult: function (node, query, result, resultCount) {
-              let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+              let text = window.TYPEAHEADS.typeaheadHelpText(
+                resultCount,
+                query,
+                result,
+              );
               $('#modal_baptized_by-result-container').html(text);
             },
             onHideLayout: function () {
-              $('.modal_baptized_by-result-container').html("");
+              $('.modal_baptized_by-result-container').html('');
             },
           },
         });
       }
-      if ( window.lodash.get(newContact, "baptism_date.timestamp", 0) > 0){
-        modalBaptismDatePicker.datepicker('setDate', window.moment.unix(newContact['baptism_date']["timestamp"]).format("YYYY-MM-DD"));
-        modalBaptismDatePicker.val(window.SHAREDFUNCTIONS.formatDate(newContact['baptism_date']["timestamp"]) )
+      if (window.lodash.get(newContact, 'baptism_date.timestamp', 0) > 0) {
+        modalBaptismDatePicker.datepicker(
+          'setDate',
+          window.moment
+            .unix(newContact['baptism_date']['timestamp'])
+            .format('YYYY-MM-DD'),
+        );
+        modalBaptismDatePicker.val(
+          window.SHAREDFUNCTIONS.formatDate(
+            newContact['baptism_date']['timestamp'],
+          ),
+        );
       }
     }
-    post = newContact
-  }
+    post = newContact;
+  };
   $('#close-baptism-modal').on('click', function () {
-    location.reload()
-  })
+    location.reload();
+  });
 
   /**
    * detect if an update is made on the baptized_by field.
    */
-  $( document ).on( 'dt_record_updated', function (e, response, request ){
-    post = response
-    if ( window.lodash.get(request, "baptized_by" ) && window.lodash.get( response, "baptized_by[0]" ) ) {
-      openBaptismModal( response )
+  $(document).on('dt_record_updated', function (e, response, request) {
+    post = response;
+    if (
+      window.lodash.get(request, 'baptized_by') &&
+      window.lodash.get(response, 'baptized_by[0]')
+    ) {
+      openBaptismModal(response);
     }
-  })
+  });
 
   /**
    * detect if an update is made on the milestone field for baptized.
    */
-  $( document ).on( 'dt_multi_select-updated', function (e, newContact, fieldKey, optionKey, action) {
-    if ( optionKey === 'milestone_baptized' && action === 'add' ){
-      openBaptismModal(newContact)
-    }
-  })
+  $(document).on(
+    'dt_multi_select-updated',
+    function (e, newContact, fieldKey, optionKey, action) {
+      if (optionKey === 'milestone_baptized' && action === 'add') {
+        openBaptismModal(newContact);
+      }
+    },
+  );
   /**
    * If a baptism date is added
    */
-  $( document ).on( 'dt_date_picker-updated', function (e, newContact, id, date){
-    if (id === 'baptism_date' && newContact.baptism_date && newContact.baptism_date.timestamp) {
-      openBaptismModal(newContact)
+  $(document).on('dt_date_picker-updated', function (e, newContact, id, date) {
+    if (
+      id === 'baptism_date' &&
+      newContact.baptism_date &&
+      newContact.baptism_date.timestamp
+    ) {
+      openBaptismModal(newContact);
     }
-  })
-})
+  });
+});

--- a/dt-core/admin/js/dt-extensions.js
+++ b/dt-core/admin/js/dt-extensions.js
@@ -1,32 +1,37 @@
-jQuery(function($){
-    function remove_2_column_template() {
-        $('#post-body').attr('class', 'metabox-holder');
-    }
+jQuery(function ($) {
+  function remove_2_column_template() {
+    $('#post-body').attr('class', 'metabox-holder');
+  }
 
-    remove_2_column_template();
+  remove_2_column_template();
 
-    $('.plugin-install > a').on('click', function() {
-        $('.plugin-install > a').removeClass('current');
-        $(this).addClass('current');
-        var clicked_category = $(this).data('category');
-        filter_plugin_cards(clicked_category);
-    });
+  $('.plugin-install > a').on('click', function () {
+    $('.plugin-install > a').removeClass('current');
+    $(this).addClass('current');
+    var clicked_category = $(this).data('category');
+    filter_plugin_cards(clicked_category);
+  });
 
-    function load_all_plugin_cards() {
-        let all_plugins = window.plugins.all_plugins;
-        var translations = window.plugins.translations;
-        let can_install_plugins = window.plugins.can_install_plugins;
-        var install_text = window.dt_admin_shared.escape(translations.install);
-        var delete_text = window.dt_admin_shared.escape(translations.delete);
-        var activate_text = window.dt_admin_shared.escape(translations.activate);
-        var deactivate_text = window.dt_admin_shared.escape(translations.deactivate);
-        var plugin_by_text = window.dt_admin_shared.escape(translations.plugin_by);
+  function load_all_plugin_cards() {
+    let all_plugins = window.plugins.all_plugins;
+    var translations = window.plugins.translations;
+    let can_install_plugins = window.plugins.can_install_plugins;
+    var install_text = window.dt_admin_shared.escape(translations.install);
+    var delete_text = window.dt_admin_shared.escape(translations.delete);
+    var activate_text = window.dt_admin_shared.escape(translations.activate);
+    var deactivate_text = window.dt_admin_shared.escape(
+      translations.deactivate,
+    );
+    var plugin_by_text = window.dt_admin_shared.escape(translations.plugin_by);
 
-        $.each(all_plugins, function(index, plugin) {
-            var is_proof_of_concept = plugin_is_in_category(plugin, 'proof-of-concept');
-            var is_beta = plugin_is_in_category(plugin, 'beta');
-            var plugin_description = shorten_description(plugin['description']);
-            var plugin_card_html = `
+    $.each(all_plugins, function (index, plugin) {
+      var is_proof_of_concept = plugin_is_in_category(
+        plugin,
+        'proof-of-concept',
+      );
+      var is_beta = plugin_is_in_category(plugin, 'beta');
+      var plugin_description = shorten_description(plugin['description']);
+      var plugin_card_html = `
                 <div class="plugin-card plugin-card-classic-editor" data-category="${plugin['categories']}" data-slug="${plugin['slug']}" style="display: none;">
                     <div class="plugin-card-top card-front">
                         <div class="name column-name">
@@ -40,64 +45,64 @@ jQuery(function($){
                         <div class="action-links">
                             <ul class="plugin-action-buttons">`;
 
-
-                var installation_button_html =  `
+      var installation_button_html = `
                     <li>
-                        <button class="button" data-action="install" data-plugin-slug="${plugin['slug']}" ${can_install_plugins ? '' : 'disabled' }>${install_text}</button>
+                        <button class="button" data-action="install" data-plugin-slug="${plugin['slug']}" ${can_install_plugins ? '' : 'disabled'}>${install_text}</button>
                     </li>`;
 
-                var activation_button_html = '';
-                if ( plugin['installed'] && !plugin['active']  ) {
-                    activation_button_html =   `
+      var activation_button_html = '';
+      if (plugin['installed'] && !plugin['active']) {
+        activation_button_html = `
                     <li>
                         <button class="button" data-action="activate" data-plugin-slug="${plugin['slug']}">${activate_text}</button>
                     </li>`;
-                    installation_button_html = ''
-                    if ( can_install_plugins ) {
-                      installation_button_html = `<li>
+        installation_button_html = '';
+        if (can_install_plugins) {
+          installation_button_html = `<li>
                           <button class="button" data-action="delete" data-plugin-slug="${plugin['slug']}">${delete_text}</button>
                       </li>`;
-                    }
-                }
+        }
+      }
 
-
-                if ( plugin['active'] ) {
-                    activation_button_html = `
+      if (plugin['active']) {
+        activation_button_html = `
                         <li>
                             <button class="button" data-action="deactivate" data-plugin-slug="${plugin['slug']}">${deactivate_text}</button>
                         </li>`;
-                    installation_button_html = '';
-                }
+        installation_button_html = '';
+      }
 
-                plugin_card_html += activation_button_html;
-                plugin_card_html += installation_button_html;
+      plugin_card_html += activation_button_html;
+      plugin_card_html += installation_button_html;
 
-
-                if ( is_proof_of_concept ) {
-                    plugin_card_html += `
+      if (is_proof_of_concept) {
+        plugin_card_html += `
                         <li>
                             <a class="warning-pill">POC</a>
                         </li>`;
-                }
-                if ( is_beta ) {
-                    plugin_card_html += `
+      }
+      if (is_beta) {
+        plugin_card_html += `
                         <li>
                             <a class="warning-pill">BETA</a>
                         </li>`;
-                }
-                plugin_card_html += `
+      }
+      plugin_card_html += `
                     </ul>
                         </div>
                         <div class="extension-buttons"></div>
                         <div class="desc column-description">
                             <p>${plugin_description}</p>
                             <p class="authors">
-                                <cite>${plugin_by_text.replace('%s', `
+                                <cite>${plugin_by_text.replace(
+                                  '%s',
+                                  `
                                     <a href="${plugin['author_homepage']}">
                                         ${plugin['author']}
                                         <img src="https://avatars.githubusercontent.com/${plugin['author_github_username']}?size=28" class="plugin-author-img">
                                     </a>
-                                `)}
+                                `,
+                                )}
                                 </cite>
                             </p>
                         </div>
@@ -106,243 +111,293 @@ jQuery(function($){
                         <div class="plugin-card-content-back"></div>
                     </div>
                 </div>`;
-                $('#the-list').append(plugin_card_html);
-            });
-    }
-    load_all_plugin_cards();
-
-    function filter_plugin_cards(category='all-plugins') {
-        if ( category === 'all-plugins' ) {
-            $('.plugin-card').fadeIn();
-            return;
-        }
-
-        $('.plugin-card').fadeOut(50);
-
-        let all_plugins = window.plugins.all_plugins;
-        $.each(all_plugins, function(index, plugin) {
-            if ( plugin['categories'] ) {
-                var categories = plugin['categories'].split(',');
-                if ( $.inArray(category, categories) != -1 ) {
-                    $('#the-list').prepend($(`.plugin-card[data-category*="${category}"]`));
-                    $(`.plugin-card[data-category*="${category}"]`).fadeIn();
-                }
-            }
-        });
-        $('#the-list').append($('#no-typeahead-results'));
-    }
-
-    filter_plugin_cards('featured');
-
-    function plugin_is_in_category(plugin, category) {
-        if ( plugin['categories'] ) {
-            if ( plugin['categories'].indexOf(category) != -1 ) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    function shorten_description(description='') {
-        if ( description.length > 75 ) {
-            description = description.slice(0, 175) + '...';
-        }
-        return description;
-    }
-
-    $('.plugin-card').on('click', '.button', function() {
-        $(this).parent().closest('.plugin-card').addClass('flip-card');
-        var action = $(this).data('action');
-        var plugin_slug = $(this).data('plugin-slug');
-        var card_back = $(this).parent().closest('.plugin-card').find('.plugin-card-content-back');
-
-        if ( action === 'install') {
-            card_back.html('Installing...');
-            plugin_install(plugin_slug);
-        }
-        if ( action === 'delete') {
-            card_back.html('Deleting...');
-            plugin_delete(plugin_slug);
-        }
-        if ( action === 'activate') {
-            card_back.html('Activating...');
-            plugin_activate(plugin_slug);
-        }
-        if ( action === 'deactivate') {
-            card_back.html('Deactivating...');
-            plugin_deactivate(plugin_slug);
-        }
-        card_back.append('<br><span class="loading"></span>');
+      $('#the-list').append(plugin_card_html);
     });
+  }
+  load_all_plugin_cards();
 
-    function makeRequest(type, url, data, base = "dt/v1/") {
-        // Add trailing slash if missing
-        if ( !base.endsWith('/') && !url.startsWith('/')){
-          base += '/'
+  function filter_plugin_cards(category = 'all-plugins') {
+    if (category === 'all-plugins') {
+      $('.plugin-card').fadeIn();
+      return;
+    }
+
+    $('.plugin-card').fadeOut(50);
+
+    let all_plugins = window.plugins.all_plugins;
+    $.each(all_plugins, function (index, plugin) {
+      if (plugin['categories']) {
+        var categories = plugin['categories'].split(',');
+        if ($.inArray(category, categories) != -1) {
+          $('#the-list').prepend(
+            $(`.plugin-card[data-category*="${category}"]`),
+          );
+          $(`.plugin-card[data-category*="${category}"]`).fadeIn();
         }
-        const options = {
-          type: type,
-          contentType: "application/json; charset=utf-8",
-          dataType: "json",
-          url: url.startsWith("http") ? url : `${window.wpApiSettings.root}${base}${url}`,
-          beforeSend: (xhr) => {
-            xhr.setRequestHeader("X-WP-Nonce", window.wpApiSettings.nonce);
-          },
-        };
-        if (data) {
-          options.data = type === "GET" ? data : JSON.stringify(data);
+      }
+    });
+    $('#the-list').append($('#no-typeahead-results'));
+  }
+
+  filter_plugin_cards('featured');
+
+  function plugin_is_in_category(plugin, category) {
+    if (plugin['categories']) {
+      if (plugin['categories'].indexOf(category) != -1) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function shorten_description(description = '') {
+    if (description.length > 75) {
+      description = description.slice(0, 175) + '...';
+    }
+    return description;
+  }
+
+  $('.plugin-card').on('click', '.button', function () {
+    $(this).parent().closest('.plugin-card').addClass('flip-card');
+    var action = $(this).data('action');
+    var plugin_slug = $(this).data('plugin-slug');
+    var card_back = $(this)
+      .parent()
+      .closest('.plugin-card')
+      .find('.plugin-card-content-back');
+
+    if (action === 'install') {
+      card_back.html('Installing...');
+      plugin_install(plugin_slug);
+    }
+    if (action === 'delete') {
+      card_back.html('Deleting...');
+      plugin_delete(plugin_slug);
+    }
+    if (action === 'activate') {
+      card_back.html('Activating...');
+      plugin_activate(plugin_slug);
+    }
+    if (action === 'deactivate') {
+      card_back.html('Deactivating...');
+      plugin_deactivate(plugin_slug);
+    }
+    card_back.append('<br><span class="loading"></span>');
+  });
+
+  function makeRequest(type, url, data, base = 'dt/v1/') {
+    // Add trailing slash if missing
+    if (!base.endsWith('/') && !url.startsWith('/')) {
+      base += '/';
+    }
+    const options = {
+      type: type,
+      contentType: 'application/json; charset=utf-8',
+      dataType: 'json',
+      url: url.startsWith('http')
+        ? url
+        : `${window.wpApiSettings.root}${base}${url}`,
+      beforeSend: (xhr) => {
+        xhr.setRequestHeader('X-WP-Nonce', window.wpApiSettings.nonce);
+      },
+    };
+    if (data) {
+      options.data = type === 'GET' ? data : JSON.stringify(data);
+    }
+    return jQuery.ajax(options);
+  }
+
+  window.API = {
+    plugin_install: (download_url) =>
+      makeRequest(
+        'POST',
+        `plugin-install`,
+        {
+          download_url: download_url,
+        },
+        `dt-admin-settings/`,
+      ),
+
+    plugin_delete: (plugin_slug) =>
+      makeRequest(
+        'POST',
+        `plugin-delete`,
+        {
+          plugin_slug: plugin_slug,
+        },
+        `dt-admin-settings/`,
+      ),
+
+    plugin_activate: (plugin_slug) =>
+      makeRequest(
+        'POST',
+        `plugin-activate`,
+        {
+          plugin_slug: plugin_slug,
+        },
+        `dt-admin-settings/`,
+      ),
+
+    plugin_deactivate: (plugin_slug) =>
+      makeRequest(
+        'POST',
+        `plugin-deactivate`,
+        {
+          plugin_slug: plugin_slug,
+        },
+        `dt-admin-settings/`,
+      ),
+  };
+
+  function get_plugin_download_url(plugin_slug) {
+    const all_plugins = window.plugins.all_plugins;
+    var download_url = false;
+    $.each(all_plugins, function (index, plugin) {
+      if (plugin.slug === plugin_slug) {
+        download_url = plugin.download_url;
+      }
+    });
+    return download_url;
+  }
+
+  function plugin_install(plugin_slug) {
+    var download_url = get_plugin_download_url(plugin_slug);
+    window.API.plugin_install(download_url)
+      .promise()
+      .then(function (response) {
+        if (!response) {
+          display_error_message(plugin_slug);
+          return;
         }
-        return jQuery.ajax(options);
-    }
-
-    window.API = {
-        plugin_install: (download_url) => makeRequest("POST", `plugin-install`, {
-                download_url: download_url
-            }, `dt-admin-settings/`),
-
-        plugin_delete: (plugin_slug) => makeRequest("POST", `plugin-delete`, {
-            plugin_slug: plugin_slug
-        }, `dt-admin-settings/`),
-
-        plugin_activate: (plugin_slug) => makeRequest("POST", `plugin-activate`, {
-                plugin_slug: plugin_slug
-            }, `dt-admin-settings/`),
-
-        plugin_deactivate: (plugin_slug) => makeRequest("POST", `plugin-deactivate`, {
-                plugin_slug: plugin_slug
-            }, `dt-admin-settings/`),
-    }
-
-    function get_plugin_download_url(plugin_slug) {
-        const all_plugins = window.plugins.all_plugins;
-        var download_url = false;
-        $.each(all_plugins, function(index, plugin) {
-            if (plugin.slug === plugin_slug) {
-                download_url = plugin.download_url;
-            }
-        });
-        return download_url;
-    }
-
-    function plugin_install(plugin_slug) {
-        var download_url = get_plugin_download_url(plugin_slug);
-        window.API.plugin_install(download_url).promise()
-        .then(function(response) {
-            if ( !response ) {
-                display_error_message(plugin_slug);
-                return;
-            }
-            $(`.plugin-card[data-slug="${plugin_slug}"] > .card-front > .action-links > .plugin-action-buttons`).html(`
+        $(
+          `.plugin-card[data-slug="${plugin_slug}"] > .card-front > .action-links > .plugin-action-buttons`,
+        ).html(`
             <li>
                 <button class="button" data-action="activate" data-plugin-slug="${plugin_slug}">Activate</button>
             </li>
             <li>
                 <button class="button" data-action="delete" data-plugin-slug="${plugin_slug}">Delete</button>
             </li>`);
-            $(`.plugin-card[data-slug="${plugin_slug}"]`).removeClass('flip-card');
-        });
-        return;
-    }
+        $(`.plugin-card[data-slug="${plugin_slug}"]`).removeClass('flip-card');
+      });
+    return;
+  }
 
-    function plugin_delete(plugin_slug) {
-        window.API.plugin_delete(plugin_slug).promise()
-        .then(function(response) {
-            if ( !response ) {
-                display_error_message(plugin_slug);
-                return;
-            }
-            $(`.plugin-card[data-slug="${plugin_slug}"] > .card-front > .action-links > .plugin-action-buttons`).html(`
+  function plugin_delete(plugin_slug) {
+    window.API.plugin_delete(plugin_slug)
+      .promise()
+      .then(function (response) {
+        if (!response) {
+          display_error_message(plugin_slug);
+          return;
+        }
+        $(
+          `.plugin-card[data-slug="${plugin_slug}"] > .card-front > .action-links > .plugin-action-buttons`,
+        ).html(`
             <li>
                 <button class="button" data-action="install" data-plugin-slug="${plugin_slug}">Install</button>
             </li>`);
-            $(`.plugin-card[data-slug="${plugin_slug}"]`).removeClass('flip-card');
-        });
-        return;
-    }
+        $(`.plugin-card[data-slug="${plugin_slug}"]`).removeClass('flip-card');
+      });
+    return;
+  }
 
-    function plugin_activate(plugin_slug) {
-        window.API.plugin_activate(plugin_slug).promise()
-        .then(function(response) {
-            if ( !response ) {
-                display_error_message(plugin_slug);
-                return;
-            }
-            $(`.plugin-card[data-slug="${plugin_slug}"] > .card-front > .action-links > .plugin-action-buttons`).html(`
+  function plugin_activate(plugin_slug) {
+    window.API.plugin_activate(plugin_slug)
+      .promise()
+      .then(function (response) {
+        if (!response) {
+          display_error_message(plugin_slug);
+          return;
+        }
+        $(
+          `.plugin-card[data-slug="${plugin_slug}"] > .card-front > .action-links > .plugin-action-buttons`,
+        ).html(`
             <li>
                 <button class="button" data-action="deactivate" data-plugin-slug="${plugin_slug}">Deactivate</button>
             </li>`);
-            $(`.plugin-card[data-slug="${plugin_slug}"]`).removeClass('flip-card');
-        });
-        return;
-    }
-    function plugin_deactivate(plugin_slug) {
-        let can_install_plugins = window.plugins.can_install_plugins;
-        window.API.plugin_deactivate(plugin_slug).promise()
-        .then(function(response) {
-            if ( !response ) {
-                display_error_message(plugin_slug);
-                return;
-            }
-            $(`.plugin-card[data-slug="${plugin_slug}"] > .card-front > .action-links > .plugin-action-buttons`).html(`
+        $(`.plugin-card[data-slug="${plugin_slug}"]`).removeClass('flip-card');
+      });
+    return;
+  }
+  function plugin_deactivate(plugin_slug) {
+    let can_install_plugins = window.plugins.can_install_plugins;
+    window.API.plugin_deactivate(plugin_slug)
+      .promise()
+      .then(function (response) {
+        if (!response) {
+          display_error_message(plugin_slug);
+          return;
+        }
+        $(
+          `.plugin-card[data-slug="${plugin_slug}"] > .card-front > .action-links > .plugin-action-buttons`,
+        ).html(`
             <li>
                 <button class="button" data-action="activate" data-plugin-slug="${plugin_slug}">Activate</button>
             </li>`);
-            if ( can_install_plugins ) {
-                $(`.plugin-card[data-slug="${plugin_slug}"] > .card-front > .action-links > .plugin-action-buttons`).append(`
+        if (can_install_plugins) {
+          $(
+            `.plugin-card[data-slug="${plugin_slug}"] > .card-front > .action-links > .plugin-action-buttons`,
+          ).append(`
                 <li>
                 <button class="button" data-action="delete" data-plugin-slug="${plugin_slug}">Delete</button>
                 </li>`);
-            }
-            $(`.plugin-card[data-slug="${plugin_slug}"]`).removeClass('flip-card');
-        });
-        return;
-    }
-
-    function display_error_message(plugin_slug) {
-        var card_back = $(`.plugin-card[data-slug="${plugin_slug}"] > .card-back > .plugin-card-content-back`);
-        var error_message = window.plugins.translations['something_went_wrong'];
-        card_back.html(`<div class="error_message">${error_message}</div>`);
-        return;
-    }
-
-    $.typeahead({
-        input: '.js-typeahead-extensions',
-        minLength: 3,
-        order: "desc",
-        cancelButton: false,
-        dynamic: false,
-        emptyTemplate: '{{query}}',
-        template: '{{name}}',
-        correlativeTemplate: true,
-        source: window.plugins.all_plugins,
-        callback: {
-            onCancel: function() {
-                $('#no-typeahead-results').hide();
-                $('.plugin-card').fadeIn();
-                $('.plugin-install > a[data-category="all-plugins"]').addClass('current');
-
-            },
-            onResult: function(i, query, matches) {
-                if (query.length < 3) {
-                    return matches;
-                }
-                $('.plugin-card').hide();
-                $('.current').removeClass('current');
-                $('#no-typeahead-results').hide();
-                if (matches.length == 0) {
-                    $('#no-typeahead-results').fadeIn(100);
-                    return;
-                } else {
-                    $.each(matches, function(match_index,plugin) {
-                        $('#no-typeahead-results').hide();
-                        $('#the-list').prepend($(`.plugin-card[data-slug="${plugin.slug}"]`));
-                        $(`.plugin-card[data-slug="${plugin.slug}"]`).fadeIn();
-                    });
-                }
-                return;
-            },
         }
-    })
+        $(`.plugin-card[data-slug="${plugin_slug}"]`).removeClass('flip-card');
+      });
+    return;
+  }
 
-    $('.plugin-install > a[data-category="featured"]').addClass('current');
+  function display_error_message(plugin_slug) {
+    var card_back = $(
+      `.plugin-card[data-slug="${plugin_slug}"] > .card-back > .plugin-card-content-back`,
+    );
+    var error_message = window.plugins.translations['something_went_wrong'];
+    card_back.html(`<div class="error_message">${error_message}</div>`);
+    return;
+  }
+
+  $.typeahead({
+    input: '.js-typeahead-extensions',
+    minLength: 3,
+    order: 'desc',
+    cancelButton: false,
+    dynamic: false,
+    emptyTemplate: '{{query}}',
+    template: '{{name}}',
+    correlativeTemplate: true,
+    source: window.plugins.all_plugins,
+    callback: {
+      onCancel: function () {
+        $('#no-typeahead-results').hide();
+        $('.plugin-card').fadeIn();
+        $('.plugin-install > a[data-category="all-plugins"]').addClass(
+          'current',
+        );
+      },
+      onResult: function (i, query, matches) {
+        if (query.length < 3) {
+          return matches;
+        }
+        $('.plugin-card').hide();
+        $('.current').removeClass('current');
+        $('#no-typeahead-results').hide();
+        if (matches.length == 0) {
+          $('#no-typeahead-results').fadeIn(100);
+          return;
+        } else {
+          $.each(matches, function (match_index, plugin) {
+            $('#no-typeahead-results').hide();
+            $('#the-list').prepend(
+              $(`.plugin-card[data-slug="${plugin.slug}"]`),
+            );
+            $(`.plugin-card[data-slug="${plugin.slug}"]`).fadeIn();
+          });
+        }
+        return;
+      },
+    },
+  });
+
+  $('.plugin-install > a[data-category="featured"]').addClass('current');
 });

--- a/dt-core/admin/js/dt-options.js
+++ b/dt-core/admin/js/dt-options.js
@@ -1,7 +1,11 @@
 jQuery(document).ready(function ($) {
   $('.expand_translations').click(function (e) {
     e.preventDefault();
-    display_translation_dialog($(this).siblings(), $(this).data('form_name'), $(this).data('source'));
+    display_translation_dialog(
+      $(this).siblings(),
+      $(this).data('form_name'),
+      $(this).data('source'),
+    );
   });
 
   $('.change-icon-button').click(function (e) {
@@ -9,7 +13,9 @@ jQuery(document).ready(function ($) {
 
     // Fetch handle to key workflow elements
     let parent_form = $("form[name='" + $(e.currentTarget).data('form') + "']");
-    let icon_input = $("input[name='" + $(e.currentTarget).data('icon-input') + "']");
+    let icon_input = $(
+      "input[name='" + $(e.currentTarget).data('icon-input') + "']",
+    );
 
     // Display icon selector dialog
     display_icon_selector_dialog(parent_form, icon_input);
@@ -17,11 +23,12 @@ jQuery(document).ready(function ($) {
 
   // Support DT customization icon picker requests.
   $('.dt-admin-modal-box').on('click', '.change-icon-button', function (e) {
-    let icon_input = $("input[name='" + $(e.currentTarget).data('icon-input') + "']");
+    let icon_input = $(
+      "input[name='" + $(e.currentTarget).data('icon-input') + "']",
+    );
     let dialog = $('#dt_icon_selector_dialog');
 
     if (dialog) {
-
       dialog.dialog({
         modal: false,
         autoOpen: false,
@@ -37,27 +44,24 @@ jQuery(document).ready(function ($) {
             icon: 'ui-icon-close',
             click: function () {
               $(this).dialog('close');
-            }
+            },
           },
           {
             text: 'Save',
             icon: 'ui-icon-copy',
-            click: function () {
-            }
+            click: function () {},
           },
           {
             text: 'Upload Custom Icon',
             icon: 'ui-icon-circle-zoomout',
-            click: function () {
-            }
-          }
+            click: function () {},
+          },
         ],
         open: function (event, ui) {
           let ui_dialog = $(document).find('.ui-dialog')[0];
 
           // Fetch and set font icon picker dialog contents.
           if (ui_dialog) {
-
             let cloned = $(ui_dialog).clone();
             let html = `
               <table>
@@ -88,8 +92,9 @@ jQuery(document).ready(function ($) {
             content.html(html);
             content.find('button.ui-dialog-titlebar-close').hide();
             content.find('span.ui-dialog-title').css('font-weight', 'bold');
-            content.find('button.ui-button').data('icon-input', icon_input.attr('name'));
-
+            content
+              .find('button.ui-button')
+              .data('icon-input', icon_input.attr('name'));
           }
 
           // Force an immediate close, to draw attention to flipped content!
@@ -98,29 +103,27 @@ jQuery(document).ready(function ($) {
           // Display some initial icons
           execute_icon_selection_filter_query(false);
         },
-        close: function (event, ui) {
-        }
+        close: function (event, ui) {},
       });
 
       // Insert selection area div, within dialog button footer
       let ui_dialog_buttonset = $('.ui-dialog-buttonset');
       ui_dialog_buttonset.css('margin', '1.5em');
-      ui_dialog_buttonset.prepend($('<span>')
-        .attr('id', 'dialog_icon_selector_icon_selection_div')
-        .css('display', 'inline-block')
-        .css('vertical-align', 'middle')
-        .css('padding', '0')
-        .css('margin-right', '175px')
+      ui_dialog_buttonset.prepend(
+        $('<span>')
+          .attr('id', 'dialog_icon_selector_icon_selection_div')
+          .css('display', 'inline-block')
+          .css('vertical-align', 'middle')
+          .css('padding', '0')
+          .css('margin-right', '175px'),
       );
 
       // Display updated dialog
       dialog.dialog('open');
-
     }
   });
 
   $('.dt-admin-modal-box').on('click', '.ui-button', function (e) {
-
     // Determine action to be taken.
     let button = $(e.currentTarget);
     let icon_input = $("input[name='" + $(button).data('icon-input') + "']");
@@ -130,37 +133,41 @@ jQuery(document).ready(function ($) {
 
     if (close_button && close_button.length > 0) {
       $('.dt-admin-modal-icon-picker-box-close-button').click();
-
     } else if (save_button && save_button.length > 0) {
       handle_icon_save(null, null, icon_input, function (source) {
-
         // Refresh icon image accordingly, to capture any changes.
-        let icon_img_wrapper = $(icon_input).parent().find('.field-icon-wrapper');
+        let icon_img_wrapper = $(icon_input)
+          .parent()
+          .find('.field-icon-wrapper');
         if (icon_img_wrapper) {
           let icon = $(icon_input).val();
-          $(icon_img_wrapper).html((icon && icon.trim().toLowerCase().startsWith('mdi') ? `<i class="${icon} field-icon" style="font-size: 30px; vertical-align: middle;"></i>`:`<img src="${icon}" class="field-icon" style="vertical-align: middle;">`));
+          $(icon_img_wrapper).html(
+            icon && icon.trim().toLowerCase().startsWith('mdi')
+              ? `<i class="${icon} field-icon" style="font-size: 30px; vertical-align: middle;"></i>`
+              : `<img src="${icon}" class="field-icon" style="vertical-align: middle;">`,
+          );
         }
 
         $('.dt-admin-modal-icon-picker-box-close-button').click();
-
       });
-
     } else if (upload_button && upload_button.length > 0) {
       handle_icon_upload(null, null, icon_input, function (source) {
-
         // Refresh icon image accordingly, to capture any changes.
-        let icon_img_wrapper = $(icon_input).parent().find('.field-icon-wrapper');
+        let icon_img_wrapper = $(icon_input)
+          .parent()
+          .find('.field-icon-wrapper');
         if (icon_img_wrapper) {
           let icon = $(icon_input).val();
-          $(icon_img_wrapper).html((icon && icon.trim().toLowerCase().startsWith('mdi') ? `<i class="${icon} field-icon" style="font-size: 30px; vertical-align: middle;"></i>`:`<img src="${icon}" class="field-icon" style="vertical-align: middle;">`));
+          $(icon_img_wrapper).html(
+            icon && icon.trim().toLowerCase().startsWith('mdi')
+              ? `<i class="${icon} field-icon" style="font-size: 30px; vertical-align: middle;"></i>`
+              : `<img src="${icon}" class="field-icon" style="vertical-align: middle;">`,
+          );
         }
 
         $('.dt-admin-modal-icon-picker-box-close-button').click();
-
       });
-
     }
-
   });
 
   /**
@@ -168,13 +175,10 @@ jQuery(document).ready(function ($) {
    */
 
   $(document).on('keyup', '#dialog_icon_selector_filter_input', function (e) {
-    let code = (e.keyCode || e.which);
+    let code = e.keyCode || e.which;
 
     // Only get excited over specific key codes.
-    if ((code===8) ||
-      (code===13) ||
-      ((code >= 48) && (code <= 90))) {
-
+    if (code === 8 || code === 13 || (code >= 48 && code <= 90)) {
       execute_icon_selection_filter_query();
     }
   });
@@ -193,9 +197,10 @@ jQuery(document).ready(function ($) {
   function display_translation_dialog(container, form_name, source = '') {
     let dialog = $('#dt_translation_dialog');
     if (container && form_name && dialog) {
-
       // Update dialog div
-      $(dialog).empty().append($($(container).find('table')[0]).clone());
+      $(dialog)
+        .empty()
+        .append($($(container).find('table')[0]).clone());
 
       // Refresh dialog config
       dialog.dialog({
@@ -209,7 +214,6 @@ jQuery(document).ready(function ($) {
         title: 'Translation Dialog',
         buttons: {
           Update: function () {
-
             // Update source translation container
             $(container).empty().append($(this).children());
 
@@ -218,20 +222,24 @@ jQuery(document).ready(function ($) {
 
             // Finally, auto save changes, accordingly, based on source.
             if (window.lodash.includes(['fields'], source)) {
-              handle_custom_field_save_request(null, $('.dt-custom-fields-save-button')[0], true);
+              handle_custom_field_save_request(
+                null,
+                $('.dt-custom-fields-save-button')[0],
+                true,
+              );
             } else {
               $('form[name="' + form_name + '"]').submit();
             }
-
-          }
-        }
+          },
+        },
       });
 
       // Display updated dialog
       dialog.dialog('open');
-
     } else {
-      console.log('Unable to reference a valid: [container, form-name, dialog]');
+      console.log(
+        'Unable to reference a valid: [container, form-name, dialog]',
+      );
     }
   }
 
@@ -239,11 +247,13 @@ jQuery(document).ready(function ($) {
    * Icon selector modal dialog
    */
 
-  function display_icon_selector_dialog(parent_form, icon_input, callback = function (source) {
-  }) {
+  function display_icon_selector_dialog(
+    parent_form,
+    icon_input,
+    callback = function (source) {},
+  ) {
     let dialog = $('#dt_icon_selector_dialog');
     if (dialog) {
-
       // Refresh dialog config
       dialog.dialog({
         modal: true,
@@ -261,45 +271,44 @@ jQuery(document).ready(function ($) {
             click: function () {
               $(this).dialog('close');
               callback('cancel');
-            }
+            },
           },
           {
             text: 'Save',
             icon: 'ui-icon-copy',
             click: function () {
               handle_icon_save(this, parent_form, icon_input, callback);
-            }
+            },
           },
           {
             text: 'Upload Custom Icon',
             icon: 'ui-icon-circle-zoomout',
             click: function () {
               handle_icon_upload(this, parent_form, icon_input, callback);
-            }
-          }
+            },
+          },
         ],
         open: function (event, ui) {
-
           // Display some initial icons
           execute_icon_selection_filter_query();
         },
         close: function (event, ui) {
           callback('dialogclose');
-        }
+        },
       });
 
       // Insert selection area div, within dialog button footer
-      $('.ui-dialog-buttonset').prepend($('<span>')
-        .attr('id', 'dialog_icon_selector_icon_selection_div')
-        .css('display', 'inline-block')
-        .css('vertical-align', 'middle')
-        .css('padding', '0')
-        .css('margin-right', '175px')
+      $('.ui-dialog-buttonset').prepend(
+        $('<span>')
+          .attr('id', 'dialog_icon_selector_icon_selection_div')
+          .css('display', 'inline-block')
+          .css('vertical-align', 'middle')
+          .css('padding', '0')
+          .css('margin-right', '175px'),
       );
 
       // Display updated dialog
       dialog.dialog('open');
-
     } else {
       console.log('Unable to reference a valid: [dialog]');
     }
@@ -312,11 +321,19 @@ jQuery(document).ready(function ($) {
   function build_icon_class_name_list() {
     let icon_class_names = [];
     $.each(document.styleSheets, function (idx, style_sheet) {
-      if (window.lodash.includes(style_sheet.href, 'dt-core/dependencies/mdi/css/materialdesignicons.min.css')) {
+      if (
+        window.lodash.includes(
+          style_sheet.href,
+          'dt-core/dependencies/mdi/css/materialdesignicons.min.css',
+        )
+      ) {
         $.each(style_sheet.cssRules, function (key, rule) {
           if (rule.constructor.name === 'CSSStyleRule') {
             icon_class_names.push({
-              class: rule.selectorText.substring(1, rule.selectorText.indexOf(':'))
+              class: rule.selectorText.substring(
+                1,
+                rule.selectorText.indexOf(':'),
+              ),
             });
           }
         });
@@ -347,7 +364,6 @@ jQuery(document).ready(function ($) {
    */
 
   function execute_icon_selection_filter_query(enable_tooltips = true) {
-
     // Always default to a somewhat wildcard search if input text is blank
     let query = $('#dialog_icon_selector_filter_input').val().trim();
     query = window.lodash.isEmpty(query) ? 'a' : query;
@@ -355,60 +371,75 @@ jQuery(document).ready(function ($) {
     // Proceed with icon display refresh
     $('#dialog_icon_selector_icons_div').fadeOut('fast', function () {
       $('#dialog_icon_selector_icons_search_msg').text('').fadeOut('fast');
-      $('#dialog_icon_selector_icons_search_spinner').addClass('active').fadeIn('fast', function () {
+      $('#dialog_icon_selector_icons_search_spinner')
+        .addClass('active')
+        .fadeIn('fast', function () {
+          // Clear currently displayed icons
+          $('#dialog_icon_selector_icons_table > tbody > tr').remove();
 
-        // Clear currently displayed icons
-        $('#dialog_icon_selector_icons_table > tbody > tr').remove();
-
-        // Obtain filtered icon list
-        let filtered_icons = window.lodash.filter(icons, function (icon) {
-          return icon['class'] && window.lodash.includes(icon['class'], query);
-        });
-
-        // Truncate filtered list for performance purposes
-        filtered_icons = filtered_icons.slice(0, 200);
-
-        // Populate icons table
-        let loop_counter = 0;
-        let icon_counter = 0;
-        let tds = '';
-
-        $.each(filtered_icons, function (idx, filtered_icon) {
-          loop_counter++;
-
-          let icon_class_name = filtered_icon['class'];
-          if (icon_class_name && is_icon_valid(icon_class_name)) {
-            tds += '<td><i title="' + icon_class_name + '" class="dialog-icon-selector-icon mdi ' + icon_class_name + '" data-icon_class="' + icon_class_name + '"></i></td>'
-
-            if ((++icon_counter > 5) || (loop_counter >= filtered_icons.length)) {
-              $('#dialog_icon_selector_icons_table > tbody').append('<tr>' + tds + '</tr>');
-              icon_counter = 0;
-              tds = '';
-            }
-          }
-        });
-
-        // If requested, activate icon tooltips
-        if (enable_tooltips) {
-          $('#dialog_icon_selector_icons_table > tbody').find('.mdi').each(function (idx, icon) {
-            $(icon).tooltip({
-              show: {effect: 'fade', duration: 100}
-            });
+          // Obtain filtered icon list
+          let filtered_icons = window.lodash.filter(icons, function (icon) {
+            return (
+              icon['class'] && window.lodash.includes(icon['class'], query)
+            );
           });
-        }
 
-        $('#dialog_icon_selector_icons_search_spinner').removeClass('active').fadeOut('fast', function () {
+          // Truncate filtered list for performance purposes
+          filtered_icons = filtered_icons.slice(0, 200);
 
-          // Display results or no icons found message
-          if (filtered_icons.length > 0) {
-            $('#dialog_icon_selector_icons_div').fadeIn('fast');
+          // Populate icons table
+          let loop_counter = 0;
+          let icon_counter = 0;
+          let tds = '';
 
-          } else {
-            $('#dialog_icon_selector_icons_search_msg').text('No Icons Found').fadeIn('fast');
+          $.each(filtered_icons, function (idx, filtered_icon) {
+            loop_counter++;
+
+            let icon_class_name = filtered_icon['class'];
+            if (icon_class_name && is_icon_valid(icon_class_name)) {
+              tds +=
+                '<td><i title="' +
+                icon_class_name +
+                '" class="dialog-icon-selector-icon mdi ' +
+                icon_class_name +
+                '" data-icon_class="' +
+                icon_class_name +
+                '"></i></td>';
+
+              if (++icon_counter > 5 || loop_counter >= filtered_icons.length) {
+                $('#dialog_icon_selector_icons_table > tbody').append(
+                  '<tr>' + tds + '</tr>',
+                );
+                icon_counter = 0;
+                tds = '';
+              }
+            }
+          });
+
+          // If requested, activate icon tooltips
+          if (enable_tooltips) {
+            $('#dialog_icon_selector_icons_table > tbody')
+              .find('.mdi')
+              .each(function (idx, icon) {
+                $(icon).tooltip({
+                  show: { effect: 'fade', duration: 100 },
+                });
+              });
           }
 
+          $('#dialog_icon_selector_icons_search_spinner')
+            .removeClass('active')
+            .fadeOut('fast', function () {
+              // Display results or no icons found message
+              if (filtered_icons.length > 0) {
+                $('#dialog_icon_selector_icons_div').fadeIn('fast');
+              } else {
+                $('#dialog_icon_selector_icons_search_msg')
+                  .text('No Icons Found')
+                  .fadeIn('fast');
+              }
+            });
         });
-      });
     });
   }
 
@@ -417,7 +448,6 @@ jQuery(document).ready(function ($) {
    */
 
   function is_icon_valid(icon_class_name) {
-
     // Firstly, empty sandbox...
     $('#dialog_icon_selector_icons_sandbox_div').empty();
 
@@ -427,7 +457,8 @@ jQuery(document).ready(function ($) {
       .appendTo('#dialog_icon_selector_icons_sandbox_div');
 
     // Determine icon validity
-    let valid = window.getComputedStyle(icon[0], ':before')['content'] !== 'none';
+    let valid =
+      window.getComputedStyle(icon[0], ':before')['content'] !== 'none';
 
     // Clear down sandbox and return findings
     $('#dialog_icon_selector_icons_sandbox_div').empty();
@@ -441,26 +472,26 @@ jQuery(document).ready(function ($) {
 
   function handle_icon_selection(icon) {
     if (icon) {
-
       // Create a clone element, to be assigned to dialog footer
       let cloned_icon = $(icon).clone(true);
 
       // Using some fancy transitions, assign new cloned selection
-      $('#dialog_icon_selector_icon_selection_div').fadeOut('fast', function () {
+      $('#dialog_icon_selector_icon_selection_div').fadeOut(
+        'fast',
+        function () {
+          // Clear out previous selections
+          $('#dialog_icon_selector_icon_selection_div').empty();
 
-        // Clear out previous selections
-        $('#dialog_icon_selector_icon_selection_div').empty();
+          // Make use of selection css class
+          $(cloned_icon).removeClass('dialog-icon-selector-icon');
+          $(cloned_icon).addClass('dialog-icon-selector-icon-selected');
+          $(cloned_icon).attr('title', $(icon).data('icon_class'));
 
-        // Make use of selection css class
-        $(cloned_icon).removeClass('dialog-icon-selector-icon');
-        $(cloned_icon).addClass('dialog-icon-selector-icon-selected');
-        $(cloned_icon).attr('title', $(icon).data('icon_class'));
-
-        // Append and display selection
-        $('#dialog_icon_selector_icon_selection_div').append($(cloned_icon));
-        $('#dialog_icon_selector_icon_selection_div').fadeIn('fast');
-
-      });
+          // Append and display selection
+          $('#dialog_icon_selector_icon_selection_div').append($(cloned_icon));
+          $('#dialog_icon_selector_icon_selection_div').fadeIn('fast');
+        },
+      );
     }
   }
 
@@ -468,13 +499,17 @@ jQuery(document).ready(function ($) {
    * Icon selector modal dialog - Handle Icon Save
    */
 
-  function handle_icon_save(dialog, parent_form, icon_input, callback = function (source) {
-  }) {
-
+  function handle_icon_save(
+    dialog,
+    parent_form,
+    icon_input,
+    callback = function (source) {},
+  ) {
     // Determine if there is a valid selection
-    let selected_icon = $('#dialog_icon_selector_icon_selection_div').find('.dialog-icon-selector-icon-selected');
+    let selected_icon = $('#dialog_icon_selector_icon_selection_div').find(
+      '.dialog-icon-selector-icon-selected',
+    );
     if ($(selected_icon).length) {
-
       // Update form icon class input
       icon_input.val('mdi ' + $(selected_icon).data('icon_class'));
 
@@ -497,18 +532,22 @@ jQuery(document).ready(function ($) {
    * Icon selector modal dialog - Handle Icon Uploads
    */
 
-  function handle_icon_upload(dialog, parent_form, icon_input, callback = function (source) {
-  }) {
-
+  function handle_icon_upload(
+    dialog,
+    parent_form,
+    icon_input,
+    callback = function (source) {},
+  ) {
     // Build media uploader modal
     let mediaFrame = window.wp.media({
-
       // Accepts [ 'select', 'post', 'image', 'audio', 'video' ]
       // Determines what kind of library should be rendered.
       frame: 'select',
 
       // Modal title.
-      title: window.dt_admin_shared.escape(window.dt_admin_scripts.upload.title),
+      title: window.dt_admin_shared.escape(
+        window.dt_admin_scripts.upload.title,
+      ),
 
       // Enable/disable multiple select
       multiple: false,
@@ -527,18 +566,18 @@ jQuery(document).ready(function ($) {
         search: null,
 
         // Includes media only uploaded to the specified post (ID)
-        uploadedTo: null // wp.media.view.settings.post.id (for current post ID)
+        uploadedTo: null, // wp.media.view.settings.post.id (for current post ID)
       },
 
       button: {
-        text: window.dt_admin_shared.escape(window.dt_admin_scripts.upload.button_txt)
-      }
-
+        text: window.dt_admin_shared.escape(
+          window.dt_admin_scripts.upload.button_txt,
+        ),
+      },
     });
 
     // Handle selected files
     mediaFrame.on('select', function () {
-
       // Fetch and convert selected into json object
       let selected = mediaFrame.state().get('selection').first().toJSON();
 
@@ -557,7 +596,6 @@ jQuery(document).ready(function ($) {
 
       // Execute callback with relevant source flag.
       callback('upload');
-
     });
 
     // Open the media uploader.
@@ -567,100 +605,110 @@ jQuery(document).ready(function ($) {
   /**
    * Sorting code for tiles
    */
-  $( ".connectedSortable" ).sortable({
-    connectWith: ".connectedSortable",
-    placeholder: "ui-state-highlight"
-  }).disableSelection();
+  $('.connectedSortable')
+    .sortable({
+      connectWith: '.connectedSortable',
+      placeholder: 'ui-state-highlight',
+    })
+    .disableSelection();
 
-  $( "#sort-tiles" ).sortable({
-    items: "div.sort-tile:not(.disabled-drag)",
-    placeholder: "ui-state-highlight",
-    cancel: ".connectedSortable",
-  }).disableSelection();
+  $('#sort-tiles')
+    .sortable({
+      items: 'div.sort-tile:not(.disabled-drag)',
+      placeholder: 'ui-state-highlight',
+      cancel: '.connectedSortable',
+    })
+    .disableSelection();
 
-  $(".save-drag-changes").on( "click", function (){
+  $('.save-drag-changes').on('click', function () {
     let order = [];
-    $(".sort-tile").each((a, b)=>{
-      let tile_key = $(b).attr("id")
+    $('.sort-tile').each((a, b) => {
+      let tile_key = $(b).attr('id');
       let tile = {
         key: tile_key,
-        fields: []
-      }
-      $(`#${tile_key} .connectedSortable li`).each((field_index, field)=>{
-        tile.fields.push($(field).attr('id'))
-      })
-      order.push(tile)
-    })
-    let input = $("<input>")
-               .attr("type", "hidden")
-               .attr("name", "order").val(JSON.stringify(order));
+        fields: [],
+      };
+      $(`#${tile_key} .connectedSortable li`).each((field_index, field) => {
+        tile.fields.push($(field).attr('id'));
+      });
+      order.push(tile);
+    });
+    let input = $('<input>')
+      .attr('type', 'hidden')
+      .attr('name', 'order')
+      .val(JSON.stringify(order));
     $('#tile-order-form').append(input).submit();
-
-  })
-
+  });
 
   /**
    * new fields
    */
   //show more fields when connection option selected
 
-  $('#new_field_type_select').on('change', function (){
-    if ( this.value === "connection" ){
-      $('.connection_field_target_row').show()
-      $('#private_field_row').hide()
+  $('#new_field_type_select').on('change', function () {
+    if (this.value === 'connection') {
+      $('.connection_field_target_row').show();
+      $('#private_field_row').hide();
       $('#connection_field_target').prop('required', true);
     } else {
-      $('.connection_field_reverse_row').hide()
-      $('.connection_field_target_row').hide()
-      $('#private_field_row').show()
+      $('.connection_field_reverse_row').hide();
+      $('.connection_field_target_row').hide();
+      $('#private_field_row').show();
       $('#connection_field_target').prop('required', false);
     }
-  })
+  });
 
   //show the reverse connection field name row if the post type is not "self"
-  $('#connection_field_target').on("change", function (){
-    let post_type_label = $( "#connection_field_target option:selected" ).text();
-    $('.connected_post_type').html(post_type_label)
-    if ( this.value === $('#current_post_type').val()){
-      $('.same_post_type_other_field_name').toggle(!$('#multidirectional_checkbox').is(':checked'))
-      $('.connection_field_reverse_row').hide()
-      $('.same_post_type_row').show()
+  $('#connection_field_target').on('change', function () {
+    let post_type_label = $('#connection_field_target option:selected').text();
+    $('.connected_post_type').html(post_type_label);
+    if (this.value === $('#current_post_type').val()) {
+      $('.same_post_type_other_field_name').toggle(
+        !$('#multidirectional_checkbox').is(':checked'),
+      );
+      $('.connection_field_reverse_row').hide();
+      $('.same_post_type_row').show();
     } else {
-      $('.same_post_type_other_field_name').hide()
-      $('.connection_field_reverse_row').show()
-      $('.same_post_type_row').hide()
+      $('.same_post_type_other_field_name').hide();
+      $('.connection_field_reverse_row').show();
+      $('.same_post_type_row').hide();
     }
-  })
+  });
 
-
-  $('#multidirectional_checkbox').on("change", function (){
-    $('.same_post_type_other_field_name').toggle(!this.checked)
-  })
+  $('#multidirectional_checkbox').on('change', function () {
+    $('.same_post_type_other_field_name').toggle(!this.checked);
+  });
 
   /**
    * Sorting code for field options
    */
 
-  $('.sortable-field-options').sortable({
-    connectWith: '.sortable-field-options',
-    placeholder: 'ui-state-highlight',
-    update: function (evt, ui) {
+  $('.sortable-field-options')
+    .sortable({
+      connectWith: '.sortable-field-options',
+      placeholder: 'ui-state-highlight',
+      update: function (evt, ui) {
+        let updated_field_options_ordering = [];
 
-      let updated_field_options_ordering = [];
+        // Snapshot updated field options ordering by key.
+        $('.sortable-field-options')
+          .find('.sortable-field-options-key')
+          .each(function (idx, key_div) {
+            let key = $(key_div).text().trim();
+            if (key) {
+              updated_field_options_ordering.push(
+                encode_field_key_special_characters(key),
+              );
+            }
+          });
 
-      // Snapshot updated field options ordering by key.
-      $('.sortable-field-options').find('.sortable-field-options-key').each(function (idx, key_div) {
-        let key = $(key_div).text().trim();
-        if (key) {
-          updated_field_options_ordering.push(encode_field_key_special_characters(key));
-        }
-      });
-
-      // Persist updated field options ordering.
-      $('#sortable_field_options_ordering').val(JSON.stringify(updated_field_options_ordering));
-
-    }
-  }).disableSelection();
+        // Persist updated field options ordering.
+        $('#sortable_field_options_ordering').val(
+          JSON.stringify(updated_field_options_ordering),
+        );
+      },
+    })
+    .disableSelection();
 
   function encode_field_key_special_characters(key) {
     key = window.lodash.replace(key, '<', '_less_than_');
@@ -673,14 +721,21 @@ jQuery(document).ready(function ($) {
    * Tile Display Conditions - [START]
    */
 
-  $(document).on('click', 'input:radio[name="tile_display_option"]', function (e) {
-    handle_tile_display_condition_selection($(e.currentTarget));
-  });
+  $(document).on(
+    'click',
+    'input:radio[name="tile_display_option"]',
+    function (e) {
+      handle_tile_display_condition_selection($(e.currentTarget));
+    },
+  );
 
   function handle_tile_display_condition_selection(display_condition) {
-    let show_custom = display_condition && $(display_condition).val() == 'custom';
+    let show_custom =
+      display_condition && $(display_condition).val() == 'custom';
     let custom_elements = $('#tile_display_custom_elements');
-    show_custom ? $(custom_elements).slideDown('slow') : $(custom_elements).slideUp('slow');
+    show_custom
+      ? $(custom_elements).slideDown('slow')
+      : $(custom_elements).slideUp('slow');
   }
 
   /**
@@ -698,7 +753,6 @@ jQuery(document).ready(function ($) {
   function handle_tile_display_help_modal(help_button) {
     let dialog = $('#' + $(help_button).data('dialog_id'));
     if (dialog) {
-
       // Refresh help dialog config
       dialog.dialog({
         modal: true,
@@ -715,16 +769,14 @@ jQuery(document).ready(function ($) {
             icon: 'ui-icon-check',
             click: function () {
               $(this).dialog('close');
-            }
-          }
+            },
+          },
         ],
-        open: function (event, ui) {
-        }
+        open: function (event, ui) {},
       });
 
       // Display help dialog
       dialog.dialog('open');
-
     } else {
       console.log('Unable to reference a valid: [dialog]');
     }
@@ -742,8 +794,11 @@ jQuery(document).ready(function ($) {
     handle_custom_field_save_request(e, $(e.currentTarget), false);
   });
 
-  function handle_custom_field_save_request(event, save_button, translate_update_only) {
-
+  function handle_custom_field_save_request(
+    event,
+    save_button,
+    translate_update_only,
+  ) {
     // If defined, short-circuit default save flow and adopt ajax approach if needed.
     if (event) {
       event.preventDefault();
@@ -753,14 +808,20 @@ jQuery(document).ready(function ($) {
     if (!translate_update_only) {
       $('form[name="' + $(save_button).data('form_id') + '"]').submit();
     } else {
-
       // Always capture field parent level name & description translations; which is present across all fields.
       let payload = {
-        'post_type': $(save_button).data('post_type'),
-        'field_id': $(save_button).data('field_id'),
-        'field_type': $(save_button).data('field_type'),
-        'translations': package_custom_field_translations($(save_button).data('field_id')),
-        'option_translations': window.lodash.includes(['key_select', 'multi_select', 'link'], $(save_button).data('field_type')) ? package_custom_field_option_translations():[]
+        post_type: $(save_button).data('post_type'),
+        field_id: $(save_button).data('field_id'),
+        field_type: $(save_button).data('field_type'),
+        translations: package_custom_field_translations(
+          $(save_button).data('field_id'),
+        ),
+        option_translations: window.lodash.includes(
+          ['key_select', 'multi_select', 'link'],
+          $(save_button).data('field_type'),
+        )
+          ? package_custom_field_option_translations()
+          : [],
       };
 
       // Have core endpoint process field translations accordingly.
@@ -772,31 +833,74 @@ jQuery(document).ready(function ($) {
         url: `${window.dt_admin_scripts.rest_root}dt-admin/scripts/update_custom_field_translations`,
         beforeSend: (xhr) => {
           xhr.setRequestHeader('X-WP-Nonce', window.dt_admin_scripts.nonce);
-        }
-      }).done(function (response) {
-
-        // Update translation counts.
-        $('#custom_name_translation_count').html((response['translations']) ? Object.keys(response['translations']).length:0);
-        $('#custom_description_translation_count').html((response['description_translations']) ? Object.keys(response['description_translations']).length:0);
-        if ((response['defaults']) && window.lodash.includes(['key_select', 'multi_select', 'link'], $(save_button).data('field_type'))) {
-          $('.sortable-field-options').find('tr.ui-sortable-handle').each(function (idx, tr) {
-            let option_key = $(tr).find('.sortable-field-options-key').text().trim();
-            $(tr).find('#option_name_translation_count').html((response['defaults'] && response['defaults'][option_key] && response['defaults'][option_key]['translations']) ? Object.keys(response['defaults'][option_key]['translations']).length:0);
-            $(tr).find('#option_description_translation_count').html((response['defaults'] && response['defaults'][option_key] && response['defaults'][option_key]['description_translations']) ? Object.keys(response['defaults'][option_key]['description_translations']).length:0);
-          });
-        }
-
-      }).fail(function (error) {
-        console.log("error");
-        console.log(error);
-      });
+        },
+      })
+        .done(function (response) {
+          // Update translation counts.
+          $('#custom_name_translation_count').html(
+            response['translations']
+              ? Object.keys(response['translations']).length
+              : 0,
+          );
+          $('#custom_description_translation_count').html(
+            response['description_translations']
+              ? Object.keys(response['description_translations']).length
+              : 0,
+          );
+          if (
+            response['defaults'] &&
+            window.lodash.includes(
+              ['key_select', 'multi_select', 'link'],
+              $(save_button).data('field_type'),
+            )
+          ) {
+            $('.sortable-field-options')
+              .find('tr.ui-sortable-handle')
+              .each(function (idx, tr) {
+                let option_key = $(tr)
+                  .find('.sortable-field-options-key')
+                  .text()
+                  .trim();
+                $(tr)
+                  .find('#option_name_translation_count')
+                  .html(
+                    response['defaults'] &&
+                      response['defaults'][option_key] &&
+                      response['defaults'][option_key]['translations']
+                      ? Object.keys(
+                          response['defaults'][option_key]['translations'],
+                        ).length
+                      : 0,
+                  );
+                $(tr)
+                  .find('#option_description_translation_count')
+                  .html(
+                    response['defaults'] &&
+                      response['defaults'][option_key] &&
+                      response['defaults'][option_key][
+                        'description_translations'
+                      ]
+                      ? Object.keys(
+                          response['defaults'][option_key][
+                            'description_translations'
+                          ],
+                        ).length
+                      : 0,
+                  );
+              });
+          }
+        })
+        .fail(function (error) {
+          console.log('error');
+          console.log(error);
+        });
     }
   }
 
   function package_custom_field_translations(field_id) {
     let packaged_translations = {
-      'translations': [],
-      'description_translations': []
+      translations: [],
+      description_translations: [],
     };
 
     // Locate field name translations.
@@ -806,24 +910,26 @@ jQuery(document).ready(function ($) {
       let value = $(input).val();
       if (locale && value) {
         packaged_translations['translations'].push({
-          'locale': locale,
-          'value': value
+          locale: locale,
+          value: value,
         });
       }
     });
 
     // Locate field description translations.
     let field_description_prefix = 'field_description_translation-';
-    $("input[id^='" + field_description_prefix + "']").each(function (idx, input) {
-      let locale = window.lodash.split($(input).attr('id'), '-')[1];
-      let value = $(input).val();
-      if (locale && value) {
-        packaged_translations['description_translations'].push({
-          'locale': locale,
-          'value': value
-        });
-      }
-    });
+    $("input[id^='" + field_description_prefix + "']").each(
+      function (idx, input) {
+        let locale = window.lodash.split($(input).attr('id'), '-')[1];
+        let value = $(input).val();
+        if (locale && value) {
+          packaged_translations['description_translations'].push({
+            locale: locale,
+            value: value,
+          });
+        }
+      },
+    );
 
     return packaged_translations;
   }
@@ -831,48 +937,62 @@ jQuery(document).ready(function ($) {
   function package_custom_field_option_translations() {
     let packaged_translations = [];
 
-    $('.sortable-field-options').find('tr.ui-sortable-handle').each(function (idx, tr) {
-      let translations = {
-        'option_key': '',
-        'option_translations': [],
-        'option_description_translations': []
-      };
+    $('.sortable-field-options')
+      .find('tr.ui-sortable-handle')
+      .each(function (idx, tr) {
+        let translations = {
+          option_key: '',
+          option_translations: [],
+          option_description_translations: [],
+        };
 
-      // Determine option key.
-      let option_key = $(tr).find('.sortable-field-options-key').text().trim();
-      if (option_key) {
-        translations['option_key'] = option_key;
+        // Determine option key.
+        let option_key = $(tr)
+          .find('.sortable-field-options-key')
+          .text()
+          .trim();
+        if (option_key) {
+          translations['option_key'] = option_key;
 
-        // Locate option key translations.
-        let option_key_prefix = 'field_option_' + option_key + '_translation-';
-        $(tr).find("input[id^='" + option_key_prefix + "']").each(function (okt_idx, okt_input) {
-          let locale = window.lodash.split($(okt_input).attr('id'), '-')[1];
-          let value = $(okt_input).val();
-          if (locale && value) {
-            translations['option_translations'].push({
-              'locale': locale,
-              'value': $(okt_input).val()
+          // Locate option key translations.
+          let option_key_prefix =
+            'field_option_' + option_key + '_translation-';
+          $(tr)
+            .find("input[id^='" + option_key_prefix + "']")
+            .each(function (okt_idx, okt_input) {
+              let locale = window.lodash.split($(okt_input).attr('id'), '-')[1];
+              let value = $(okt_input).val();
+              if (locale && value) {
+                translations['option_translations'].push({
+                  locale: locale,
+                  value: $(okt_input).val(),
+                });
+              }
             });
-          }
-        });
 
-        // Locate option key description translations.
-        let option_key_description_prefix = 'option_description_' + option_key + '_translation-';
-        $(tr).find("input[id^='" + option_key_description_prefix + "']").each(function (okdt_idx, okdt_input) {
-          let locale = window.lodash.split($(okdt_input).attr('id'), '-')[1];
-          let value = $(okdt_input).val();
-          if (locale && value) {
-            translations['option_description_translations'].push({
-              'locale': locale,
-              'value': $(okdt_input).val()
+          // Locate option key description translations.
+          let option_key_description_prefix =
+            'option_description_' + option_key + '_translation-';
+          $(tr)
+            .find("input[id^='" + option_key_description_prefix + "']")
+            .each(function (okdt_idx, okdt_input) {
+              let locale = window.lodash.split(
+                $(okdt_input).attr('id'),
+                '-',
+              )[1];
+              let value = $(okdt_input).val();
+              if (locale && value) {
+                translations['option_description_translations'].push({
+                  locale: locale,
+                  value: $(okdt_input).val(),
+                });
+              }
             });
-          }
-        });
 
-        // Package recent translations.
-        packaged_translations.push(translations);
-      }
-    });
+          // Package recent translations.
+          packaged_translations.push(translations);
+        }
+      });
 
     return packaged_translations;
   }
@@ -880,6 +1000,4 @@ jQuery(document).ready(function ($) {
   /**
    * Alternative Save Flow - [END]
    */
-
-
-})
+});

--- a/dt-core/admin/js/dt-settings.js
+++ b/dt-core/admin/js/dt-settings.js
@@ -1,162 +1,347 @@
-"use strict";
+'use strict';
 
-let all_settings = window.field_settings
-let dt_shared = window.dt_admin_shared
+let all_settings = window.field_settings;
+let dt_shared = window.dt_admin_shared;
 
-function makeRequest(type, url, data, base = "dt/v1/") {
+function makeRequest(type, url, data, base = 'dt/v1/') {
   //make sure base has a trailing slash if url does not start with one
-  if ( !base.endsWith('/') && !url.startsWith('/')){
-    base += '/'
+  if (!base.endsWith('/') && !url.startsWith('/')) {
+    base += '/';
   }
   const options = {
     type: type,
-    contentType: "application/json; charset=utf-8",
-    dataType: "json",
-    url: url.startsWith("http") ? url : `${window.field_settings.root}${base}${url}`,
+    contentType: 'application/json; charset=utf-8',
+    dataType: 'json',
+    url: url.startsWith('http')
+      ? url
+      : `${window.field_settings.root}${base}${url}`,
     beforeSend: (xhr) => {
-      xhr.setRequestHeader("X-WP-Nonce", window.field_settings.nonce);
+      xhr.setRequestHeader('X-WP-Nonce', window.field_settings.nonce);
     },
   };
 
   if (data) {
-    options.data = type === "GET" ? data : JSON.stringify(data);
+    options.data = type === 'GET' ? data : JSON.stringify(data);
   }
 
   return jQuery.ajax(options);
 }
 
-jQuery(document).ready(function($) {
-  $( document ).tooltip();
+jQuery(document).ready(function ($) {
+  $(document).tooltip();
 
   window.API = {};
-  window.API.create_new_post_type = (new_key, new_name_single, new_name_plural) => makeRequest("POST", `create-new-post-type`, {
-    key: new_key,
-    single: new_name_single,
-    plural: new_name_plural
-  }, `dt-admin-settings/`);
+  window.API.create_new_post_type = (
+    new_key,
+    new_name_single,
+    new_name_plural,
+  ) =>
+    makeRequest(
+      'POST',
+      `create-new-post-type`,
+      {
+        key: new_key,
+        single: new_name_single,
+        plural: new_name_plural,
+      },
+      `dt-admin-settings/`,
+    );
 
-  window.API.update_post_type = (post_type, name_singular, name_plural, displayed) => makeRequest("POST", `update-post-type`, {
-    post_type: post_type,
-    single: name_singular,
-    plural: name_plural,
-    displayed: displayed
-  }, `dt-admin-settings/`);
+  window.API.update_post_type = (
+    post_type,
+    name_singular,
+    name_plural,
+    displayed,
+  ) =>
+    makeRequest(
+      'POST',
+      `update-post-type`,
+      {
+        post_type: post_type,
+        single: name_singular,
+        plural: name_plural,
+        displayed: displayed,
+      },
+      `dt-admin-settings/`,
+    );
 
-  window.API.delete_post_type = (key, delete_all_records) => makeRequest("POST", `delete-post-type`, {
-    key: key,
-    delete_all_records: delete_all_records
-  }, `dt-admin-settings/`);
+  window.API.delete_post_type = (key, delete_all_records) =>
+    makeRequest(
+      'POST',
+      `delete-post-type`,
+      {
+        key: key,
+        delete_all_records: delete_all_records,
+      },
+      `dt-admin-settings/`,
+    );
 
-  window.API.update_roles = (post_type, roles) => makeRequest("POST", `update-roles`, {
-    post_type: post_type,
-    roles: roles
-  }, `dt-admin-settings/`);
+  window.API.update_roles = (post_type, roles) =>
+    makeRequest(
+      'POST',
+      `update-roles`,
+      {
+        post_type: post_type,
+        roles: roles,
+      },
+      `dt-admin-settings/`,
+    );
 
-  window.API.create_new_tile = (post_type, new_tile_name, new_tile_description) => makeRequest("POST", `create-new-tile`, {
-    post_type: post_type,
-    new_tile_name: new_tile_name,
-    new_tile_description: new_tile_description,
-  }, `dt-admin-settings/`);
+  window.API.create_new_tile = (
+    post_type,
+    new_tile_name,
+    new_tile_description,
+  ) =>
+    makeRequest(
+      'POST',
+      `create-new-tile`,
+      {
+        post_type: post_type,
+        new_tile_name: new_tile_name,
+        new_tile_description: new_tile_description,
+      },
+      `dt-admin-settings/`,
+    );
 
-  window.API.get_tile = (post_type, tile_key) => makeRequest("POST", `get-tile`, {
-    post_type: post_type,
-    tile_key: tile_key,
-  }, `dt-admin-settings`);
+  window.API.get_tile = (post_type, tile_key) =>
+    makeRequest(
+      'POST',
+      `get-tile`,
+      {
+        post_type: post_type,
+        tile_key: tile_key,
+      },
+      `dt-admin-settings`,
+    );
 
-  window.API.edit_tile = (post_type, tile_key, tile_label, tile_description, hide_tile) => makeRequest("POST", `edit-tile`, {
-    post_type: post_type,
-    tile_key: tile_key,
-    tile_label: tile_label,
-    tile_description: tile_description,
-    hide_tile: hide_tile,
-  }, `dt-admin-settings/`);
+  window.API.edit_tile = (
+    post_type,
+    tile_key,
+    tile_label,
+    tile_description,
+    hide_tile,
+  ) =>
+    makeRequest(
+      'POST',
+      `edit-tile`,
+      {
+        post_type: post_type,
+        tile_key: tile_key,
+        tile_label: tile_label,
+        tile_description: tile_description,
+        hide_tile: hide_tile,
+      },
+      `dt-admin-settings/`,
+    );
 
-  window.API.delete_tile = (post_type, tile_key) => makeRequest("POST", `delete-tile`, {
-    post_type: post_type,
-    tile_key: tile_key,
-  }, `dt-admin-settings/`);
+  window.API.delete_tile = (post_type, tile_key) =>
+    makeRequest(
+      'POST',
+      `delete-tile`,
+      {
+        post_type: post_type,
+        tile_key: tile_key,
+      },
+      `dt-admin-settings/`,
+    );
 
-  window.API.edit_translations = (translation_type, post_type, tile_key, translations, field_key=null, field_option_key=null) => makeRequest("POST", `edit-translations`, {
-    translation_type: translation_type,
-    post_type: post_type,
-    tile_key: tile_key,
-    translations: translations,
-    field_key: field_key,
-    field_option_key: field_option_key,
-  }, `dt-admin-settings`);
+  window.API.edit_translations = (
+    translation_type,
+    post_type,
+    tile_key,
+    translations,
+    field_key = null,
+    field_option_key = null,
+  ) =>
+    makeRequest(
+      'POST',
+      `edit-translations`,
+      {
+        translation_type: translation_type,
+        post_type: post_type,
+        tile_key: tile_key,
+        translations: translations,
+        field_key: field_key,
+        field_option_key: field_option_key,
+      },
+      `dt-admin-settings`,
+    );
 
-  window.API.new_field = (post_type, tile_key, new_field_name, new_field_type, new_field_private, connection_field_options) => makeRequest("POST", `new-field`, {
+  window.API.new_field = (
     post_type,
     tile_key,
     new_field_name,
     new_field_type,
     new_field_private,
-    connection_field_options
-  }, `dt-admin-settings/`);
+    connection_field_options,
+  ) =>
+    makeRequest(
+      'POST',
+      `new-field`,
+      {
+        post_type,
+        tile_key,
+        new_field_name,
+        new_field_type,
+        new_field_private,
+        connection_field_options,
+      },
+      `dt-admin-settings/`,
+    );
 
-  window.API.edit_field = (post_type, tile_key, field_key, custom_name, tile_select, field_description, field_icon, visibility) => makeRequest("POST", `edit-field`, {
-    post_type: post_type,
-    tile_key: tile_key,
-    field_key: field_key,
-    custom_name: custom_name,
-    tile_select: tile_select,
-    field_description: field_description,
-    field_icon: field_icon,
-    visibility: visibility,
-  }, `dt-admin-settings/`);
+  window.API.edit_field = (
+    post_type,
+    tile_key,
+    field_key,
+    custom_name,
+    tile_select,
+    field_description,
+    field_icon,
+    visibility,
+  ) =>
+    makeRequest(
+      'POST',
+      `edit-field`,
+      {
+        post_type: post_type,
+        tile_key: tile_key,
+        field_key: field_key,
+        custom_name: custom_name,
+        tile_select: tile_select,
+        field_description: field_description,
+        field_icon: field_icon,
+        visibility: visibility,
+      },
+      `dt-admin-settings/`,
+    );
 
-  window.API.delete_field = ( post_type, field_key ) => makeRequest("DELETE", `field`, {
+  window.API.delete_field = (post_type, field_key) =>
+    makeRequest(
+      'DELETE',
+      `field`,
+      {
+        post_type,
+        field_key,
+      },
+      `dt-admin-settings/`,
+    );
+
+  window.API.new_field_option = (
+    post_type,
+    tile_key,
+    field_key,
+    field_option_name,
+    field_option_description,
+    field_option_icon,
+  ) =>
+    makeRequest(
+      'POST',
+      `new-field-option`,
+      {
+        post_type: post_type,
+        tile_key: tile_key,
+        field_key: field_key,
+        field_option_name: field_option_name,
+        field_option_description: field_option_description,
+        field_option_icon: field_option_icon,
+      },
+      `dt-admin-settings/`,
+    );
+
+  window.API.edit_field_option = (
+    post_type,
+    tile_key,
+    field_key,
+    field_option_key,
+    new_field_option_label,
+    new_field_option_description,
+    field_option_icon,
+    visibility,
+  ) =>
+    makeRequest(
+      'POST',
+      `edit-field-option`,
+      {
+        post_type: post_type,
+        tile_key: tile_key,
+        field_key: field_key,
+        field_option_key: field_option_key,
+        new_field_option_label: new_field_option_label,
+        new_field_option_description: new_field_option_description,
+        field_option_icon: field_option_icon,
+        visibility: visibility,
+      },
+      `dt-admin-settings/`,
+    );
+
+  window.API.delete_field_option = (post_type, field_key, field_option_key) =>
+    makeRequest(
+      'DELETE',
+      `field-option`,
+      {
+        post_type,
+        field_key,
+        field_option_key,
+      },
+      `dt-admin-settings/`,
+    );
+
+  window.API.update_tile_and_fields_order = (
+    post_type,
+    dt_custom_tiles_and_fields_ordered,
+  ) =>
+    makeRequest(
+      'POST',
+      `update-tiles-and-fields-order`,
+      {
+        post_type: post_type,
+        dt_custom_tiles_and_fields_ordered: dt_custom_tiles_and_fields_ordered,
+      },
+      `dt-admin-settings/`,
+    );
+
+  window.API.update_field_options_order = (
     post_type,
     field_key,
-  }, `dt-admin-settings/`);
+    sortable_field_options_ordering,
+  ) =>
+    makeRequest(
+      'POST',
+      `update-field-options-order`,
+      {
+        post_type: post_type,
+        field_key: field_key,
+        sortable_field_options_ordering: sortable_field_options_ordering,
+      },
+      `dt-admin-settings/`,
+    );
 
-  window.API.new_field_option = (post_type, tile_key, field_key, field_option_name, field_option_description, field_option_icon) => makeRequest("POST", `new-field-option`, {
-    post_type: post_type,
-    tile_key: tile_key,
-    field_key: field_key,
-    field_option_name: field_option_name,
-    field_option_description: field_option_description,
-    field_option_icon: field_option_icon,
-  }, `dt-admin-settings/`);
+  window.API.remove_custom_field_name = (post_type, field_key) =>
+    makeRequest(
+      'POST',
+      `remove-custom-field-name`,
+      {
+        post_type: post_type,
+        field_key: field_key,
+      },
+      `dt-admin-settings/`,
+    );
 
-  window.API.edit_field_option = (post_type, tile_key, field_key, field_option_key, new_field_option_label, new_field_option_description, field_option_icon, visibility) => makeRequest("POST", `edit-field-option`, {
-    post_type: post_type,
-    tile_key: tile_key,
-    field_key: field_key,
-    field_option_key: field_option_key,
-    new_field_option_label: new_field_option_label,
-    new_field_option_description: new_field_option_description,
-    field_option_icon: field_option_icon,
-    visibility: visibility,
-  }, `dt-admin-settings/`);
-
-  window.API.delete_field_option = ( post_type, field_key, field_option_key ) => makeRequest("DELETE", `field-option`, {
+  window.API.remove_custom_field_option_label = (
     post_type,
     field_key,
     field_option_key,
-  }, `dt-admin-settings/`);
-
-  window.API.update_tile_and_fields_order = (post_type, dt_custom_tiles_and_fields_ordered) => makeRequest("POST", `update-tiles-and-fields-order`, {
-    post_type: post_type,
-    dt_custom_tiles_and_fields_ordered: dt_custom_tiles_and_fields_ordered,
-  }, `dt-admin-settings/`);
-
-  window.API.update_field_options_order = (post_type, field_key, sortable_field_options_ordering) => makeRequest("POST", `update-field-options-order`, {
-    post_type: post_type,
-    field_key: field_key,
-    sortable_field_options_ordering: sortable_field_options_ordering,
-  }, `dt-admin-settings/`);
-
-  window.API.remove_custom_field_name = (post_type, field_key) => makeRequest("POST", `remove-custom-field-name`, {
-    post_type: post_type,
-    field_key: field_key,
-  }, `dt-admin-settings/`);
-
-  window.API.remove_custom_field_option_label = (post_type, field_key, field_option_key) => makeRequest("POST", `remove-custom-field-option-label`, {
-    post_type: post_type,
-    field_key: field_key,
-    field_option_key: field_option_key,
-  }, `dt-admin-settings/`);
+  ) =>
+    makeRequest(
+      'POST',
+      `remove-custom-field-option-label`,
+      {
+        post_type: post_type,
+        field_key: field_key,
+        field_option_key: field_option_key,
+      },
+      `dt-admin-settings/`,
+    );
 
   function autonavigate_to_menu() {
     let tile_key = get_tile_from_uri();
@@ -167,7 +352,7 @@ jQuery(document).ready(function($) {
 
   function get_tile_from_uri() {
     let tile = window.location.search.match('tile=(.*)');
-    if ( tile !== null ) {
+    if (tile !== null) {
       return tile[1];
     }
     return null;
@@ -175,22 +360,34 @@ jQuery(document).ready(function($) {
 
   function get_field_from_uri() {
     let field = window.location.hash;
-    field = field.replace('#','');
+    field = field.replace('#', '');
     return field;
   }
 
   function click_tile(tile_key) {
-    $(`.field-settings-table-tile-name[data-key="${tile_key}"]`).ready(function() {
-      $(`.field-settings-table-tile-name[data-key="${tile_key}"]`).addClass('menu-highlight');
-      $(`.field-settings-table-tile-name[data-key="${tile_key}"]`).trigger('click');
-    });
+    $(`.field-settings-table-tile-name[data-key="${tile_key}"]`).ready(
+      function () {
+        $(`.field-settings-table-tile-name[data-key="${tile_key}"]`).addClass(
+          'menu-highlight',
+        );
+        $(`.field-settings-table-tile-name[data-key="${tile_key}"]`).trigger(
+          'click',
+        );
+      },
+    );
   }
 
   function click_field(field_key) {
-    $(`.field-settings-table-field-name[data-key="${field_key}"]`).ready(function() {
-      $(`.field-settings-table-field-name[data-key="${field_key}"]`).addClass('menu-highlight');
-      $(`.field-settings-table-field-name[data-key="${field_key}"]`).trigger('click');
-    });
+    $(`.field-settings-table-field-name[data-key="${field_key}"]`).ready(
+      function () {
+        $(`.field-settings-table-field-name[data-key="${field_key}"]`).addClass(
+          'menu-highlight',
+        );
+        $(`.field-settings-table-field-name[data-key="${field_key}"]`).trigger(
+          'click',
+        );
+      },
+    );
   }
 
   autonavigate_to_menu();
@@ -200,7 +397,7 @@ jQuery(document).ready(function($) {
   }
 
   let sortable_options = {
-    update: function(event,ui) {
+    update: function (event, ui) {
       if (!$(event)[0].originalEvent.target.dataset) {
         return;
       }
@@ -212,70 +409,99 @@ jQuery(document).ready(function($) {
       if (moved_element.dataset['fieldOptionKey']) {
         let field_key = moved_element.dataset['fieldKey'];
         let sortable_field_options_ordering = [];
-        let field_options = $(`.field-name-content[data-field-key=${field_key}]`);
+        let field_options = $(
+          `.field-name-content[data-field-key=${field_key}]`,
+        );
 
-        $.each(field_options, function(option_index, option_element) {
-          sortable_field_options_ordering.push(option_element.dataset['fieldOptionKey']);
+        $.each(field_options, function (option_index, option_element) {
+          sortable_field_options_ordering.push(
+            option_element.dataset['fieldOptionKey'],
+          );
         });
-        window.API.update_field_options_order(post_type, field_key, sortable_field_options_ordering).promise().then(function(new_order){
-          let old_order = all_settings.post_type_settings.fields[field_key]['default'];
-          all_settings.post_type_settings.fields[field_key]['default'] = order_field_option_keys_by_array(old_order, new_order);
+        window.API.update_field_options_order(
+          post_type,
+          field_key,
+          sortable_field_options_ordering,
+        )
+          .promise()
+          .then(function (new_order) {
+            let old_order =
+              all_settings.post_type_settings.fields[field_key]['default'];
+            all_settings.post_type_settings.fields[field_key]['default'] =
+              order_field_option_keys_by_array(old_order, new_order);
 
-          tile_key = window.field_settings.post_type_settings.fields[field_key].tile;
-          show_preview_tile(tile_key);
-        });
+            tile_key =
+              window.field_settings.post_type_settings.fields[field_key].tile;
+            show_preview_tile(tile_key);
+          });
         return;
       }
-      let dt_custom_tiles_and_fields_ordered = get_dt_custom_tiles_and_fields_ordered();
-      window.API.update_tile_and_fields_order(post_type, dt_custom_tiles_and_fields_ordered).promise().then(function(result) {
-        if ( result[post_type][tile_key] ) {
-          window.field_settings.post_type_settings.tiles[tile_key].order = result[post_type][tile_key]['order'];
-        }
-        show_preview_tile(tile_key);
-      });
+      let dt_custom_tiles_and_fields_ordered =
+        get_dt_custom_tiles_and_fields_ordered();
+      window.API.update_tile_and_fields_order(
+        post_type,
+        dt_custom_tiles_and_fields_ordered,
+      )
+        .promise()
+        .then(function (result) {
+          if (result[post_type][tile_key]) {
+            window.field_settings.post_type_settings.tiles[tile_key].order =
+              result[post_type][tile_key]['order'];
+          }
+          show_preview_tile(tile_key);
+        });
     },
-  }
-  $('.field-settings-table, .tile-rundown-elements, .field-settings-table-child-toggle').sortable(sortable_options);
+  };
+  $(
+    '.field-settings-table, .tile-rundown-elements, .field-settings-table-child-toggle',
+  ).sortable(sortable_options);
 
   function order_field_option_keys_by_array(old_order, new_order) {
     return Object.fromEntries(
-      Object.entries(old_order).sort((a, b) => new_order.indexOf(a[0]) - new_order.indexOf(b[0]))
+      Object.entries(old_order).sort(
+        (a, b) => new_order.indexOf(a[0]) - new_order.indexOf(b[0]),
+      ),
     );
   }
 
   function get_dt_custom_tiles_and_fields_ordered() {
     let dt_custom_tiles_and_fields_ordered = {};
-    let tiles = $('.field-settings-table-tile-name').map((index, tile)=>{
+    let tiles = $('.field-settings-table-tile-name').map((index, tile) => {
       return tile.dataset.key;
-    })
+    });
 
     let tile_priority = 10;
 
-    $.each(tiles, function(tile_index, tile_key) {
-      if ( tile_key === '' || tile_key === 'no_tile' ) {
+    $.each(tiles, function (tile_index, tile_key) {
+      if (tile_key === '' || tile_key === 'no_tile') {
         return;
       }
       dt_custom_tiles_and_fields_ordered[tile_key] = {};
-      let fields = $(document).find(`.field-settings-table-field-name[data-parent-tile-key="${tile_key}"]`);
+      let fields = $(document).find(
+        `.field-settings-table-field-name[data-parent-tile-key="${tile_key}"]`,
+      );
       let field_order = [];
-      $.each(fields, function(field_index, field_element) {
+      $.each(fields, function (field_index, field_element) {
         field_order.push(field_element.dataset.key);
       });
 
       dt_custom_tiles_and_fields_ordered[tile_key]['order'] = field_order;
-      dt_custom_tiles_and_fields_ordered[tile_key]['tile_priority'] = tile_priority;
+      dt_custom_tiles_and_fields_ordered[tile_key]['tile_priority'] =
+        tile_priority;
       tile_priority += 10;
     });
     return dt_custom_tiles_and_fields_ordered;
   }
 
   function get_field_defaults(tile_key, field_key) {
-    let field_options = $(`.field-name-content[data-parent-tile-key="${tile_key}"][data-field-key="${field_key}"]`);
+    let field_options = $(
+      `.field-name-content[data-parent-tile-key="${tile_key}"][data-field-key="${field_key}"]`,
+    );
     let field_default = [];
-    $.each(field_options, function(field_index, field_element){
+    $.each(field_options, function (field_index, field_element) {
       let field_option_key = $(field_element).data('field-option-key');
       let field_option_label = $(field_element).prop('innerText');
-      field_default[field_option_key] = {'label': field_option_label};
+      field_default[field_option_key] = { label: field_option_label };
     });
     return field_default;
   }
@@ -285,16 +511,20 @@ jQuery(document).ready(function($) {
   let dt_admin_modal_overlay = $('.dt-admin-modal-overlay');
   let dt_overlay_form = $('#modal-overlay-form');
 
-  field_settings_table.on('click', '.field-settings-table-tile-name', function() {
-    let tile_key = $(this).data('key');
-    if (!tile_key || tile_key === 'no-tile-hidden') {
-      hide_preview_tile();
-      return;
-    }
-    show_preview_tile(tile_key);
-  });
+  field_settings_table.on(
+    'click',
+    '.field-settings-table-tile-name',
+    function () {
+      let tile_key = $(this).data('key');
+      if (!tile_key || tile_key === 'no-tile-hidden') {
+        hide_preview_tile();
+        return;
+      }
+      show_preview_tile(tile_key);
+    },
+  );
 
-  field_settings_table.on('click', '.edit-icon', function() {
+  field_settings_table.on('click', '.edit-icon', function () {
     let edit_modal = $(this).parent().data('modal');
     let data = {};
     if (edit_modal === 'edit-field') {
@@ -306,41 +536,49 @@ jQuery(document).ready(function($) {
     showOverlayModal(edit_modal, data);
   });
 
-  field_settings_table.on('click', '.edit-icon[data-modal="edit-field-option"]', function() {
-    let edit_modal = $(this).data('modal');
-    let data = {};
-    if (edit_modal === 'edit-field-option') {
-      data['tile_key'] = $(this).data('parent-tile-key');
-      data['field_key'] = $(this).data('field-key');
-      data['option_key'] = $(this).data('field-option-key');
-    }
-    showOverlayModal(edit_modal, data);
-  });
-
-  field_settings_table.on('click', "div[class*='expandable']", function(event) {
-    if ( event.target.className !== 'edit-icon' ) {
-      $(this).next().slideToggle(333, 'swing');
-      if ($(this).children('.expand-icon').text() === '+'){
-        $(this).children('.expand-icon').text('-');
-        $(this).addClass('outset-shadow');
-      } else {
-        $(this).children('.expand-icon').text('+');
-        $(this).removeClass('outset-shadow');
+  field_settings_table.on(
+    'click',
+    '.edit-icon[data-modal="edit-field-option"]',
+    function () {
+      let edit_modal = $(this).data('modal');
+      let data = {};
+      if (edit_modal === 'edit-field-option') {
+        data['tile_key'] = $(this).data('parent-tile-key');
+        data['field_key'] = $(this).data('field-key');
+        data['option_key'] = $(this).data('field-option-key');
       }
-    }
-  });
+      showOverlayModal(edit_modal, data);
+    },
+  );
 
-  $('#add-new-tile-link').on('click', function(event){
+  field_settings_table.on(
+    'click',
+    "div[class*='expandable']",
+    function (event) {
+      if (event.target.className !== 'edit-icon') {
+        $(this).next().slideToggle(333, 'swing');
+        if ($(this).children('.expand-icon').text() === '+') {
+          $(this).children('.expand-icon').text('-');
+          $(this).addClass('outset-shadow');
+        } else {
+          $(this).children('.expand-icon').text('+');
+          $(this).removeClass('outset-shadow');
+        }
+      }
+    },
+  );
+
+  $('#add-new-tile-link').on('click', function (event) {
     event.preventDefault();
     showOverlayModal('add-new-tile');
   });
 
-  $('#add_new_post_type').on('click', function(event){
+  $('#add_new_post_type').on('click', function (event) {
     event.preventDefault();
     showOverlayModal('add-new-post-type');
   });
 
-  field_settings_table.on('click', '.add-new-field', function() {
+  field_settings_table.on('click', '.add-new-field', function () {
     let tile_key = $(this).data('parent-tile-key');
     showOverlayModal('add-new-field', tile_key);
   });
@@ -359,8 +597,8 @@ jQuery(document).ready(function($) {
 
     let fields = [];
     let all_fields = all_settings.post_type_settings.fields;
-    $.each(all_fields, function(field_index, field_value) {
-      if( field_value['tile'] === tile_key ) {
+    $.each(all_fields, function (field_index, field_value) {
+      if (field_value['tile'] === tile_key) {
         fields.push(field_index);
       }
     });
@@ -370,17 +608,24 @@ jQuery(document).ready(function($) {
       fields = field_order;
     }
 
-
-    $.each(fields, function(field_index, field_key) {
+    $.each(fields, function (field_index, field_key) {
       let field = all_settings.post_type_settings.fields[field_key];
-      if( !field?.type ){
+      if (!field?.type) {
         return;
       }
 
       let icon_html = '';
-      let icon = (field['icon'] && field['icon'] !== '') ? field['icon'] : field['font-icon'];
-      if (icon && (typeof icon !== 'undefined') && (icon !== 'undefined')) {
-        icon_html = '<span class="field-icon-wrapper">' + (icon.trim().toLowerCase().startsWith('mdi') ? `<i class="${dt_shared.escape(icon)} dt-icon lightgray" style="font-size: 20px;"></i>`:`<img src="${icon}" class="dt-icon lightgray">`) + '</span>';
+      let icon =
+        field['icon'] && field['icon'] !== ''
+          ? field['icon']
+          : field['font-icon'];
+      if (icon && typeof icon !== 'undefined' && icon !== 'undefined') {
+        icon_html =
+          '<span class="field-icon-wrapper">' +
+          (icon.trim().toLowerCase().startsWith('mdi')
+            ? `<i class="${dt_shared.escape(icon)} dt-icon lightgray" style="font-size: 20px;"></i>`
+            : `<img src="${icon}" class="dt-icon lightgray">`) +
+          '</span>';
       }
 
       tile_html += `
@@ -390,39 +635,40 @@ jQuery(document).ready(function($) {
           </div>
       `;
 
-
       /*** TEXT - START ***/
-      if ( [ 'text', 'communication_channel', 'location', 'location_meta', 'link' ].indexOf(field['type']) > -1 ) {
+      if (
+        [
+          'text',
+          'communication_channel',
+          'location',
+          'location_meta',
+          'link',
+        ].indexOf(field['type']) > -1
+      ) {
         tile_html += `
             <input type="text" class="text-input">
         `;
       }
       /*** TEXT - END ***/
 
-
-
       /*** TEXTAREA - START ***/
-      if ( field['type'] === 'textarea' ) {
+      if (field['type'] === 'textarea') {
         tile_html += `
             <textarea style="width: 100%;" class="textarea dt_textarea"></textarea>
         `;
       }
       /*** TEXTAREA - END ***/
 
-
-
       /*** NUMBER - START ***/
-      if ( field['type'] === 'number' ) {
+      if (field['type'] === 'number') {
         tile_html += `
             <input type="number" class="text-input" value="1" min="" max=""></input>
         `;
       }
       /*** NUMBER - END ***/
 
-
-
       /*** DATE - START ***/
-      if ( field['type'] === 'date' ) {
+      if (field['type'] === 'date') {
         tile_html += `
             <div class="typeahead-container">
                 <input class="typeahead-input">
@@ -432,10 +678,8 @@ jQuery(document).ready(function($) {
       }
       /*** DATE - END ***/
 
-
-
       /*** USER_SELECT - START ***/
-      if ( field['type'] === 'user_select' ) {
+      if (field['type'] === 'user_select') {
         tile_html += `
             <div class="typeahead-container">
                 <span class="typeahead-cancel-button">×</span>
@@ -448,10 +692,8 @@ jQuery(document).ready(function($) {
       }
       /*** USER_SELECT - END ***/
 
-
-
       /*** CONNECTION - START ***/
-      if ( ['connection', 'tags'].indexOf(field['type'] ) > -1 ) {
+      if (['connection', 'tags'].indexOf(field['type']) > -1) {
         tile_html += `
             <div class="typeahead-container">
                 <input class="typeahead-input" placeholder="Search ${field['name']}">
@@ -463,16 +705,24 @@ jQuery(document).ready(function($) {
       }
       /*** CONNECTION - END ***/
 
-
-
       /*** MULTISELECT - START ***/
-      if ( field['type'] === 'multi_select' ) {
+      if (field['type'] === 'multi_select') {
         tile_html += `<div class="button-group" style="display: inline-flex;">`;
-        $.each( field['default'], function(k,f) {
+        $.each(field['default'], function (k, f) {
           let multi_select_icon_html = '';
-          let multi_icon = (f['icon'] && f['icon'] !== '') ? f['icon'] : f['font-icon'];
-          if (multi_icon && (typeof multi_icon !== 'undefined') && (multi_icon !== 'undefined')) {
-            multi_select_icon_html = '<span class="field-icon-wrapper">' + (multi_icon.trim().toLowerCase().startsWith('mdi') ? `<i class="${multi_icon} dt-icon lightgray" style="font-size: 20px;"></i>`:`<img src="${multi_icon}" class="dt-icon lightgray">`) + '</span>';
+          let multi_icon =
+            f['icon'] && f['icon'] !== '' ? f['icon'] : f['font-icon'];
+          if (
+            multi_icon &&
+            typeof multi_icon !== 'undefined' &&
+            multi_icon !== 'undefined'
+          ) {
+            multi_select_icon_html =
+              '<span class="field-icon-wrapper">' +
+              (multi_icon.trim().toLowerCase().startsWith('mdi')
+                ? `<i class="${multi_icon} dt-icon lightgray" style="font-size: 20px;"></i>`
+                : `<img src="${multi_icon}" class="dt-icon lightgray">`) +
+              '</span>';
           }
           tile_html += `
               <button>
@@ -485,9 +735,8 @@ jQuery(document).ready(function($) {
       }
       /*** MULTISELECT - START ***/
 
-
       /*** BOOLEAN - START ***/
-      if ( field['type'] === 'boolean' ) {
+      if (field['type'] === 'boolean') {
         tile_html += `
         <select class="select-field">
           <option value="0">No</option>
@@ -497,15 +746,14 @@ jQuery(document).ready(function($) {
       }
       /*** BOOLEAN - START ***/
 
-
       /*** KEY_SELECT - START ***/
-      if ( field['type'] === 'key_select' ) {
+      if (field['type'] === 'key_select') {
         let color_select = '';
-        if ( field['custom_display'] ) {
+        if (field['custom_display']) {
           color_select = 'color-select';
         }
         tile_html += `<select class="select-field ${color_select}" style="width: 100%;">`;
-        $.each( field['default'], function(k,f) {
+        $.each(field['default'], function (k, f) {
           tile_html += `<option>${f['label']}</option>`;
         });
         tile_html += `</select>`;
@@ -522,36 +770,36 @@ jQuery(document).ready(function($) {
     $('.fields-table-right').html('');
   }
 
-  function showOverlayModal(modalName, data=null) {
+  function showOverlayModal(modalName, data = null) {
     unflip_card();
     dt_admin_modal_overlay.fadeIn(150, 'swing');
     dt_admin_modal_box.slideDown(150, 'swing');
     showOverlayModalContentBox(modalName, data);
   }
 
-  function showOverlayModalContentBox(modalName, data=null) {
-    if ( modalName === 'delete-post-type') {
+  function showOverlayModalContentBox(modalName, data = null) {
+    if (modalName === 'delete-post-type') {
       loadDeletePostTypeContentBox(data);
     }
-    if ( modalName === 'add-new-post-type') {
+    if (modalName === 'add-new-post-type') {
       loadAddPostTypeContentBox();
     }
-    if ( modalName === 'add-new-tile' ) {
+    if (modalName === 'add-new-tile') {
       loadAddTileContentBox();
     }
-    if ( modalName === 'edit-tile' ) {
+    if (modalName === 'edit-tile') {
       loadEditTileContentBox(data);
     }
-    if ( modalName === 'add-new-field' ) {
+    if (modalName === 'add-new-field') {
       loadAddFieldContentBox(data);
     }
-    if ( modalName === 'edit-field' ) {
+    if (modalName === 'edit-field') {
       loadEditFieldContentBox(data);
     }
-    if ( modalName === 'edit-field-option' ) {
+    if (modalName === 'edit-field-option') {
       loadEditFieldOptionContentBox(data);
     }
-    if ( modalName === 'new-field-option') {
+    if (modalName === 'new-field-option') {
       loadAddFieldOptionBox(data);
     }
   }
@@ -570,10 +818,13 @@ jQuery(document).ready(function($) {
     $('#modal-overlay-content-table').html('');
   }
 
-  function scrollTo(target_element, offset=0) {
-    $([document.documentElement, document.body]).animate({
-      scrollTop: target_element.offset().top + offset
-    }, 500);
+  function scrollTo(target_element, offset = 0) {
+    $([document.documentElement, document.body]).animate(
+      {
+        scrollTop: target_element.offset().top + offset,
+      },
+      500,
+    );
   }
 
   // Delete Post Type Modal
@@ -692,32 +943,42 @@ jQuery(document).ready(function($) {
 
     let translations_count = 0;
     if (all_settings['post_type_tiles'][tile_key]['translations']) {
-      translations_count = Object.values(all_settings['post_type_tiles'][tile_key]['translations']).filter(function(t) {return t;}).length;
+      translations_count = Object.values(
+        all_settings['post_type_tiles'][tile_key]['translations'],
+      ).filter(function (t) {
+        return t;
+      }).length;
     }
 
     let description_translations_count = 0;
     if (all_settings['post_type_tiles'][tile_key]['description_translations']) {
-      description_translations_count = Object.values(all_settings['post_type_tiles'][tile_key]['description_translations']).filter(function(t) {return t;}).length;
+      description_translations_count = Object.values(
+        all_settings['post_type_tiles'][tile_key]['description_translations'],
+      ).filter(function (t) {
+        return t;
+      }).length;
     }
 
-    window.API.get_tile(post_type, tile_key).promise().then(function(data) {
-      let tile_description = '';
-      if ( data['description'] ) {
-        tile_description = data['description'];
-      }
-      let hide_tile = '';
-      if (data['hidden']) {
-        hide_tile = 'checked';
-      }
+    window.API.get_tile(post_type, tile_key)
+      .promise()
+      .then(function (data) {
+        let tile_description = '';
+        if (data['description']) {
+          tile_description = data['description'];
+        }
+        let hide_tile = '';
+        if (data['hidden']) {
+          hide_tile = 'checked';
+        }
 
-      let delete_tile_html_content = '';
-      if (window.field_settings.default_tiles.includes(tile_key) === false) {
-        delete_tile_html_content = `<a id="delete-tile-text" class="delete-text" data-tile-key="${tile_key}">Delete Tile</a>`;
-      }
+        let delete_tile_html_content = '';
+        if (window.field_settings.default_tiles.includes(tile_key) === false) {
+          delete_tile_html_content = `<a id="delete-tile-text" class="delete-text" data-tile-key="${tile_key}">Delete Tile</a>`;
+        }
 
-      let key_tag = `<span title="Tile key" class="dt-tag dt-tag-grey">${tile_key}</span>`
+        let key_tag = `<span title="Tile key" class="dt-tag dt-tag-grey">${tile_key}</span>`;
 
-      let modal_html_content = `
+        let modal_html_content = `
           <tr>
               <th colspan="2">
                   <h3 class="modal-box-title">Edit '${data['label']}' Tile</h3>
@@ -785,8 +1046,8 @@ jQuery(document).ready(function($) {
               </td>
           </tr>`;
 
-      $('#modal-overlay-content-table').html(modal_html_content);
-    });
+        $('#modal-overlay-content-table').html(modal_html_content);
+      });
   }
 
   function enableModalBackDiv(divId) {
@@ -805,9 +1066,9 @@ jQuery(document).ready(function($) {
   });
 
   // Delete Tile Text Click
-  dt_overlay_form.on('click', '#delete-tile-text', function(e) {
+  dt_overlay_form.on('click', '#delete-tile-text', function (e) {
     $(this).blur();
-    if( $('#delete-confirmation-container').length > 0 ) {
+    if ($('#delete-confirmation-container').length > 0) {
       return;
     }
     let tile_key = $(this).data('tile-key');
@@ -820,9 +1081,9 @@ jQuery(document).ready(function($) {
   });
 
   // Delete Field Text Click
-  dt_overlay_form.on('click', '#delete-field-text', function(e) {
+  dt_overlay_form.on('click', '#delete-field-text', function (e) {
     $(this).blur();
-    if( $('#delete-confirmation-container').length > 0 ) {
+    if ($('#delete-confirmation-container').length > 0) {
       return;
     }
     let field_key = $(this).data('field-key');
@@ -835,9 +1096,9 @@ jQuery(document).ready(function($) {
   });
 
   // Delete Field Option Text Click
-  dt_overlay_form.on('click', '#delete-field-option-text', function(e) {
+  dt_overlay_form.on('click', '#delete-field-option-text', function (e) {
     $(this).blur();
-    if( $('#delete-confirmation-container').length > 0 ) {
+    if ($('#delete-confirmation-container').length > 0) {
       return;
     }
     let field_key = $(this).data('field-key');
@@ -848,75 +1109,116 @@ jQuery(document).ready(function($) {
             <svg id="delete-confirmation-cancel" stroke="#e14d43" fill="none" stroke-width="2" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
         </div>
     `);
-  })
+  });
 
   // Delete Confirmation Confirm
-  dt_overlay_form.on('click', '#delete-tile-confirmation-confirm', function(e) {
-    let post_type = get_post_type();
-    let tile_key = $(this).data('tile-key');
-    window.API.delete_tile(post_type, tile_key).promise().then(function() {
-      let tile_submenu = $(`div.field-settings-table-field-name[data-parent-tile-key="${tile_key}"]`);
-      closeModal();
-      if (tile_submenu.is(':visible')) {
-        let tile_expand_icon = $(`.field-settings-table-tile-name[data-key="${tile_key}"]>span.expand-icon`);
-        tile_expand_icon.click();
-      }
+  dt_overlay_form.on(
+    'click',
+    '#delete-tile-confirmation-confirm',
+    function (e) {
+      let post_type = get_post_type();
+      let tile_key = $(this).data('tile-key');
+      window.API.delete_tile(post_type, tile_key)
+        .promise()
+        .then(function () {
+          let tile_submenu = $(
+            `div.field-settings-table-field-name[data-parent-tile-key="${tile_key}"]`,
+          );
+          closeModal();
+          if (tile_submenu.is(':visible')) {
+            let tile_expand_icon = $(
+              `.field-settings-table-tile-name[data-key="${tile_key}"]>span.expand-icon`,
+            );
+            tile_expand_icon.click();
+          }
 
-      let no_tile_menu = $('.tile-rundown-elements[data-parent-tile-key="no_tile"]');
-      if (no_tile_menu.is(':hidden')) {
-        let no_tile_expand_icon = $('.field-settings-table-tile-name[data-key="no_tile"] > span.expand-icon');
-        no_tile_expand_icon.click();
-      }
+          let no_tile_menu = $(
+            '.tile-rundown-elements[data-parent-tile-key="no_tile"]',
+          );
+          if (no_tile_menu.is(':hidden')) {
+            let no_tile_expand_icon = $(
+              '.field-settings-table-tile-name[data-key="no_tile"] > span.expand-icon',
+            );
+            no_tile_expand_icon.click();
+          }
 
-      let deleted_tile_field_options =  $(`.tile-rundown-elements[data-parent-tile-key="${tile_key}"]`).children().not('.add-new-item');
-      deleted_tile_field_options.each(function() {
-        $(this).removeClass('inset-shadow');
-        let no_tile_menu_last_submenu = $('.tile-rundown-elements[data-parent-tile-key="no_tile"] > .add-new-item');
-        no_tile_menu_last_submenu.before($(this));
-        $(this).attr('data-parent-tile-key', 'no_tile');
-        $(this).find('.field-name-content').attr('data-parent-tile-key', 'no_tile');
-        $(this).find('.field-settings-table-field-name').attr('data-parent-tile-key', 'no_tile');
-        $(this).find('.field-settings-table-field-name').addClass('menu-highlight');
-      });
+          let deleted_tile_field_options = $(
+            `.tile-rundown-elements[data-parent-tile-key="${tile_key}"]`,
+          )
+            .children()
+            .not('.add-new-item');
+          deleted_tile_field_options.each(function () {
+            $(this).removeClass('inset-shadow');
+            let no_tile_menu_last_submenu = $(
+              '.tile-rundown-elements[data-parent-tile-key="no_tile"] > .add-new-item',
+            );
+            no_tile_menu_last_submenu.before($(this));
+            $(this).attr('data-parent-tile-key', 'no_tile');
+            $(this)
+              .find('.field-name-content')
+              .attr('data-parent-tile-key', 'no_tile');
+            $(this)
+              .find('.field-settings-table-field-name')
+              .attr('data-parent-tile-key', 'no_tile');
+            $(this)
+              .find('.field-settings-table-field-name')
+              .addClass('menu-highlight');
+          });
 
-      let tile_element = $(`.field-settings-table-tile-name[data-key="${tile_key}"]`);
-      tile_element.css('background', '#e14d43');
-      tile_element.fadeOut(500, function(){
-        tile_element.parent().remove();
-      });
-    });
-  });
+          let tile_element = $(
+            `.field-settings-table-tile-name[data-key="${tile_key}"]`,
+          );
+          tile_element.css('background', '#e14d43');
+          tile_element.fadeOut(500, function () {
+            tile_element.parent().remove();
+          });
+        });
+    },
+  );
 
-  dt_overlay_form.on('click', '#delete-field-confirmation-confirm', function(e) {
-    let post_type = get_post_type();
-    let field_key = $(this).data('field-key');
-    window.API.delete_field(post_type, field_key).promise().then(function() {
-      closeModal();
-      let field_element = $(`.sortable-field[data-key="${field_key}"]`);
-      field_element.css('background', '#e14d43');
-      field_element.fadeOut(500, function(){
-        field_element.remove();
-      });
-    })
-  });
+  dt_overlay_form.on(
+    'click',
+    '#delete-field-confirmation-confirm',
+    function (e) {
+      let post_type = get_post_type();
+      let field_key = $(this).data('field-key');
+      window.API.delete_field(post_type, field_key)
+        .promise()
+        .then(function () {
+          closeModal();
+          let field_element = $(`.sortable-field[data-key="${field_key}"]`);
+          field_element.css('background', '#e14d43');
+          field_element.fadeOut(500, function () {
+            field_element.remove();
+          });
+        });
+    },
+  );
 
-
-  dt_overlay_form.on('click', '#delete-field-option-confirmation-confirm', function(e) {
-    let post_type = get_post_type();
-    let field_key = $(this).data('field-key');
-    let field_option_key = $(this).data('field-option-key');
-    window.API.delete_field_option(post_type, field_key, field_option_key).promise().then(function() {
-      closeModal();
-      let field_element = $(`.sortable-field[data-key="${field_key}"] .field-settings-table-field-option[data-field-option-key="${field_option_key}"]` );
-      field_element.css('background', '#e14d43');
-      field_element.fadeOut(500, function(){
-        field_element.remove();
-      });
-    })
-  });
+  dt_overlay_form.on(
+    'click',
+    '#delete-field-option-confirmation-confirm',
+    function (e) {
+      let post_type = get_post_type();
+      let field_key = $(this).data('field-key');
+      let field_option_key = $(this).data('field-option-key');
+      window.API.delete_field_option(post_type, field_key, field_option_key)
+        .promise()
+        .then(function () {
+          closeModal();
+          let field_element = $(
+            `.sortable-field[data-key="${field_key}"] .field-settings-table-field-option[data-field-option-key="${field_option_key}"]`,
+          );
+          field_element.css('background', '#e14d43');
+          field_element.fadeOut(500, function () {
+            field_element.remove();
+          });
+        });
+    },
+  );
 
   // Delete Confirmation Cancel
-  dt_overlay_form.on('click', '#delete-tile-confirmation-cancel', function(e) {
+  dt_overlay_form.on('click', '#delete-tile-confirmation-cancel', function (e) {
     $(this).parent().remove();
   });
 
@@ -925,7 +1227,8 @@ jQuery(document).ready(function($) {
     let post_type = get_post_type();
     let all_post_types = window.field_settings.all_post_types;
     let selected_post_type_label = all_post_types[post_type];
-    let tile_key_label = window.field_settings.post_type_tiles[tile_key].label || tile_key;
+    let tile_key_label =
+      window.field_settings.post_type_tiles[tile_key].label || tile_key;
     if (!tile_key) {
       tile_key_label = `<i>This post type doesn't have any tiles</i>`;
     }
@@ -988,7 +1291,7 @@ jQuery(document).ready(function($) {
             <td>
                 <select name="connection-target" id="connection-field-target">
                     <option></option>
-                    ${Object.keys(all_post_types).map((k)=>`<option value="${k}">${all_post_types[k]}</option>`)}
+                    ${Object.keys(all_post_types).map((k) => `<option value="${k}">${all_post_types[k]}</option>`)}
                 </select>
             </td>
         </tr>
@@ -1061,36 +1364,52 @@ jQuery(document).ready(function($) {
     let field_type = field_settings['type'];
 
     let name_is_custom = false;
-    if ( field_settings['default_name'] ) {
+    if (field_settings['default_name']) {
       name_is_custom = true;
     }
 
     let translations_count = 0;
     if (all_settings.post_type_settings.fields[field_key]['translations']) {
-      translations_count = Object.values(all_settings.post_type_settings.fields[field_key]['translations']).filter(function(t){return t;}).length;
+      translations_count = Object.values(
+        all_settings.post_type_settings.fields[field_key]['translations'],
+      ).filter(function (t) {
+        return t;
+      }).length;
     }
 
     let description_translations_count = 0;
-    if ( all_settings.post_type_settings.fields[field_key]['description_translations'] ) {
-      description_translations_count = Object.values(all_settings.post_type_settings.fields[field_key]['description_translations']).filter(function(t){return t;}).length;
+    if (
+      all_settings.post_type_settings.fields[field_key][
+        'description_translations'
+      ]
+    ) {
+      description_translations_count = Object.values(
+        all_settings.post_type_settings.fields[field_key][
+          'description_translations'
+        ],
+      ).filter(function (t) {
+        return t;
+      }).length;
     }
 
     let field_icon_image_html = '';
-    let icon = (field_settings['icon'] && field_settings['icon'] !== '') ? field_settings['icon'] : field_settings['font-icon'];
-    if ( icon && (typeof icon !== 'undefined') && (icon !== 'undefined') ) {
-      if ( icon.trim().toLowerCase().startsWith('mdi') ){
+    let icon =
+      field_settings['icon'] && field_settings['icon'] !== ''
+        ? field_settings['icon']
+        : field_settings['font-icon'];
+    if (icon && typeof icon !== 'undefined' && icon !== 'undefined') {
+      if (icon.trim().toLowerCase().startsWith('mdi')) {
         field_icon_image_html = `<i class="${icon} field-icon" style="font-size: 30px; vertical-align: middle;"></i>`;
       } else {
         field_icon_image_html = `<img src="${icon}" class="field-icon" style="vertical-align: middle;">`;
       }
-
     } else icon = '';
 
-    if ( !field_settings['description'] ) {
+    if (!field_settings['description']) {
       field_settings['description'] = '';
     }
 
-    if ( !field_settings['icon'] ) {
+    if (!field_settings['icon']) {
       field_settings['icon'] = '';
     }
 
@@ -1099,44 +1418,56 @@ jQuery(document).ready(function($) {
       delete_field_html_content = `<a id="delete-field-text" class="delete-text" data-field-key="${field_key}">Delete Field</a>`;
     }
 
-    let key_tag = `<span title="Field key" class="dt-tag dt-tag-grey">${field_key}</span>`
-    let field_type_tag = `<span title="Field type" class="dt-tag dt-tag-teal">${window.field_settings.field_types[field_type]?.label || field_type.replace('_', ' ')}</span>`
+    let key_tag = `<span title="Field key" class="dt-tag dt-tag-grey">${field_key}</span>`;
+    let field_type_tag = `<span title="Field type" class="dt-tag dt-tag-teal">${window.field_settings.field_types[field_type]?.label || field_type.replace('_', ' ')}</span>`;
     let private_tag = ``;
-    if ( field_settings['private'] ) {
-      private_tag = `<span title="The content of private fields can only be seen by the user who creates it and will not be shared with other DT users." class="dt-tag dt-tag-orange">Private Field</span>`
+    if (field_settings['private']) {
+      private_tag = `<span title="The content of private fields can only be seen by the user who creates it and will not be shared with other DT users." class="dt-tag dt-tag-orange">Private Field</span>`;
     }
 
-    let type_visibility_html = ''
-    if ( field_settings['type'] && field_settings['type'] === 'boolean' ) {
+    let type_visibility_html = '';
+    if (field_settings['type'] && field_settings['type'] === 'boolean') {
       type_visibility_html += `
         <tr>
             <td>
                 <strong>Checked By Default</strong>
             </td>
             <td>
-                <input type="checkbox" name="checked_by_default" id="checked_by_default" ${ ( field_settings['default'] && field_settings['default'] === true ) ? 'checked' : ''}>
+                <input type="checkbox" name="checked_by_default" id="checked_by_default" ${field_settings['default'] && field_settings['default'] === true ? 'checked' : ''}>
             </td>
         </tr>
       `;
     }
 
-    if ( window.field_settings?.post_type_settings?.fields['type']?.default ) {
+    if (window.field_settings?.post_type_settings?.fields['type']?.default) {
       type_visibility_html += `
           <tr>
               <td>
                   <strong>Show For</strong>
               </td>
               <td class="checkbox-group" id="type-visibility">
-                  ${Object.keys(window.field_settings?.post_type_settings?.fields['type']?.default).map((option_key)=>{
-                    let type_option = window.field_settings.post_type_settings.fields['type'].default[option_key]
-                    let type_selected = field_settings.only_for_types === undefined || field_settings.only_for_types === true || Object.values(field_settings.only_for_types).includes(option_key)
-                    return `<label><input type="checkbox" value="${option_key}" name="type-visibility" ${type_selected?'checked':''}>
+                  ${Object.keys(
+                    window.field_settings?.post_type_settings?.fields['type']
+                      ?.default,
+                  )
+                    .map((option_key) => {
+                      let type_option =
+                        window.field_settings.post_type_settings.fields['type']
+                          .default[option_key];
+                      let type_selected =
+                        field_settings.only_for_types === undefined ||
+                        field_settings.only_for_types === true ||
+                        Object.values(field_settings.only_for_types).includes(
+                          option_key,
+                        );
+                      return `<label><input type="checkbox" value="${option_key}" name="type-visibility" ${type_selected ? 'checked' : ''}>
                       ${type_option.label}
-                    </label>`
-                  }).join('')}
+                    </label>`;
+                    })
+                    .join('')}
               </td>
           </tr>
-      `
+      `;
     }
 
     let modal_html_content = `
@@ -1153,7 +1484,7 @@ jQuery(document).ready(function($) {
                 ${key_tag} ${field_type_tag} ${private_tag}
             </td>
         </tr>
-    `
+    `;
 
     let name_section_html = `
         <tr>
@@ -1220,11 +1551,14 @@ jQuery(document).ready(function($) {
             <td>
                 <select name="tile-select" id="tile_select">
                     <option value="no_tile">No tile / hidden</option>
-                    ${Object.keys(window.field_settings.post_type_tiles).map(k=>{
-                      let tile = window.field_settings.post_type_tiles[k]
-                      let selected = field_settings.tile === k ? 'selected' : ''
-                      return `<option value="${k}" ${selected}>${tile['label']}</option>`
-                    })}
+                    ${Object.keys(window.field_settings.post_type_tiles).map(
+                      (k) => {
+                        let tile = window.field_settings.post_type_tiles[k];
+                        let selected =
+                          field_settings.tile === k ? 'selected' : '';
+                        return `<option value="${k}" ${selected}>${tile['label']}</option>`;
+                      },
+                    )}
 
                 </select>
             </td>
@@ -1329,29 +1663,52 @@ jQuery(document).ready(function($) {
     let option_description = '';
 
     let name_is_custom = false;
-    if ( field_option['default_name'] ) {
+    if (field_option['default_name']) {
       name_is_custom = true;
     }
 
-    if ( 'description' in field_settings['default'][field_option_key] ) {
-      option_description = field_settings['default'][field_option_key]['description'];
+    if ('description' in field_settings['default'][field_option_key]) {
+      option_description =
+        field_settings['default'][field_option_key]['description'];
     }
 
     let translations_count = 0;
     if (field_settings['default'][field_option_key]['translations']) {
-      translations_count = Object.values(field_settings['default'][field_option_key]['translations']).filter(function(t) {return t;}).length;
+      translations_count = Object.values(
+        field_settings['default'][field_option_key]['translations'],
+      ).filter(function (t) {
+        return t;
+      }).length;
     }
 
     let description_translations_count = 0;
-    if (field_settings['default'][field_option_key]['description_translations']) {
-      description_translations_count = Object.values(field_settings['default'][field_option_key]['description_translations']).filter(function(t) {return t;}).length;
+    if (
+      field_settings['default'][field_option_key]['description_translations']
+    ) {
+      description_translations_count = Object.values(
+        field_settings['default'][field_option_key]['description_translations'],
+      ).filter(function (t) {
+        return t;
+      }).length;
     }
 
-    let field_icon_url = (field_settings['default'][field_option_key]['font-icon']) ? field_settings['default'][field_option_key]['font-icon']:field_settings['default'][field_option_key]['icon'];
+    let field_icon_url = field_settings['default'][field_option_key][
+      'font-icon'
+    ]
+      ? field_settings['default'][field_option_key]['font-icon']
+      : field_settings['default'][field_option_key]['icon'];
     let field_icon_image_html = '';
-    if( field_icon_url && (typeof field_icon_url !== 'undefined') && (field_icon_url !== 'undefined') ){
-      field_icon_image_html = '<span class="field-icon-wrapper">' + (field_icon_url.trim().toLowerCase().startsWith('mdi') ? `<i class="${field_icon_url} field-icon" style="font-size: 30px; vertical-align: middle;"></i>` : `<img src="${field_icon_url}" class="field-icon" style="vertical-align: middle;">`) + '</span>';
-
+    if (
+      field_icon_url &&
+      typeof field_icon_url !== 'undefined' &&
+      field_icon_url !== 'undefined'
+    ) {
+      field_icon_image_html =
+        '<span class="field-icon-wrapper">' +
+        (field_icon_url.trim().toLowerCase().startsWith('mdi')
+          ? `<i class="${field_icon_url} field-icon" style="font-size: 30px; vertical-align: middle;"></i>`
+          : `<img src="${field_icon_url}" class="field-icon" style="vertical-align: middle;">`) +
+        '</span>';
     } else field_icon_url = '';
 
     let delete_field_option_html_content = '';
@@ -1359,7 +1716,7 @@ jQuery(document).ready(function($) {
       delete_field_option_html_content = `<a id="delete-field-option-text" class="delete-text" data-field-key="${field_key}" data-field-option-key="${field_option_key}">Delete Field Option</a>`;
     }
 
-    let key_tag = `<span title="Field option key" class="dt-tag dt-tag-grey">${field_option_key}</span>`
+    let key_tag = `<span title="Field option key" class="dt-tag dt-tag-grey">${field_option_key}</span>`;
 
     let modal_html_content = `
         <tr>
@@ -1468,8 +1825,7 @@ jQuery(document).ready(function($) {
     $('#modal-overlay-content-table').html(modal_html_content);
   }
 
-
-  dt_overlay_form.on('submit', function(event){
+  dt_overlay_form.on('submit', function (event) {
     event.preventDefault();
   });
 
@@ -1496,32 +1852,32 @@ jQuery(document).ready(function($) {
         roles[role_key] = [];
       }
       roles[role_key].push({
-        'key': capability_key,
-        'enabled': enabled
+        key: capability_key,
+        enabled: enabled,
       });
     });
 
     // Dispatch update endpoint api request.
-    window.API.update_roles(post_type, roles).promise().then(function (data) {
-      button_icon.removeClass('active');
-      button_icon.removeClass('loading-spinner');
-      button_icon.css('color', '#ffffff');
+    window.API.update_roles(post_type, roles)
+      .promise()
+      .then(function (data) {
+        button_icon.removeClass('active');
+        button_icon.removeClass('loading-spinner');
+        button_icon.css('color', '#ffffff');
 
-      if (data && data['updated']) {
-        button_icon.addClass('mdi mdi-comment-check-outline');
-
-      } else {
-        button_icon.addClass('mdi mdi-comment-remove-outline');
-      }
-    });
+        if (data && data['updated']) {
+          button_icon.addClass('mdi mdi-comment-check-outline');
+        } else {
+          button_icon.addClass('mdi mdi-comment-remove-outline');
+        }
+      });
   });
 
   // Process Add Post Type - Single Name Events
   dt_overlay_form.on('keyup', '#new_post_type_name_single', function (e) {
-
     // Generate corresponding key.
     let single_name = $('#new_post_type_name_single').val().trim();
-    let key = single_name.toLowerCase().replaceAll(/[!-\/:-@[-`{-~\s*]/ig, '_');
+    let key = single_name.toLowerCase().replaceAll(/[!-\/:-@[-`{-~\s*]/gi, '_');
     $('#new_post_type_key').val(key.substring(0, 20));
 
     // Generate corresponding plural name.
@@ -1533,7 +1889,7 @@ jQuery(document).ready(function($) {
     e.preventDefault();
 
     showOverlayModal('delete-post-type', {
-      'post_type': $('#post_type_settings_key').html()
+      post_type: $('#post_type_settings_key').html(),
     });
   });
 
@@ -1551,16 +1907,20 @@ jQuery(document).ready(function($) {
     button_icon.addClass('active');
     button_icon.addClass('loading-spinner');
 
-    window.API.delete_post_type(post_type, delete_all_records).promise().then(function (data) {
-      button_icon.removeClass('active');
-      button_icon.removeClass('loading-spinner');
+    window.API.delete_post_type(post_type, delete_all_records)
+      .promise()
+      .then(function (data) {
+        button_icon.removeClass('active');
+        button_icon.removeClass('loading-spinner');
 
-      if(data && data['deleted']) {
-        window.location.href = window.dt_admin_scripts.site_url + '/wp-admin/admin.php?page=dt_customizations&post_type=contacts&tab=tiles';
-      } else {
-        $(delete_post_type_msg).html(dt_shared.escape(data['msg']));
-      }
-    });
+        if (data && data['deleted']) {
+          window.location.href =
+            window.dt_admin_scripts.site_url +
+            '/wp-admin/admin.php?page=dt_customizations&post_type=contacts&tab=tiles';
+        } else {
+          $(delete_post_type_msg).html(dt_shared.escape(data['msg']));
+        }
+      });
   });
 
   // Update Post Type
@@ -1594,29 +1954,31 @@ jQuery(document).ready(function($) {
       $(post_type_settings_singular).css('border', '2px solid #e14d43');
       button_icon.removeClass('active');
       button_icon.removeClass('loading-spinner');
-
-    } else if ( is_custom && plural.trim() === '') {
+    } else if (is_custom && plural.trim() === '') {
       alert('Plural field cannot be empty');
       $(post_type_settings_plural).css('border', '2px solid #e14d43');
       button_icon.removeClass('active');
       button_icon.removeClass('loading-spinner');
-
     } else {
+      window.API.update_post_type(post_type, singular, plural, displayed)
+        .promise()
+        .then(function (data) {
+          button_icon.removeClass('active');
+          button_icon.removeClass('loading-spinner');
+          button_icon.css('color', '#ffffff');
 
-      window.API.update_post_type(post_type, singular, plural, displayed).promise().then(function (data) {
-        button_icon.removeClass('active');
-        button_icon.removeClass('loading-spinner');
-        button_icon.css('color', '#ffffff');
-
-        if (data && data['updated']) {
-          button_icon.addClass('mdi mdi-comment-check-outline');
-
-        } else {
-          button_icon.addClass('mdi mdi-comment-remove-outline');
-        }
-      }).catch(e=>{
-        alert(e?.responseJSON?.message || 'An error occurred while updating the post type settings.')
-      });
+          if (data && data['updated']) {
+            button_icon.addClass('mdi mdi-comment-check-outline');
+          } else {
+            button_icon.addClass('mdi mdi-comment-remove-outline');
+          }
+        })
+        .catch((e) => {
+          alert(
+            e?.responseJSON?.message ||
+              'An error occurred while updating the post type settings.',
+          );
+        });
     }
   });
 
@@ -1644,58 +2006,65 @@ jQuery(document).ready(function($) {
     let single_name = $(new_post_type_name_single).val().trim();
     let plural_name = $(new_post_type_name_plural).val().trim();
 
-    if(single_name === '') {
+    if (single_name === '') {
       $(new_post_type_name_single).css('border', '2px solid #e14d43');
       button_icon.css('margin', '');
       button_icon.removeClass('active');
       button_icon.removeClass('loading-spinner');
       return false;
-
-    } else if ( ( key === '' ) || ( key.length > 20 ) ) {
+    } else if (key === '' || key.length > 20) {
       $(new_post_type_key).css('border', '2px solid #e14d43');
       button_icon.css('margin', '');
       button_icon.removeClass('active');
       button_icon.removeClass('loading-spinner');
       return false;
-
-    } else if(plural_name === '') {
+    } else if (plural_name === '') {
       $(new_post_type_name_plural).css('border', '2px solid #e14d43');
       button_icon.css('margin', '');
       button_icon.removeClass('active');
       button_icon.removeClass('loading-spinner');
       return false;
-
     } else {
-
       // Submit post type creation request.
-      window.API.create_new_post_type(key, single_name, plural_name).promise().then(function (data) {
+      window.API.create_new_post_type(key, single_name, plural_name)
+        .promise()
+        .then(function (data) {
+          button_icon.css('margin', '');
+          button_icon.removeClass('active');
+          button_icon.removeClass('loading-spinner');
 
-        button_icon.css('margin', '');
-        button_icon.removeClass('active');
-        button_icon.removeClass('loading-spinner');
+          if (
+            data &&
+            data['success'] &&
+            data['post_type'] &&
+            data['post_type_label']
+          ) {
+            // Unselect all/any primary buttons.
+            let latest_post_type_buttons = $('.latest-post-type-buttons');
+            $(latest_post_type_buttons)
+              .find('.button')
+              .removeClass('button-primary');
 
-        if (data && data['success'] && data['post_type'] && data['post_type_label']) {
+            // Generate new post type button.
+            let pill_link =
+              window.dt_admin_scripts.site_url +
+              '/wp-admin/admin.php?page=dt_customizations&post_type=' +
+              data['post_type'] +
+              '&tab=tiles';
+            let pill_link_html = `<a href="${pill_link}" class="button button-primary">${data['post_type_label']}</a>`;
+            $(latest_post_type_buttons).append(pill_link_html);
 
-          // Unselect all/any primary buttons.
-          let latest_post_type_buttons = $('.latest-post-type-buttons');
-          $(latest_post_type_buttons).find('.button').removeClass('button-primary');
-
-          // Generate new post type button.
-          let pill_link = window.dt_admin_scripts.site_url + '/wp-admin/admin.php?page=dt_customizations&post_type=' + data['post_type'] + '&tab=tiles';
-          let pill_link_html = `<a href="${pill_link}" class="button button-primary">${data['post_type_label']}</a>`;
-          $(latest_post_type_buttons).append(pill_link_html);
-
-          // Refresh page with new post type selected
-          window.location.href = pill_link;
-        } else {
-          $(new_post_type_msg).html(dt_shared.escape(data['msg']));
-        }
-      });
+            // Refresh page with new post type selected
+            window.location.href = pill_link;
+          } else {
+            $(new_post_type_msg).html(dt_shared.escape(data['msg']));
+          }
+        });
     }
   });
 
   // Process Add Tile
-  dt_overlay_form.on('click', '#js-add-tile', function(e) {
+  dt_overlay_form.on('click', '#js-add-tile', function (e) {
     let post_type = get_post_type();
     let new_tile_name = $('#new_tile_name').val().trim();
     if (new_tile_name === '') {
@@ -1704,12 +2073,14 @@ jQuery(document).ready(function($) {
     }
     let new_tile_description = $('#new_tile_description').val().trim();
 
-    window.API.create_new_tile(post_type, new_tile_name, new_tile_description).promise().then(function(data) {
-      let tile_key = data['key'];
-      let tile_label = data['label'];
-      window.field_settings.post_type_tiles[tile_key] = {'label':tile_label};
-      closeModal();
-      $('#no_tile').before(`
+    window.API.create_new_tile(post_type, new_tile_name, new_tile_description)
+      .promise()
+      .then(function (data) {
+        let tile_key = data['key'];
+        let tile_label = data['label'];
+        window.field_settings.post_type_tiles[tile_key] = { label: tile_label };
+        closeModal();
+        $('#no_tile').before(`
           <div class="sortable-tile" id="${tile_key}">
               <div class="field-settings-table-tile-name expandable menu-highlight" data-modal="edit-tile" data-key="${tile_key}">
                   <span class="sortable ui-icon ui-icon-arrow-4"></span>
@@ -1731,13 +2102,15 @@ jQuery(document).ready(function($) {
               </div>
           </div>
       `);
-      $('.field-settings-table, .tile-rundown-elements, .field-settings-table-child-toggle').sortable(sortable_options);
-      show_preview_tile(tile_key);
-    });
+        $(
+          '.field-settings-table, .tile-rundown-elements, .field-settings-table-child-toggle',
+        ).sortable(sortable_options);
+        show_preview_tile(tile_key);
+      });
   });
 
   // Process Edit Tile
-  dt_overlay_form.on('click', '#js-edit-tile', function(e) {
+  dt_overlay_form.on('click', '#js-edit-tile', function (e) {
     let post_type = get_post_type();
     let tile_key = $(this).data('tile-key');
     let tile_label = $(`#edit-tile-label-${tile_key}`).val().trim();
@@ -1749,18 +2122,26 @@ jQuery(document).ready(function($) {
       return false;
     }
 
-    window.API.edit_tile(post_type, tile_key, tile_label, tile_description, hide_tile).promise().then(function(response) {
-      $(`#tile-key-${tile_key}`).parent().removeClass('menu-highlight');
-      all_settings['post_type_tiles'][tile_key] = response;
-      $(`#tile-key-${tile_key}`).html(tile_label);
-      show_preview_tile(tile_key);
-      closeModal();
-      $(`#tile-key-${tile_key}`).parent().addClass('menu-highlight');
-    });
+    window.API.edit_tile(
+      post_type,
+      tile_key,
+      tile_label,
+      tile_description,
+      hide_tile,
+    )
+      .promise()
+      .then(function (response) {
+        $(`#tile-key-${tile_key}`).parent().removeClass('menu-highlight');
+        all_settings['post_type_tiles'][tile_key] = response;
+        $(`#tile-key-${tile_key}`).html(tile_label);
+        show_preview_tile(tile_key);
+        closeModal();
+        $(`#tile-key-${tile_key}`).parent().addClass('menu-highlight');
+      });
   });
 
   // Process Add Field
-  dt_overlay_form.on('click', '#js-add-field', function(e) {
+  dt_overlay_form.on('click', '#js-add-field', function (e) {
     let post_type = get_post_type();
     let tile_key = $(this).data('tile-key');
     let new_field_name = $(`#new-field-name`).val().trim();
@@ -1771,21 +2152,34 @@ jQuery(document).ready(function($) {
     let connection_field_options = {
       connection_target: $('#connection-field-target').val().trim(),
       other_field_name: $('#other_field_name').val().trim(),
-      disable_other_post_type_field: $('#hide_reverse_connection').is(':checked'),
+      disable_other_post_type_field: $('#hide_reverse_connection').is(
+        ':checked',
+      ),
       multidirectional: $('#multidirectional_checkbox').is(':checked'),
-      reverse_connection_name: $('#reverse_connection_direction_field_name').val().trim(),
+      reverse_connection_name: $('#reverse_connection_direction_field_name')
+        .val()
+        .trim(),
       disable_reverse_connection: $('#hide-reverse-connection').is(':checked'),
-    }
+    };
 
     if (new_field_name === '') {
       $('#new-field-name').css('border', '2px solid #e14d43');
       return false;
     }
 
-    window.API.new_field(post_type, tile_key, new_field_name, new_field_type, new_field_private, connection_field_options ).promise().then(function(response) {
-      let field_key = response['key'];
-      all_settings.post_type_settings.fields[field_key] = response;
-      let new_field_nonexpandable_html = `
+    window.API.new_field(
+      post_type,
+      tile_key,
+      new_field_name,
+      new_field_type,
+      new_field_private,
+      connection_field_options,
+    )
+      .promise()
+      .then(function (response) {
+        let field_key = response['key'];
+        all_settings.post_type_settings.fields[field_key] = response;
+        let new_field_nonexpandable_html = `
           <div class="sortable-field" id="${field_key}" data-parent-tile-key="${tile_key}">
               <div class="field-settings-table-field-name submenu-highlight" id="${field_key}" data-parent-tile-key="${tile_key}" data-key="${field_key}" data-modal="edit-field">
                  <span class="sortable ui-icon ui-icon-arrow-4"></span>
@@ -1800,7 +2194,7 @@ jQuery(document).ready(function($) {
           </div>
       `;
 
-      let new_field_expandable_html = `
+        let new_field_expandable_html = `
             <div class="sortable-field" data-parent-tile-key="${tile_key}" data-key="${field_key}">
                 <div class="field-settings-table-field-name expandable submenu-highlight" data-parent-tile-key="${tile_key}" data-key="${field_key}" data-modal="edit-field">
                    <span class="sortable ui-icon ui-icon-arrow-4"></span>
@@ -1827,23 +2221,31 @@ jQuery(document).ready(function($) {
                 <!-- END TOGGLED ITEMS -->
             </div>
             `;
-      let new_field_html = new_field_nonexpandable_html;
-      if(['key_select', 'multi_select', 'link'].indexOf(new_field_type) > -1) {
-        new_field_html = new_field_expandable_html;
-      }
-      if (tile_key){
-        $(`.add-new-field[data-parent-tile-key='${tile_key}']`).parent().before(new_field_html);
-        show_preview_tile(tile_key);
-      } else {
-        $('.add-new-field').parent().before(new_field_html);
-      }
-      closeModal();
-      $(document).find('.field-settings-table, .tile-rundown-elements, .field-settings-table-child-toggle').sortable(sortable_options)
-    });
+        let new_field_html = new_field_nonexpandable_html;
+        if (
+          ['key_select', 'multi_select', 'link'].indexOf(new_field_type) > -1
+        ) {
+          new_field_html = new_field_expandable_html;
+        }
+        if (tile_key) {
+          $(`.add-new-field[data-parent-tile-key='${tile_key}']`)
+            .parent()
+            .before(new_field_html);
+          show_preview_tile(tile_key);
+        } else {
+          $('.add-new-field').parent().before(new_field_html);
+        }
+        closeModal();
+        $(document)
+          .find(
+            '.field-settings-table, .tile-rundown-elements, .field-settings-table-child-toggle',
+          )
+          .sortable(sortable_options);
+      });
   });
 
   // Process Edit Field
-  dt_overlay_form.on('click', '#js-edit-field', function() {
+  dt_overlay_form.on('click', '#js-edit-field', function () {
     let post_type = get_post_type();
     let tile_key = $(this).data('tile-key');
     let field_key = $(this).data('field-key');
@@ -1853,15 +2255,19 @@ jQuery(document).ready(function($) {
     let field_icon = $('#edit-field-icon').val().trim();
     let visibility = {
       hidden: $('#hide-field').is(':checked'),
-      type_visibility: $('#type-visibility input:checked').map((index, obj)=>{
-        return $(obj).val()
-      }).get(),
-      show_in_table: $('#show-in-table').is(':checked')
-    }
+      type_visibility: $('#type-visibility input:checked')
+        .map((index, obj) => {
+          return $(obj).val();
+        })
+        .get(),
+      show_in_table: $('#show-in-table').is(':checked'),
+    };
 
     let field_settings = all_settings.post_type_settings.fields[field_key];
-    if ( field_settings['type'] && field_settings['type'] === 'boolean' ) {
-      visibility['checked_by_default'] = $('#checked_by_default').is(':checked');
+    if (field_settings['type'] && field_settings['type'] === 'boolean') {
+      visibility['checked_by_default'] = $('#checked_by_default').is(
+        ':checked',
+      );
     }
 
     if (custom_name === '') {
@@ -1869,59 +2275,97 @@ jQuery(document).ready(function($) {
       return false;
     }
 
-    window.API.edit_field(post_type, tile_key, field_key, custom_name, tile_select, field_description, field_icon, visibility).promise().then(function(result){
-      $.extend(window.field_settings.post_type_settings.fields[field_key], result);
+    window.API.edit_field(
+      post_type,
+      tile_key,
+      field_key,
+      custom_name,
+      tile_select,
+      field_description,
+      field_icon,
+      visibility,
+    )
+      .promise()
+      .then(function (result) {
+        $.extend(
+          window.field_settings.post_type_settings.fields[field_key],
+          result,
+        );
 
-      let edited_field_menu_element = $(`.sortable-field[data-key=${field_key}]`)
+        let edited_field_menu_element = $(
+          `.sortable-field[data-key=${field_key}]`,
+        );
 
-      let edited_field_submenu_element = edited_field_menu_element.find('.field-settings-table-child-toggle')
-      let edited_field_menu_name_element = edited_field_menu_element.find('.field-settings-table-field-name');
-      let hidden_icon = edited_field_menu_name_element.find('.hidden-icon')
+        let edited_field_submenu_element = edited_field_menu_element.find(
+          '.field-settings-table-child-toggle',
+        );
+        let edited_field_menu_name_element = edited_field_menu_element.find(
+          '.field-settings-table-field-name',
+        );
+        let hidden_icon = edited_field_menu_name_element.find('.hidden-icon');
 
-      edited_field_menu_name_element.removeClass('submenu-highlight').removeClass('menu-highlight');
-      edited_field_submenu_element.children('.field-settings-table-field-option').removeClass('submenu-highlight');
+        edited_field_menu_name_element
+          .removeClass('submenu-highlight')
+          .removeClass('menu-highlight');
+        edited_field_submenu_element
+          .children('.field-settings-table-field-option')
+          .removeClass('submenu-highlight');
 
-      if ( custom_name !== '' ) {
-        $(`.sortable-field[data-key=${field_key}] .field-settings-table-field-name .field-name-content`).html(custom_name);
-      }
-
-      // Check if rundown element and sub element need to be moved to another tile
-      if ( tile_key !== tile_select ) {
-        let target_tile_menu = $(`.field-settings-table-tile-name[data-key="${tile_select}"]`);
-        let target_tile_submenu = $(`.tile-rundown-elements[data-parent-tile-key="${tile_select}"]`);
-
-        if ( target_tile_submenu.is(':visible') === false ) {
-          target_tile_menu.trigger('click');
+        if (custom_name !== '') {
+          $(
+            `.sortable-field[data-key=${field_key}] .field-settings-table-field-name .field-name-content`,
+          ).html(custom_name);
         }
 
-        target_tile_submenu.prepend(edited_field_menu_element);
+        // Check if rundown element and sub element need to be moved to another tile
+        if (tile_key !== tile_select) {
+          let target_tile_menu = $(
+            `.field-settings-table-tile-name[data-key="${tile_select}"]`,
+          );
+          let target_tile_submenu = $(
+            `.tile-rundown-elements[data-parent-tile-key="${tile_select}"]`,
+          );
 
-        scrollTo(target_tile_menu, -32);
+          if (target_tile_submenu.is(':visible') === false) {
+            target_tile_menu.trigger('click');
+          }
 
-        edited_field_menu_element.data('parent-tile-key', tile_select);
-        edited_field_menu_name_element.data('parent-tile-key', tile_select);
-        edited_field_submenu_element.data('parent-tile-key', tile_select);
-      }
+          target_tile_submenu.prepend(edited_field_menu_element);
 
-      // hide or show field hidden icon
-      hidden_icon.toggle(result.hidden)
+          scrollTo(target_tile_menu, -32);
 
-      show_preview_tile(tile_key);
-      closeModal();
-      edited_field_menu_name_element.addClass('menu-highlight');
-      edited_field_submenu_element.children('.field-settings-table-field-option').addClass('submenu-highlight');
-      $(document).find('.field-settings-table, .tile-rundown-elements, .field-settings-table-child-toggle').sortable(sortable_options)
-    });
+          edited_field_menu_element.data('parent-tile-key', tile_select);
+          edited_field_menu_name_element.data('parent-tile-key', tile_select);
+          edited_field_submenu_element.data('parent-tile-key', tile_select);
+        }
+
+        // hide or show field hidden icon
+        hidden_icon.toggle(result.hidden);
+
+        show_preview_tile(tile_key);
+        closeModal();
+        edited_field_menu_name_element.addClass('menu-highlight');
+        edited_field_submenu_element
+          .children('.field-settings-table-field-option')
+          .addClass('submenu-highlight');
+        $(document)
+          .find(
+            '.field-settings-table, .tile-rundown-elements, .field-settings-table-child-toggle',
+          )
+          .sortable(sortable_options);
+      });
     return;
   });
 
   // Process Add Field Option
-  dt_overlay_form.on('click', '#js-add-field-option', function(e) {
+  dt_overlay_form.on('click', '#js-add-field-option', function (e) {
     let post_type = get_post_type();
     let tile_key = $(this).data('tile-key');
     let field_key = $(this).data('field-key');
     let field_option_name = $('.new-field-option-name').val().trim();
-    let field_option_description = $('.new-field-option-description').val().trim();
+    let field_option_description = $('.new-field-option-description')
+      .val()
+      .trim();
     let field_option_icon = $('#edit-field-icon').val().trim();
 
     if (field_option_name === '') {
@@ -1929,14 +2373,25 @@ jQuery(document).ready(function($) {
       return false;
     }
 
-    window.API.new_field_option(post_type, tile_key, field_key, field_option_name, field_option_description, field_option_icon).promise().then(function(new_field_option_key) {
-      all_settings.post_type_settings.fields[field_key]['default'][new_field_option_key] = {
-        label:field_option_name,
-        description:field_option_description,
-        icon:field_option_icon,
-      };
+    window.API.new_field_option(
+      post_type,
+      tile_key,
+      field_key,
+      field_option_name,
+      field_option_description,
+      field_option_icon,
+    )
+      .promise()
+      .then(function (new_field_option_key) {
+        all_settings.post_type_settings.fields[field_key]['default'][
+          new_field_option_key
+        ] = {
+          label: field_option_name,
+          description: field_option_description,
+          icon: field_option_icon,
+        };
 
-      let new_field_option_html = `
+        let new_field_option_html = `
           <div class="field-settings-table-field-option">
              <span class="sortable ui-icon ui-icon-arrow-4"></span>
               <span class="field-name-content" data-parent-tile-key="${tile_key}" data-field-key="${field_key}" data-field-option-key="${new_field_option_key}" >
@@ -1947,85 +2402,129 @@ jQuery(document).ready(function($) {
               </span>
               <span class="edit-icon" data-modal="edit-field-option" data-parent-tile-key="${tile_key}" data-field-key="${field_key}" data-field-option-key="${new_field_option_key}"></span>
           </div>`;
-      $(`.new-field-option[data-parent-tile-key="${tile_key}"][data-field-key="${field_key}"]`).before(new_field_option_html);
-      show_preview_tile(tile_key);
-      closeModal();
-    });
+        $(
+          `.new-field-option[data-parent-tile-key="${tile_key}"][data-field-key="${field_key}"]`,
+        ).before(new_field_option_html);
+        show_preview_tile(tile_key);
+        closeModal();
+      });
   });
 
   // Process Edit Field Option
-  dt_overlay_form.on('click', '#js-edit-field-option', function(e) {
+  dt_overlay_form.on('click', '#js-edit-field-option', function (e) {
     let post_type = get_post_type();
     let tile_key = $(this).data('tile-key');
     let field_key = $(this).data('field-key');
     let field_option_key = $(this).data('field-option-key');
     let new_field_option_label = $('#new-option-name').val().trim();
-    let new_field_option_description = $('#new-option-description').val().trim();
+    let new_field_option_description = $('#new-option-description')
+      .val()
+      .trim();
     let field_option_icon = $('#edit-field-icon').val().trim();
     let visibility = {
       hidden: $('#hide-field-option').is(':checked'),
-    }
+    };
 
     if (new_field_option_label === '') {
       $('#new-option-name').css('border', '2px solid #e14d43');
       return false;
     }
 
-    window.API.edit_field_option(post_type, tile_key, field_key, field_option_key, new_field_option_label, new_field_option_description, field_option_icon, visibility).promise().then(function(result) {
-      all_settings.post_type_settings.fields[field_key]['default'][field_option_key] = result;
-      let edited_field_option_element = $(`.field-name-content[data-parent-tile-key="${tile_key}"][data-field-key="${field_key}"][data-field-option-key="${field_option_key}"]`);
-      edited_field_option_element.parent().removeClass('submenu-highlight');
-      edited_field_option_element[0].innerText = new_field_option_label;
+    window.API.edit_field_option(
+      post_type,
+      tile_key,
+      field_key,
+      field_option_key,
+      new_field_option_label,
+      new_field_option_description,
+      field_option_icon,
+      visibility,
+    )
+      .promise()
+      .then(function (result) {
+        all_settings.post_type_settings.fields[field_key]['default'][
+          field_option_key
+        ] = result;
+        let edited_field_option_element = $(
+          `.field-name-content[data-parent-tile-key="${tile_key}"][data-field-key="${field_key}"][data-field-option-key="${field_option_key}"]`,
+        );
+        edited_field_option_element.parent().removeClass('submenu-highlight');
+        edited_field_option_element[0].innerText = new_field_option_label;
 
-      //show or hide the hidden icon
-      $(`.field-settings-table-field-option[data-field-key=${field_key}][data-field-option-key="${field_option_key}"] .hidden-icon`).toggle(result.deleted)
-      show_preview_tile(tile_key);
-      closeModal();
-      edited_field_option_element.parent().addClass('submenu-highlight');
-    });
+        //show or hide the hidden icon
+        $(
+          `.field-settings-table-field-option[data-field-key=${field_key}][data-field-option-key="${field_option_key}"] .hidden-icon`,
+        ).toggle(result.deleted);
+        show_preview_tile(tile_key);
+        closeModal();
+        edited_field_option_element.parent().addClass('submenu-highlight');
+      });
   });
 
   // Process Remove Custom Field Name
-  dt_admin_modal_box.on('click', '#remove-custom-name', function() {
+  dt_admin_modal_box.on('click', '#remove-custom-name', function () {
     let post_type = $(this).data('post-type');
     let tile_key = $(this).data('tile-key');
     let field_key = $(this).data('field-key');
 
-    window.API.remove_custom_field_name(post_type, field_key).promise().then(function(default_name) {
-      all_settings.post_type_settings.fields[field_key]['name'] = default_name;
-      delete all_settings.post_type_settings.fields[field_key]['default_name'];
-      let edited_field_content_element = $(`.field-name-content[data-parent-tile-key="${tile_key}"][data-key="${field_key}"]`);
-      let edited_field_parent_element = $(`.field-name-content[data-parent-tile-key="${tile_key}"][data-key="${field_key}"]`).parent();
-      edited_field_parent_element.removeClass('menu-highlight');
-      closeModal();
-      edited_field_content_element.html(default_name);
-      edited_field_parent_element.addClass('menu-highlight');
-    });
+    window.API.remove_custom_field_name(post_type, field_key)
+      .promise()
+      .then(function (default_name) {
+        all_settings.post_type_settings.fields[field_key]['name'] =
+          default_name;
+        delete all_settings.post_type_settings.fields[field_key][
+          'default_name'
+        ];
+        let edited_field_content_element = $(
+          `.field-name-content[data-parent-tile-key="${tile_key}"][data-key="${field_key}"]`,
+        );
+        let edited_field_parent_element = $(
+          `.field-name-content[data-parent-tile-key="${tile_key}"][data-key="${field_key}"]`,
+        ).parent();
+        edited_field_parent_element.removeClass('menu-highlight');
+        closeModal();
+        edited_field_content_element.html(default_name);
+        edited_field_parent_element.addClass('menu-highlight');
+      });
   });
 
   // Process Remove Custom Field Option Label
-  dt_admin_modal_box.on('click', '#remove-custom-label', function() {
+  dt_admin_modal_box.on('click', '#remove-custom-label', function () {
     let post_type = $(this).data('post-type');
     let tile_key = $(this).data('tile-key');
     let field_key = $(this).data('field-key');
     let field_option_key = $(this).data('field-option-key');
 
-    window.API.remove_custom_field_option_label(post_type, field_key, field_option_key).promise().then(function(default_label) {
-      all_settings.post_type_settings.fields[field_key]['default'][field_option_key]['label'] = default_label;
-      delete all_settings.post_type_settings.fields[field_key]['default_name'];
+    window.API.remove_custom_field_option_label(
+      post_type,
+      field_key,
+      field_option_key,
+    )
+      .promise()
+      .then(function (default_label) {
+        all_settings.post_type_settings.fields[field_key]['default'][
+          field_option_key
+        ]['label'] = default_label;
+        delete all_settings.post_type_settings.fields[field_key][
+          'default_name'
+        ];
 
-      let edited_field_option_content_element = $(`.field-name-content[data-parent-tile-key="${tile_key}"][data-field-key="${field_key}"][data-field-option-key="${field_option_key}"]`);
-      let edited_field_option_parent_element = $(`.field-name-content[data-parent-tile-key="${tile_key}"][data-field-key="${field_key}"][data-field-option-key="${field_option_key}"]`).parent();
+        let edited_field_option_content_element = $(
+          `.field-name-content[data-parent-tile-key="${tile_key}"][data-field-key="${field_key}"][data-field-option-key="${field_option_key}"]`,
+        );
+        let edited_field_option_parent_element = $(
+          `.field-name-content[data-parent-tile-key="${tile_key}"][data-field-key="${field_key}"][data-field-option-key="${field_option_key}"]`,
+        ).parent();
 
-      edited_field_option_parent_element.removeClass('submenu-highlight');
-      closeModal();
-      edited_field_option_content_element.html(default_label);
-      edited_field_option_parent_element.addClass('submenu-highlight');
-    });
+        edited_field_option_parent_element.removeClass('submenu-highlight');
+        closeModal();
+        edited_field_option_content_element.html(default_label);
+        edited_field_option_parent_element.addClass('submenu-highlight');
+      });
   });
 
   // Translation for Tiles
-  dt_admin_modal_box.on('click', '.expand_translations', function() {
+  dt_admin_modal_box.on('click', '.expand_translations', function () {
     let translation_type = $(this).data('translation-type');
     let post_type = $(this).data('post-type');
     let tile_key = $(this).data('tile-key');
@@ -2036,32 +2535,32 @@ jQuery(document).ready(function($) {
 
     let element_type = '';
     let element_key = '';
-    if ( translation_type === 'tile-label' ) {
+    if (translation_type === 'tile-label') {
       element_type = 'Tile Label';
       element_key = tile_key;
     }
 
-    if ( translation_type === 'tile-description' ) {
+    if (translation_type === 'tile-description') {
       element_type = 'Tile Description';
       element_key = tile_key;
     }
 
-    if ( translation_type === 'field-label' ) {
+    if (translation_type === 'field-label') {
       element_type = 'Field Label';
       element_key = field_key;
     }
 
-    if ( translation_type === 'field-description' ) {
+    if (translation_type === 'field-description') {
       element_type = 'Field Description';
       element_key = field_key;
     }
 
-    if ( translation_type === 'field-option-label' ) {
+    if (translation_type === 'field-option-label') {
       element_type = 'Field Option Label';
       element_key = field_option_key;
     }
 
-    if ( translation_type === 'field-option-description' ) {
+    if (translation_type === 'field-option-description') {
       element_type = 'Field Option Description';
       element_key = field_option_key;
     }
@@ -2072,57 +2571,85 @@ jQuery(document).ready(function($) {
                 <th colspan="2">Translate "${element_key}" ${element_type}</th>
             </tr>`;
 
-    if ( translation_type === 'tile-label' ) {
-      if ( all_settings['post_type_tiles'][tile_key]['translations'] ) {
-        available_translations = all_settings['post_type_tiles'][tile_key]['translations'];
+    if (translation_type === 'tile-label') {
+      if (all_settings['post_type_tiles'][tile_key]['translations']) {
+        available_translations =
+          all_settings['post_type_tiles'][tile_key]['translations'];
       }
     }
 
-    if ( translation_type === 'tile-description' ) {
-      if ( all_settings['post_type_tiles'][tile_key]['description_translations'] ) {
-        available_translations = all_settings['post_type_tiles'][tile_key]['description_translations'];
+    if (translation_type === 'tile-description') {
+      if (
+        all_settings['post_type_tiles'][tile_key]['description_translations']
+      ) {
+        available_translations =
+          all_settings['post_type_tiles'][tile_key]['description_translations'];
       }
     }
 
-    if ( translation_type === 'field-label' ) {
-      if ( field_key === 'undefined' ) {
+    if (translation_type === 'field-label') {
+      if (field_key === 'undefined') {
         return;
       }
-      if ( all_settings.post_type_settings.fields[field_key]['translations'] ) {
-        available_translations = all_settings.post_type_settings.fields[field_key]['translations'];
+      if (all_settings.post_type_settings.fields[field_key]['translations']) {
+        available_translations =
+          all_settings.post_type_settings.fields[field_key]['translations'];
       }
     }
 
-    if ( translation_type === 'field-description' ) {
-      if ( field_key === 'undefined' ) {
+    if (translation_type === 'field-description') {
+      if (field_key === 'undefined') {
         return;
       }
-      if ( all_settings.post_type_settings.fields[field_key]['description_translations'] ) {
-        available_translations = all_settings.post_type_settings.fields[field_key]['description_translations'];
+      if (
+        all_settings.post_type_settings.fields[field_key][
+          'description_translations'
+        ]
+      ) {
+        available_translations =
+          all_settings.post_type_settings.fields[field_key][
+            'description_translations'
+          ];
       }
     }
 
-    if ( translation_type === 'field-option-label' ) {
-      if( field_key === 'undefined' || field_option_key === 'undefined' ) {
+    if (translation_type === 'field-option-label') {
+      if (field_key === 'undefined' || field_option_key === 'undefined') {
         return;
       }
-      if ( all_settings.post_type_settings.fields[field_key]['default'][field_option_key]['translations'] ) {
-        available_translations = all_settings.post_type_settings.fields[field_key]['default'][field_option_key]['translations'];
+      if (
+        all_settings.post_type_settings.fields[field_key]['default'][
+          field_option_key
+        ]['translations']
+      ) {
+        available_translations =
+          all_settings.post_type_settings.fields[field_key]['default'][
+            field_option_key
+          ]['translations'];
       }
     }
 
-    if ( translation_type === 'field-option-description' ) {
-      if ( field_key === 'undefined' ) {
+    if (translation_type === 'field-option-description') {
+      if (field_key === 'undefined') {
         return;
       }
-      if ( all_settings.post_type_settings.fields[field_key]['default'][field_option_key]['description_translations'] ) {
-        available_translations = all_settings.post_type_settings.fields[field_key]['default'][field_option_key]['description_translations'];
+      if (
+        all_settings.post_type_settings.fields[field_key]['default'][
+          field_option_key
+        ]['description_translations']
+      ) {
+        available_translations =
+          all_settings.post_type_settings.fields[field_key]['default'][
+            field_option_key
+          ]['description_translations'];
       }
     }
 
     let current_translation = '';
-    $.each( languages, function(key, lang) {
-      available_translations[key] ? current_translation = available_translations[key] : current_translation = '';
+    $.each(languages, function (key, lang) {
+      available_translations[key]
+        ? (current_translation = available_translations[key])
+        : (current_translation = '');
       translations_html += `
           <tr>
               <td><label for="tile_label_translation-${key}">${lang['flag']} ${lang['native_name']}</label></td>
@@ -2140,98 +2667,175 @@ jQuery(document).ready(function($) {
     enableModalBackDiv('modal-back-translations');
     $('#modal-translations-overlay-form').html(translations_html);
     flip_card();
-
   });
 
-  $('.dt-admin-modal-translations-box-close-button').on('click', function(evt) {
-    evt.preventDefault();
-    unflip_card();
-  });
+  $('.dt-admin-modal-translations-box-close-button').on(
+    'click',
+    function (evt) {
+      evt.preventDefault();
+      unflip_card();
+    },
+  );
 
-  $('#modal-translations-overlay-form').on('click', '.cancel-translations-button', function(evt) {
-    evt.preventDefault();
-    unflip_card();
-  });
+  $('#modal-translations-overlay-form').on(
+    'click',
+    '.cancel-translations-button',
+    function (evt) {
+      evt.preventDefault();
+      unflip_card();
+    },
+  );
 
-  $('#modal-translations-overlay-form').on('click', '.save-translations-button', function(evt) {
-    evt.preventDefault();
-    let translation_type = $(this).data('translation-type');
-    let post_type = $(this).data('post-type');
-    let tile_key = $(this).data('tile-key');
-    let field_key = $(this).data('field-key');
-    let field_option_key = $(this).data('field-option-key');
+  $('#modal-translations-overlay-form').on(
+    'click',
+    '.save-translations-button',
+    function (evt) {
+      evt.preventDefault();
+      let translation_type = $(this).data('translation-type');
+      let post_type = $(this).data('post-type');
+      let tile_key = $(this).data('tile-key');
+      let field_key = $(this).data('field-key');
+      let field_option_key = $(this).data('field-option-key');
 
-    let translations = {};
-    let translation_inputs = $('#modal-translations-overlay-form input');
-    $.each(translation_inputs, function(key, t) {
-      let translation_value = $(t).val();
-      let translation_key = $(t).data('translation-key');
-      if (translation_value) {
-        translations[translation_key] = translation_value;
-      }
-    });
+      let translations = {};
+      let translation_inputs = $('#modal-translations-overlay-form input');
+      $.each(translation_inputs, function (key, t) {
+        let translation_value = $(t).val();
+        let translation_key = $(t).data('translation-key');
+        if (translation_value) {
+          translations[translation_key] = translation_value;
+        }
+      });
 
-    translations = JSON.stringify(translations);
-    let element_button_selector = $('.expand_translations[name="translate-label-button"]');
-    window.API.edit_translations(translation_type, post_type, tile_key, translations, field_key, field_option_key).promise().then(function(response) {
-      let translations_count = 0;
-      if ( translation_type === 'tile-label' ) {
-        all_settings['post_type_tiles'][tile_key]['translations'] = response;
-        translations_count = Object.values(all_settings['post_type_tiles'][tile_key]['translations']).filter(function(t) {return t;}).length;
-        element_button_selector = $('.expand_translations[name="translate-label-button"]');
-      }
+      translations = JSON.stringify(translations);
+      let element_button_selector = $(
+        '.expand_translations[name="translate-label-button"]',
+      );
+      window.API.edit_translations(
+        translation_type,
+        post_type,
+        tile_key,
+        translations,
+        field_key,
+        field_option_key,
+      )
+        .promise()
+        .then(function (response) {
+          let translations_count = 0;
+          if (translation_type === 'tile-label') {
+            all_settings['post_type_tiles'][tile_key]['translations'] =
+              response;
+            translations_count = Object.values(
+              all_settings['post_type_tiles'][tile_key]['translations'],
+            ).filter(function (t) {
+              return t;
+            }).length;
+            element_button_selector = $(
+              '.expand_translations[name="translate-label-button"]',
+            );
+          }
 
-      if ( translation_type === 'tile-description' ) {
-        all_settings['post_type_tiles'][tile_key]['description_translations'] = response;
-        translations_count = Object.values(all_settings['post_type_tiles'][tile_key]['description_translations']).filter(function(t) {return t;}).length;
-        element_button_selector = $('.expand_translations[name="translate-description-button"]');
-      }
+          if (translation_type === 'tile-description') {
+            all_settings['post_type_tiles'][tile_key][
+              'description_translations'
+            ] = response;
+            translations_count = Object.values(
+              all_settings['post_type_tiles'][tile_key][
+                'description_translations'
+              ],
+            ).filter(function (t) {
+              return t;
+            }).length;
+            element_button_selector = $(
+              '.expand_translations[name="translate-description-button"]',
+            );
+          }
 
-      if ( translation_type === 'field-label' ) {
-        all_settings.post_type_settings.fields[field_key]['translations'] = response;
-        translations_count = Object.values(all_settings.post_type_settings.fields[field_key]['translations']).filter(function(t) {return t;}).length;
-        element_button_selector = $('.expand_translations[name="translate-label-button"]');
-      }
+          if (translation_type === 'field-label') {
+            all_settings.post_type_settings.fields[field_key]['translations'] =
+              response;
+            translations_count = Object.values(
+              all_settings.post_type_settings.fields[field_key]['translations'],
+            ).filter(function (t) {
+              return t;
+            }).length;
+            element_button_selector = $(
+              '.expand_translations[name="translate-label-button"]',
+            );
+          }
 
-      if ( translation_type === 'field-description' ) {
-        all_settings.post_type_settings.fields[field_key]['description_translations'] = response;
-        translations_count = Object.values(all_settings.post_type_settings.fields[field_key]['description_translations']).filter(function(t) {return t;}).length;
-        element_button_selector = $('.expand_translations[name="translate-description-button"]');
-      }
+          if (translation_type === 'field-description') {
+            all_settings.post_type_settings.fields[field_key][
+              'description_translations'
+            ] = response;
+            translations_count = Object.values(
+              all_settings.post_type_settings.fields[field_key][
+                'description_translations'
+              ],
+            ).filter(function (t) {
+              return t;
+            }).length;
+            element_button_selector = $(
+              '.expand_translations[name="translate-description-button"]',
+            );
+          }
 
-      if ( translation_type === 'field-option-label' ) {
-        all_settings.post_type_settings.fields[field_key]['default'][field_option_key]['translations'] = response;
-        translations_count = Object.values(all_settings.post_type_settings.fields[field_key]['default'][field_option_key]['translations']).filter(function(t) {return t;}).length;
-        element_button_selector = $('.expand_translations[name="translate-label-button"]');
-      }
+          if (translation_type === 'field-option-label') {
+            all_settings.post_type_settings.fields[field_key]['default'][
+              field_option_key
+            ]['translations'] = response;
+            translations_count = Object.values(
+              all_settings.post_type_settings.fields[field_key]['default'][
+                field_option_key
+              ]['translations'],
+            ).filter(function (t) {
+              return t;
+            }).length;
+            element_button_selector = $(
+              '.expand_translations[name="translate-label-button"]',
+            );
+          }
 
-      if ( translation_type === 'field-option-description' ) {
-        all_settings.post_type_settings.fields[field_key]['default'][field_option_key]['description_translations'] = response;
-        translations_count = Object.values(all_settings.post_type_settings.fields[field_key]['default'][field_option_key]['description_translations']).filter(function(t) {return t;}).length;
-        element_button_selector = $('.expand_translations[name="translate-description-button"]');
-      }
+          if (translation_type === 'field-option-description') {
+            all_settings.post_type_settings.fields[field_key]['default'][
+              field_option_key
+            ]['description_translations'] = response;
+            translations_count = Object.values(
+              all_settings.post_type_settings.fields[field_key]['default'][
+                field_option_key
+              ]['description_translations'],
+            ).filter(function (t) {
+              return t;
+            }).length;
+            element_button_selector = $(
+              '.expand_translations[name="translate-description-button"]',
+            );
+          }
 
-      $(element_button_selector).html(`
+          $(element_button_selector).html(`
           <img style="height: 15px; vertical-align: middle" src="${window.field_settings.template_dir}/dt-assets/images/languages.svg">
                       (${translations_count})
           `);
-      unflip_card();
-    });
-  });
+          unflip_card();
+        });
+    },
+  );
 
-  $('.dt-admin-modal-box-close-button').on('click', function() {
+  $('.dt-admin-modal-box-close-button').on('click', function () {
     closeModal();
   });
-  $(document).on( 'click', '.dt-admin-modal-box-close', function() {
+  $(document).on('click', '.dt-admin-modal-box-close', function () {
     closeModal();
   });
 
-  $('.field-name').on('click', function() {
-    $(this).find('.field-name-icon-arrow:not(.disabled)').toggleClass('arrow-expanded');
+  $('.field-name').on('click', function () {
+    $(this)
+      .find('.field-name-icon-arrow:not(.disabled)')
+      .toggleClass('arrow-expanded');
     $(this).find('.field-elements-list').slideToggle(333, 'swing');
   });
 
-  field_settings_table.on('click', '.new-field-option', function() {
+  field_settings_table.on('click', '.new-field-option', function () {
     let data = [];
     data['tile_key'] = $(this).data('parent-tile-key');
     data['field_key'] = $(this).data('field-key');
@@ -2239,13 +2843,15 @@ jQuery(document).ready(function($) {
   });
 
   // Display 'connected to' dropdown if 'connection' post type field is selected
-  dt_admin_modal_box.on('change', '[id^=new-field-type]', function() {
+  dt_admin_modal_box.on('change', '[id^=new-field-type]', function () {
     let selected_type = $(this).val();
-    if ( window.field_settings.field_types[selected_type]?.description ){
-      $('#field-type-select-description').html(window.field_settings.field_types[selected_type].description);
+    if (window.field_settings.field_types[selected_type]?.description) {
+      $('#field-type-select-description').html(
+        window.field_settings.field_types[selected_type].description,
+      );
     }
 
-    if ( $(this).val() === 'connection' ) {
+    if ($(this).val() === 'connection') {
       $('.connection_field_target_row').show();
     } else {
       $('.connection_field_target_row').hide();
@@ -2255,30 +2861,36 @@ jQuery(document).ready(function($) {
     }
   });
 
-  dt_admin_modal_box.on('change', '#connection-field-target', function() {
+  dt_admin_modal_box.on('change', '#connection-field-target', function () {
     let selected_field_target = $(this).find(':selected').val();
     let same_post_type = selected_field_target === all_settings.post_type;
-    $('.same_post_type_row').toggle( same_post_type );
-    $('.connection_field_reverse_name_row').toggle( !same_post_type );
-    $('#connection_field_reverse_hide_row').toggle( !same_post_type )
+    $('.same_post_type_row').toggle(same_post_type);
+    $('.connection_field_reverse_name_row').toggle(!same_post_type);
+    $('#connection_field_reverse_hide_row').toggle(!same_post_type);
 
     let bidirectional_checked = $('#multidirectional_checkbox').prop('checked');
-    $('#connection_field_reverse_directional_name_row').toggle( same_post_type && !bidirectional_checked );
-    $('#connection_field_hide_reverse_directional_row').toggle( same_post_type && !bidirectional_checked );
+    $('#connection_field_reverse_directional_name_row').toggle(
+      same_post_type && !bidirectional_checked,
+    );
+    $('#connection_field_hide_reverse_directional_row').toggle(
+      same_post_type && !bidirectional_checked,
+    );
 
-    $('.connected_post_type').text(window.field_settings.all_post_types[selected_field_target]);
+    $('.connected_post_type').text(
+      window.field_settings.all_post_types[selected_field_target],
+    );
   });
 
-  dt_admin_modal_box.on('change', '#multidirectional_checkbox', function() {
+  dt_admin_modal_box.on('change', '#multidirectional_checkbox', function () {
     let checked = $(this).prop('checked');
-    $('#connection_field_hide_reverse_directional_row').toggle( !checked )
-    $('#connection_field_reverse_directional_name_row').toggle( !checked )
-  })
+    $('#connection_field_hide_reverse_directional_row').toggle(!checked);
+    $('#connection_field_reverse_directional_name_row').toggle(!checked);
+  });
 
-  dt_admin_modal_box.on('input', '#new-field-name', function() {
+  dt_admin_modal_box.on('input', '#new-field-name', function () {
     $('.loading-spinner').addClass('active');
     let field_name = $(this).val();
-    if ( field_name.length === 0 ) {
+    if (field_name.length === 0) {
       $('#field-exists-message').hide();
       $('#js-add-field').prop('disabled', false);
       $('.loading-spinner').removeClass('active');
@@ -2298,28 +2910,33 @@ jQuery(document).ready(function($) {
 
   $.typeahead({
     input: '.js-typeahead-settings',
-    order: "desc",
+    order: 'desc',
     cancelButton: false,
     dynamic: false,
-    emptyTemplate: '<em style="padding-left:12px;">No results for "{{query}}"</em>',
-    template: '<a href="' + window.location.origin + window.location.pathname + '?page=dt_customizations&post_type={{post_type}}&tab=tiles&tile={{post_tile}}#{{post_setting}}">{{label}}</a>',
+    emptyTemplate:
+      '<em style="padding-left:12px;">No results for "{{query}}"</em>',
+    template:
+      '<a href="' +
+      window.location.origin +
+      window.location.pathname +
+      '?page=dt_customizations&post_type={{post_type}}&tab=tiles&tile={{post_tile}}#{{post_setting}}">{{label}}</a>',
     correlativeTemplate: true,
     source: {
       ajax: {
-        type: "POST",
+        type: 'POST',
         url: window.wpApiSettings.root + 'dt-admin-settings/get-post-fields',
-        beforeSend: function(xhr) {
+        beforeSend: function (xhr) {
           xhr.setRequestHeader('X-WP-Nonce', window.wpApiSettings.nonce);
         },
-      }
+      },
     },
     callback: {
-      onResult: function() {
+      onResult: function () {
         $(`.typeahead__result`).show();
       },
       onHideLayout: function () {
         $(`.typeahead__result`).hide();
-      }
-    }
+      },
+    },
   });
 });

--- a/dt-core/admin/js/dt-shared.js
+++ b/dt-core/admin/js/dt-shared.js
@@ -2,11 +2,16 @@
 This javascript file is enqueued on all admin pages.
 shared scripts applicable to all sections.
  */
-"use strict";
+'use strict';
 
 window.dt_admin_shared = {
   escape(str) {
-    if (typeof str !== "string") return str;
-    return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
-  }
-}
+    if (typeof str !== 'string') return str;
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;');
+  },
+};

--- a/dt-core/admin/js/dt-utilities-scripts.js
+++ b/dt-core/admin/js/dt-utilities-scripts.js
@@ -2,75 +2,95 @@ jQuery(document).ready(function ($) {
   function make_admin_request(type, part, data) {
     const options = {
       type: type,
-      contentType: "application/json; charset=utf-8",
-      dataType: "json",
+      contentType: 'application/json; charset=utf-8',
+      dataType: 'json',
       url: `${window.dt_admin_scripts.rest_root}dt-admin/scripts/${part}`,
       beforeSend: (xhr) => {
-        xhr.setRequestHeader("X-WP-Nonce", window.dt_admin_scripts.nonce);
+        xhr.setRequestHeader('X-WP-Nonce', window.dt_admin_scripts.nonce);
       },
     };
     if (data && !window.lodash.isEmpty(data)) {
-      options.data = type === "GET" ? data : JSON.stringify(data);
+      options.data = type === 'GET' ? data : JSON.stringify(data);
     }
     return jQuery.ajax(options);
   }
 
-
-  $('.reset_count_button').on('click', function (){
-    let post_type = $(this).data('post-type')
-    let field_key = $(this).data('key')
-    $(`#${post_type}_${field_key} .progress .loading-spinner`).addClass( "active" )
-    make_admin_request( "POST", "reset_count_field", { post_type, field_key }).then(resp=>{
-      let interval = setInterval( ()=>{
-        make_admin_request( "GET", 'reset_count_field_progress', { post_type, field_key } ).then(status=>{
-          $(`#${post_type}_${field_key} .progress .current`).text(resp.count - status.count)
-          if ( status.count === 0 ){
-            show_done()
+  $('.reset_count_button').on('click', function () {
+    let post_type = $(this).data('post-type');
+    let field_key = $(this).data('key');
+    $(`#${post_type}_${field_key} .progress .loading-spinner`).addClass(
+      'active',
+    );
+    make_admin_request('POST', 'reset_count_field', {
+      post_type,
+      field_key,
+    }).then((resp) => {
+      let interval = setInterval(() => {
+        make_admin_request('GET', 'reset_count_field_progress', {
+          post_type,
+          field_key,
+        }).then((status) => {
+          $(`#${post_type}_${field_key} .progress .current`).text(
+            resp.count - status.count,
+          );
+          if (status.count === 0) {
+            show_done();
           }
+        });
+      }, 5000);
+      let check_status = function () {
+        make_admin_request('GET', 'reset_count_field_progress', {
+          post_type,
+          field_key,
+          process: true,
         })
-      }, 5000)
-      let check_status = function (){
-        make_admin_request( "GET", 'reset_count_field_progress', { post_type, field_key, process:true } ).then(status=>{
-          $(`#${post_type}_${field_key} .progress .current`).text(resp.count - status.count)
-          if ( status.count === 0 ){
-            show_done()
-          } else {
-            check_status()
-          }
-        }).catch(err=>{
-          if ( err?.statusText === "timeout" ){
-            check_status();
-          }
-        })
-      }
+          .then((status) => {
+            $(`#${post_type}_${field_key} .progress .current`).text(
+              resp.count - status.count,
+            );
+            if (status.count === 0) {
+              show_done();
+            } else {
+              check_status();
+            }
+          })
+          .catch((err) => {
+            if (err?.statusText === 'timeout') {
+              check_status();
+            }
+          });
+      };
       check_status();
-      let show_done = ()=>{
-        $(`#${post_type}_${field_key} .progress .current`).text("done")
-        $(`#${post_type}_${field_key} .progress .total`).text("")
-        clearInterval( interval )
-        $(`#${post_type}_${field_key} .progress .loading-spinner`).removeClass( "active" )
-      }
-      $(`#${post_type}_${field_key} .progress .current`).text( 0 )
-      $(`#${post_type}_${field_key} .progress .total`).text( '/' + resp.count)
-    })
-  })
+      let show_done = () => {
+        $(`#${post_type}_${field_key} .progress .current`).text('done');
+        $(`#${post_type}_${field_key} .progress .total`).text('');
+        clearInterval(interval);
+        $(`#${post_type}_${field_key} .progress .loading-spinner`).removeClass(
+          'active',
+        );
+      };
+      $(`#${post_type}_${field_key} .progress .current`).text(0);
+      $(`#${post_type}_${field_key} .progress .total`).text('/' + resp.count);
+    });
+  });
 
-  $('.process-jobs-button').on('click', function() {
-    $(`#process-jobs-loading-spinner.loading-spinner`).addClass( "active" )
-    make_admin_request("GET", 'process_jobs').then(status => {
-        if (status.success === true) {
-            $('#job-queue-total').text(status.remaining)
-            $('.process-jobs-result-text').html('Done!')
-            $(`#process-jobs-loading-spinner.loading-spinner`).removeClass( "active" )
-        }
-    })
-})
+  $('.process-jobs-button').on('click', function () {
+    $(`#process-jobs-loading-spinner.loading-spinner`).addClass('active');
+    make_admin_request('GET', 'process_jobs').then((status) => {
+      if (status.success === true) {
+        $('#job-queue-total').text(status.remaining);
+        $('.process-jobs-result-text').html('Done!');
+        $(`#process-jobs-loading-spinner.loading-spinner`).removeClass(
+          'active',
+        );
+      }
+    });
+  });
   /**
    * DATA CLEAN-UP
    */
 
   $('.data-clean-up-button').on('click', function () {
-
     // Confirm data clean up is to proceed.
     if (confirm(window.lodash.escape($(this).data('delete_label')) + '?')) {
       let post_type = $(this).data('post_type');
@@ -79,17 +99,17 @@ jQuery(document).ready(function ($) {
 
       // Indicate processing and submit data clean up request.
       $(spinner).addClass('active');
-      make_admin_request( 'POST', 'data_clean_up', { post_type })
-      .then(response => {
-        $(spinner).removeClass('active');
-        $(tr).find('.progress .current').text('done');
-        $(tr).find('.progress .total').text('');
-      });
+      make_admin_request('POST', 'data_clean_up', { post_type }).then(
+        (response) => {
+          $(spinner).removeClass('active');
+          $(tr).find('.progress .current').text('done');
+          $(tr).find('.progress .total').text('');
+        },
+      );
     }
   });
 
   $('#locations-clean-up-button').on('click', function () {
-
     // Confirm data clean up is to proceed.
     if (confirm(window.lodash.escape($(this).data('delete_label')) + '?')) {
       let tr = $(this).parent().parent();
@@ -97,16 +117,13 @@ jQuery(document).ready(function ($) {
 
       // Indicate processing and submit data clean up request.
       $(spinner).addClass('active');
-      make_admin_request( 'POST', 'locations_clean_up')
-      .then(response => {
+      make_admin_request('POST', 'locations_clean_up').then((response) => {
         $(spinner).removeClass('active');
         $(tr).find('.progress .current').text('done');
         $(tr).find('.progress .total').text('');
       });
     }
   });
-
-
 
   /**
    * DATA CLEAN-UP
@@ -120,20 +137,22 @@ jQuery(document).ready(function ($) {
 
     // Fetch handle to key workflow elements
     let parent_form = $("form[name='" + $(e.currentTarget).data('form') + "']");
-    let icon_input = $("input[name='" + $(e.currentTarget).data('icon-input') + "']");
+    let icon_input = $(
+      "input[name='" + $(e.currentTarget).data('icon-input') + "']",
+    );
 
     // Only proceed if we have valid handles
     if (parent_form && icon_input) {
-
       // Build media uploader modal
       let mediaFrame = window.wp.media({
-
         // Accepts [ 'select', 'post', 'image', 'audio', 'video' ]
         // Determines what kind of library should be rendered.
         frame: 'select',
 
         // Modal title.
-        title: window.dt_admin_shared.escape(window.dt_admin_scripts.upload.title),
+        title: window.dt_admin_shared.escape(
+          window.dt_admin_scripts.upload.title,
+        ),
 
         // Enable/disable multiple select
         multiple: false,
@@ -152,18 +171,18 @@ jQuery(document).ready(function ($) {
           search: null,
 
           // Includes media only uploaded to the specified post (ID)
-          uploadedTo: null // wp.media.view.settings.post.id (for current post ID)
+          uploadedTo: null, // wp.media.view.settings.post.id (for current post ID)
         },
 
         button: {
-          text: window.dt_admin_shared.escape(window.dt_admin_scripts.upload.button_txt)
-        }
-
+          text: window.dt_admin_shared.escape(
+            window.dt_admin_scripts.upload.button_txt,
+          ),
+        },
       });
 
       // Handle selected files
       mediaFrame.on('select', function () {
-
         // Fetch and convert selected into json object
         let selected = mediaFrame.state().get('selection').first().toJSON();
 
@@ -172,7 +191,6 @@ jQuery(document).ready(function ($) {
 
         // Auto-submit so as to refresh changes
         parent_form.submit();
-
       });
 
       // Open the media uploader.
@@ -188,36 +206,37 @@ jQuery(document).ready(function ($) {
    */
   $('.color-display-picker').wpColorPicker();
 
-   /**
+  /**
    * Flyout menu
    */
   const details = [...document.querySelectorAll('details.flyout')];
-  document.addEventListener('click', function(e) {
-    if (!details.some(f => f.contains(e.target))) {
-      details.forEach(f => f.removeAttribute('open'));
+  document.addEventListener('click', function (e) {
+    if (!details.some((f) => f.contains(e.target))) {
+      details.forEach((f) => f.removeAttribute('open'));
     } else {
-      details.forEach(f => !f.contains(e.target) ? f.removeAttribute('open') : '');
+      details.forEach((f) =>
+        !f.contains(e.target) ? f.removeAttribute('open') : '',
+      );
     }
-  })
-
+  });
 
   /**
    * Roles manager source filter
    */
-  const filter = document.querySelector('#role-manager #source-filter')
+  const filter = document.querySelector('#role-manager #source-filter');
   if (filter) {
-    const capabilities = document.querySelectorAll('#role-manager .capability')
+    const capabilities = document.querySelectorAll('#role-manager .capability');
     const showCapsForSource = () => {
       capabilities.forEach((capability) => {
         if (capability.dataset.source === filter.value) {
-          capability.classList.remove('hide')
+          capability.classList.remove('hide');
         } else {
-          capability.classList.add('hide')
+          capability.classList.add('hide');
         }
-      })
-    }
-    filter.addEventListener('input', showCapsForSource)
-    showCapsForSource()
+      });
+    };
+    filter.addEventListener('input', showCapsForSource);
+    showCapsForSource();
   }
 
   /**
@@ -231,7 +250,7 @@ jQuery(document).ready(function ($) {
     let services = {};
     let service_id = $(e.currentTarget).data('service_id');
     services[service_id] = {
-      'id': service_id
+      id: service_id,
     };
 
     // Update export form variables and submit.
@@ -243,7 +262,6 @@ jQuery(document).ready(function ($) {
    * DT EXPORTS
    */
 
-
   /**
    * DT IMPORTS
    */
@@ -253,139 +271,216 @@ jQuery(document).ready(function ($) {
     $('.dt-import-post-type-but').css('background-color', '');
     $(post_type_but).css('background-color', '#efe0e3');
 
-    refresh_post_type_meta_details( $(post_type_but).data('post_type') );
+    refresh_post_type_meta_details($(post_type_but).data('post_type'));
   });
 
-  $('#dt_import_details_record_type_settings_checkbox').on('change', function (e) {
-    update_config_selections( $(e.currentTarget).data('post_type'), 'update', update_config_selections_display );
-  });
+  $('#dt_import_details_record_type_settings_checkbox').on(
+    'change',
+    function (e) {
+      update_config_selections(
+        $(e.currentTarget).data('post_type'),
+        'update',
+        update_config_selections_display,
+      );
+    },
+  );
 
-  $(document).on('change', '#dt_import_tiles_fields_table_checkbox', function (e) {
-    const select_all_checkbox = $(e.currentTarget);
+  $(document).on(
+    'change',
+    '#dt_import_tiles_fields_table_checkbox',
+    function (e) {
+      const select_all_checkbox = $(e.currentTarget);
 
-    // Un/Check tile & field elements accordingly.
-    const tile_checkboxes = $('.dt-tile-select-settings-checkbox');
-    const field_checkboxes = $('.dt-tile-select-fields-checkbox');
+      // Un/Check tile & field elements accordingly.
+      const tile_checkboxes = $('.dt-tile-select-settings-checkbox');
+      const field_checkboxes = $('.dt-tile-select-fields-checkbox');
 
-    $(tile_checkboxes).prop('checked', $(select_all_checkbox).prop('checked'));
-    $(field_checkboxes).prop('checked', $(select_all_checkbox).prop('checked'));
+      $(tile_checkboxes).prop(
+        'checked',
+        $(select_all_checkbox).prop('checked'),
+      );
+      $(field_checkboxes).prop(
+        'checked',
+        $(select_all_checkbox).prop('checked'),
+      );
 
-    // Next, iterate over elements and trigger associated change events.
-    $(tile_checkboxes).each(function (idx, tile) {
-      $(tile).trigger('change');
-    });
+      // Next, iterate over elements and trigger associated change events.
+      $(tile_checkboxes).each(function (idx, tile) {
+        $(tile).trigger('change');
+      });
 
-    $(field_checkboxes).each(function (idx, field) {
-      $(field).trigger('change');
-    });
-  });
+      $(field_checkboxes).each(function (idx, field) {
+        $(field).trigger('change');
+      });
+    },
+  );
 
   $(document).on('change', '.dt-tile-select-settings-checkbox', function (e) {
-    update_config_selections( $(e.currentTarget).data('post_type'), 'update', update_config_selections_display );
+    update_config_selections(
+      $(e.currentTarget).data('post_type'),
+      'update',
+      update_config_selections_display,
+    );
   });
 
   $(document).on('change', '.dt-tile-select-fields-checkbox', function (e) {
     let tile_checkbox = $(e.currentTarget);
     let post_type = $(tile_checkbox).data('post_type');
     let tile_id = $(tile_checkbox).data('tile_id');
-    let tile_table = $(`table[data-tile_id="${window.dt_admin_shared.escape(tile_id)}"]`);
+    let tile_table = $(
+      `table[data-tile_id="${window.dt_admin_shared.escape(tile_id)}"]`,
+    );
 
     // Assuming a valid handle to tile table has been found, check field selections accordingly.
-    if ( tile_table ) {
-      $(tile_table).find('input.dt-field-checkbox').prop('checked', $(tile_checkbox).prop('checked'));
-      update_config_selections( post_type, 'update', update_config_selections_display );
+    if (tile_table) {
+      $(tile_table)
+        .find('input.dt-field-checkbox')
+        .prop('checked', $(tile_checkbox).prop('checked'));
+      update_config_selections(
+        post_type,
+        'update',
+        update_config_selections_display,
+      );
     }
   });
 
   $(document).on('click', '.dt-field-checkbox', function (e) {
     let post_type = $(e.currentTarget).data('post_type');
-    update_config_selections( post_type, 'update', update_config_selections_display );
+    update_config_selections(
+      post_type,
+      'update',
+      update_config_selections_display,
+    );
   });
 
   $('#dt_import_submit_but').on('click', function (e) {
     e.preventDefault();
 
     // Prompt user accordingly based on the current shape of things.
-    let dt_import_uploaded_config_selections = JSON.parse( $('#dt_import_uploaded_config_selections').text() );
-    if ( $.isEmptyObject( dt_import_uploaded_config_selections ) ) {
-      alert(`Nothing to import; please ensure valid selections have been made.`);
-
-    } else if ( confirm(`Are you sure you wish to import selected record types, tiles & fields?`) ) {
-
+    let dt_import_uploaded_config_selections = JSON.parse(
+      $('#dt_import_uploaded_config_selections').text(),
+    );
+    if ($.isEmptyObject(dt_import_uploaded_config_selections)) {
+      alert(
+        `Nothing to import; please ensure valid selections have been made.`,
+      );
+    } else if (
+      confirm(
+        `Are you sure you wish to import selected record types, tiles & fields?`,
+      )
+    ) {
       // Update import form variables and submit.
-      $('#dt_import_uploaded_config').val($('#dt_import_uploaded_config_raw').text());
-      $('#dt_import_selections').val(JSON.stringify(dt_import_uploaded_config_selections));
+      $('#dt_import_uploaded_config').val(
+        $('#dt_import_uploaded_config_raw').text(),
+      );
+      $('#dt_import_selections').val(
+        JSON.stringify(dt_import_uploaded_config_selections),
+      );
       $('#dt_import_form').submit();
     }
   });
 
   function auto_select_new_post_types() {
-
     // Ensure a valid config file has been selected and uploaded.
     const dt_import_uploaded_config_raw = $('#dt_import_uploaded_config_raw');
-    if ( $(dt_import_uploaded_config_raw).text() ) {
-      let dt_import_uploaded_config = JSON.parse( atob( $(dt_import_uploaded_config_raw).text(), true ) );
+    if ($(dt_import_uploaded_config_raw).text()) {
+      let dt_import_uploaded_config = JSON.parse(
+        atob($(dt_import_uploaded_config_raw).text(), true),
+      );
 
-      let dt_import_uploaded_config_selections = $('#dt_import_uploaded_config_selections');
-      let config_selections = JSON.parse( $(dt_import_uploaded_config_selections).text() );
+      let dt_import_uploaded_config_selections = $(
+        '#dt_import_uploaded_config_selections',
+      );
+      let config_selections = JSON.parse(
+        $(dt_import_uploaded_config_selections).text(),
+      );
 
-      let dt_import_existing_post_types = JSON.parse( $('#dt_import_existing_post_types').text() );
-      let dt_import_config_setting_keys = JSON.parse( $('#dt_import_config_setting_keys').text() );
+      let dt_import_existing_post_types = JSON.parse(
+        $('#dt_import_existing_post_types').text(),
+      );
+      let dt_import_config_setting_keys = JSON.parse(
+        $('#dt_import_config_setting_keys').text(),
+      );
 
-      if (dt_import_uploaded_config['dt_settings'] && dt_import_uploaded_config['dt_settings'][dt_import_config_setting_keys['post_types_settings_key']] && dt_import_uploaded_config['dt_settings'][dt_import_config_setting_keys['post_types_settings_key']]['values']) {
+      if (
+        dt_import_uploaded_config['dt_settings'] &&
+        dt_import_uploaded_config['dt_settings'][
+          dt_import_config_setting_keys['post_types_settings_key']
+        ] &&
+        dt_import_uploaded_config['dt_settings'][
+          dt_import_config_setting_keys['post_types_settings_key']
+        ]['values']
+      ) {
         let auto_display_post_type = null;
-        for (const [post_type, post_type_config] of Object.entries(dt_import_uploaded_config['dt_settings'][dt_import_config_setting_keys['post_types_settings_key']]['values'])) {
-
+        for (const [post_type, post_type_config] of Object.entries(
+          dt_import_uploaded_config['dt_settings'][
+            dt_import_config_setting_keys['post_types_settings_key']
+          ]['values'],
+        )) {
           // Identify new post types; which will default to an auto selection.
-          if ( !dt_import_existing_post_types.includes(post_type) ) {
-
+          if (!dt_import_existing_post_types.includes(post_type)) {
             // Group fields to tiles and auto select tile meta settings.
-            const tile_buckets = group_tiles_fields_buckets( post_type );
+            const tile_buckets = group_tiles_fields_buckets(post_type);
             let updated_tile_buckets = {};
             for (const [tile, fields] of Object.entries(tile_buckets)) {
               updated_tile_buckets[tile] = {
-                'import_meta': true,
-                'fields': fields
+                import_meta: true,
+                fields: fields,
               };
             }
 
             // Should not be the case, but if so, override pre-existing selections.
             config_selections[post_type] = {
-              'import_meta': true,
-              'tiles': updated_tile_buckets
+              import_meta: true,
+              tiles: updated_tile_buckets,
             };
 
             // Capture post type to be auto displayed.
-            if ( !auto_display_post_type ) {
+            if (!auto_display_post_type) {
               auto_display_post_type = post_type;
             }
           }
         }
 
         // Update config selections and auto display various import views.
-        if ( auto_display_post_type ) {
-          $(dt_import_uploaded_config_selections).text( JSON.stringify( config_selections ) );
-          refresh_post_type_meta_details( auto_display_post_type );
+        if (auto_display_post_type) {
+          $(dt_import_uploaded_config_selections).text(
+            JSON.stringify(config_selections),
+          );
+          refresh_post_type_meta_details(auto_display_post_type);
         }
       }
     }
   }
 
-  function group_tiles_fields_buckets( post_type ) {
-    let dt_import_uploaded_config = JSON.parse( atob( $('#dt_import_uploaded_config_raw').text(), true ) );
-    let dt_import_config_setting_keys = JSON.parse( $('#dt_import_config_setting_keys').text() );
+  function group_tiles_fields_buckets(post_type) {
+    let dt_import_uploaded_config = JSON.parse(
+      atob($('#dt_import_uploaded_config_raw').text(), true),
+    );
+    let dt_import_config_setting_keys = JSON.parse(
+      $('#dt_import_config_setting_keys').text(),
+    );
     let dt_settings = dt_import_uploaded_config['dt_settings'];
-    let tile_settings = dt_settings[dt_import_config_setting_keys['tiles_settings_key']]['values'][post_type];
-    let custom_tile_settings = dt_settings[dt_import_config_setting_keys['custom_tiles_settings_key']]['values'][post_type];
-    let field_settings = dt_settings[dt_import_config_setting_keys['fields_settings_key']]['values'][post_type];
+    let tile_settings =
+      dt_settings[dt_import_config_setting_keys['tiles_settings_key']][
+        'values'
+      ][post_type];
+    let custom_tile_settings =
+      dt_settings[dt_import_config_setting_keys['custom_tiles_settings_key']][
+        'values'
+      ][post_type];
+    let field_settings =
+      dt_settings[dt_import_config_setting_keys['fields_settings_key']][
+        'values'
+      ][post_type];
 
     let is_custom_import = dt_import_config_setting_keys['type'] === 'custom';
 
     // If custom; filter out non-custom fields.
-    if ( is_custom_import ) {
+    if (is_custom_import) {
       let filtered_field_settings = {};
       for (const [field_key, field] of Object.entries(field_settings)) {
-        if ( field['customizable'] && field['customizable'] !== false ) {
+        if (field['customizable'] && field['customizable'] !== false) {
           filtered_field_settings[field_key] = field;
         }
       }
@@ -409,7 +504,7 @@ jQuery(document).ready(function ($) {
     tile_buckets['no_tile'] = no_tile;
 
     // Ensure no custom tiles have been missed!
-    if ( custom_tile_settings ) {
+    if (custom_tile_settings) {
       for (const [tile_key, tile] of Object.entries(custom_tile_settings)) {
         if (tile_buckets[tile_key] === undefined) {
           tile_buckets[tile_key] = [];
@@ -420,43 +515,71 @@ jQuery(document).ready(function ($) {
     return tile_buckets;
   }
 
-  function refresh_post_type_meta_details( post_type ) {
+  function refresh_post_type_meta_details(post_type) {
     let dt_import_post_type_meta_div = $('#dt_import_post_type_meta_div');
     let dt_import_tiles_fields_div = $('#dt_import_tiles_fields_div');
     let dt_import_selections_div = $('#dt_import_selections_div');
-    let dt_import_uploaded_config = JSON.parse( atob( $('#dt_import_uploaded_config_raw').text(), true ) );
-    let dt_import_uploaded_config_selections = JSON.parse( $('#dt_import_uploaded_config_selections').text() );
-    let dt_import_existing_post_types = JSON.parse( $('#dt_import_existing_post_types').text() );
-    let dt_import_config_setting_keys = JSON.parse( $('#dt_import_config_setting_keys').text() );
+    let dt_import_uploaded_config = JSON.parse(
+      atob($('#dt_import_uploaded_config_raw').text(), true),
+    );
+    let dt_import_uploaded_config_selections = JSON.parse(
+      $('#dt_import_uploaded_config_selections').text(),
+    );
+    let dt_import_existing_post_types = JSON.parse(
+      $('#dt_import_existing_post_types').text(),
+    );
+    let dt_import_config_setting_keys = JSON.parse(
+      $('#dt_import_config_setting_keys').text(),
+    );
 
     // Refresh selected post type details.
     $(dt_import_tiles_fields_div).fadeOut('fast');
     $(dt_import_post_type_meta_div).fadeOut('fast', function () {
       let dt_settings = dt_import_uploaded_config['dt_settings'];
-      let post_type_settings = dt_settings[dt_import_config_setting_keys['post_types_settings_key']]['values'][post_type];
-      let custom_post_type_settings = dt_settings[dt_import_config_setting_keys['custom_post_types_settings_key']]['values'][post_type];
+      let post_type_settings =
+        dt_settings[dt_import_config_setting_keys['post_types_settings_key']][
+          'values'
+        ][post_type];
+      let custom_post_type_settings =
+        dt_settings[
+          dt_import_config_setting_keys['custom_post_types_settings_key']
+        ]['values'][post_type];
       let key = post_type_settings['post_type'];
       let already_exists = dt_import_existing_post_types.includes(post_type);
 
       // Default to custom settings, if present.
-      let label_singular = (custom_post_type_settings?.['label_singular']) ? custom_post_type_settings['label_singular'] : post_type_settings['label_singular'];
-      let label_plural = (custom_post_type_settings?.['label_plural']) ? custom_post_type_settings['label_plural'] : post_type_settings['label_plural'];
-      let is_custom = (custom_post_type_settings?.['is_custom']) ? custom_post_type_settings['is_custom'] : post_type_settings['is_custom'];
-      let import_meta = ( dt_import_uploaded_config_selections[post_type]?.['import_meta'] !== undefined );
+      let label_singular = custom_post_type_settings?.['label_singular']
+        ? custom_post_type_settings['label_singular']
+        : post_type_settings['label_singular'];
+      let label_plural = custom_post_type_settings?.['label_plural']
+        ? custom_post_type_settings['label_plural']
+        : post_type_settings['label_plural'];
+      let is_custom = custom_post_type_settings?.['is_custom']
+        ? custom_post_type_settings['is_custom']
+        : post_type_settings['is_custom'];
+      let import_meta =
+        dt_import_uploaded_config_selections[post_type]?.['import_meta'] !==
+        undefined;
 
       $('#dt_import_details_key_td').text(key);
-      $('#dt_import_details_already_installed_td').text(already_exists ? 'Yes' : 'No');
+      $('#dt_import_details_already_installed_td').text(
+        already_exists ? 'Yes' : 'No',
+      );
       $('#dt_import_details_label_singular_td').text(label_singular);
       $('#dt_import_details_label_plural_td').text(label_plural);
-      $('#dt_import_details_record_type_td').text(is_custom ? 'Custom' : 'Default');
+      $('#dt_import_details_record_type_td').text(
+        is_custom ? 'Custom' : 'Default',
+      );
 
       // Any detected selections to result in the displaying of tiles & fields section.
-      let import_record_type_settings_checkbox = $('#dt_import_details_record_type_settings_checkbox');
+      let import_record_type_settings_checkbox = $(
+        '#dt_import_details_record_type_settings_checkbox',
+      );
       $(import_record_type_settings_checkbox).data('post_type', post_type);
       $(import_record_type_settings_checkbox).prop('checked', import_meta);
 
       // Automatically display tiles & fields.
-      refresh_tiles_fields( post_type );
+      refresh_tiles_fields(post_type);
 
       // Display details section.
       $(dt_import_post_type_meta_div).fadeIn('fast');
@@ -464,25 +587,47 @@ jQuery(document).ready(function ($) {
     });
   }
 
-  function refresh_tiles_fields( post_type ) {
+  function refresh_tiles_fields(post_type) {
     let dt_import_tiles_fields_div = $('#dt_import_tiles_fields_div');
-    let dt_import_tiles_fields_content_div = $('#dt_import_tiles_fields_content_div');
-    let dt_import_uploaded_config = JSON.parse( atob( $('#dt_import_uploaded_config_raw').text(), true ) );
-    let dt_import_uploaded_config_selections = JSON.parse( $('#dt_import_uploaded_config_selections').text() );
-    let dt_import_config_setting_keys = JSON.parse( $('#dt_import_config_setting_keys').text() );
+    let dt_import_tiles_fields_content_div = $(
+      '#dt_import_tiles_fields_content_div',
+    );
+    let dt_import_uploaded_config = JSON.parse(
+      atob($('#dt_import_uploaded_config_raw').text(), true),
+    );
+    let dt_import_uploaded_config_selections = JSON.parse(
+      $('#dt_import_uploaded_config_selections').text(),
+    );
+    let dt_import_config_setting_keys = JSON.parse(
+      $('#dt_import_config_setting_keys').text(),
+    );
     let dt_settings = dt_import_uploaded_config['dt_settings'];
-    let tile_settings = dt_settings[dt_import_config_setting_keys['tiles_settings_key']]['values'][post_type];
-    let field_settings = dt_settings[dt_import_config_setting_keys['fields_settings_key']]['values'][post_type];
+    let tile_settings =
+      dt_settings[dt_import_config_setting_keys['tiles_settings_key']][
+        'values'
+      ][post_type];
+    let field_settings =
+      dt_settings[dt_import_config_setting_keys['fields_settings_key']][
+        'values'
+      ][post_type];
 
     $(dt_import_tiles_fields_div).fadeOut('fast', function () {
       $('#dt_import_tiles_fields_table_checkbox').prop('checked', false);
 
       // Next, iterate over tile buckets and display.
       let html = ``;
-      for (const [tile, bucket] of Object.entries(group_tiles_fields_buckets( post_type ))) {
-        let tile_label = (tile === 'no_tile') ? 'No Tile' : tile_settings[tile]['label'];
-        if ( (tile !== 'no_tile') || ((tile === 'no_tile') && (bucket.length > 0)) ) {
-          let import_meta = dt_import_uploaded_config_selections[post_type] && dt_import_uploaded_config_selections[post_type]['tiles'][tile] && dt_import_uploaded_config_selections[post_type]['tiles'][tile]['import_meta'] === true;
+      for (const [tile, bucket] of Object.entries(
+        group_tiles_fields_buckets(post_type),
+      )) {
+        let tile_label =
+          tile === 'no_tile' ? 'No Tile' : tile_settings[tile]['label'];
+        if (tile !== 'no_tile' || (tile === 'no_tile' && bucket.length > 0)) {
+          let import_meta =
+            dt_import_uploaded_config_selections[post_type] &&
+            dt_import_uploaded_config_selections[post_type]['tiles'][tile] &&
+            dt_import_uploaded_config_selections[post_type]['tiles'][tile][
+              'import_meta'
+            ] === true;
 
           html += `
           <table class="widefat striped" style="margin-bottom: 10px;" data-tile_id="${window.dt_admin_shared.escape(tile)}">
@@ -497,13 +642,13 @@ jQuery(document).ready(function ($) {
                           style="margin-right: 4px;"
                           data-post_type="${window.dt_admin_shared.escape(post_type)}"
                           data-tile_id="${window.dt_admin_shared.escape(tile)}"
-                          ${(import_meta) ? 'checked' : ''}/>
+                          ${import_meta ? 'checked' : ''}/>
                     </label>
                 </th>
               </tr>`;
 
-            if (bucket.length > 0) {
-              html += `<tr>
+          if (bucket.length > 0) {
+            html += `<tr>
                   <th></th>
                   <th style="text-align: right;">
                       <label>
@@ -516,15 +661,20 @@ jQuery(document).ready(function ($) {
                       </label>
                   </th>
                 </tr>`;
-            }
+          }
 
-            html += `</thead>
+          html += `</thead>
             <tbody>`;
 
-            bucket.forEach((field_id) => {
-              let checked = (dt_import_uploaded_config_selections[post_type] && dt_import_uploaded_config_selections[post_type]['tiles'][tile] && dt_import_uploaded_config_selections[post_type]['tiles'][tile]['fields'].includes(field_id));
-              let field_name = field_settings[field_id]['name'];
-              html += `
+          bucket.forEach((field_id) => {
+            let checked =
+              dt_import_uploaded_config_selections[post_type] &&
+              dt_import_uploaded_config_selections[post_type]['tiles'][tile] &&
+              dt_import_uploaded_config_selections[post_type]['tiles'][tile][
+                'fields'
+              ].includes(field_id);
+            let field_name = field_settings[field_id]['name'];
+            html += `
               <tr>
                 <td>
                   ${window.dt_admin_shared.escape(field_name)}
@@ -535,19 +685,19 @@ jQuery(document).ready(function ($) {
                             data-post_type="${window.dt_admin_shared.escape(post_type)}"
                             data-tile_id="${window.dt_admin_shared.escape(tile)}"
                             data-field_id="${window.dt_admin_shared.escape(field_id)}"
-                            ${(checked ? 'checked':'')}/>
+                            ${checked ? 'checked' : ''}/>
                 </td>
               </tr>`;
-            });
+          });
 
-            html += `</tbody>
+          html += `</tbody>
           </table>`;
         }
       }
       $(dt_import_tiles_fields_content_div).html(html);
 
       // Update json selections & then refresh display.
-      update_config_selections( post_type, 'update', function() {
+      update_config_selections(post_type, 'update', function () {
         update_config_selections_display();
 
         // Display tiles & fields section.
@@ -557,132 +707,191 @@ jQuery(document).ready(function ($) {
     });
   }
 
-  function update_config_selections( post_type, update_type = 'update', callback = undefined ) {
-    let dt_import_tiles_fields_content_div = $('#dt_import_tiles_fields_content_div');
-    let dt_import_uploaded_config_selections = $('#dt_import_uploaded_config_selections');
-    let config_selections = JSON.parse( $(dt_import_uploaded_config_selections).text() );
+  function update_config_selections(
+    post_type,
+    update_type = 'update',
+    callback = undefined,
+  ) {
+    let dt_import_tiles_fields_content_div = $(
+      '#dt_import_tiles_fields_content_div',
+    );
+    let dt_import_uploaded_config_selections = $(
+      '#dt_import_uploaded_config_selections',
+    );
+    let config_selections = JSON.parse(
+      $(dt_import_uploaded_config_selections).text(),
+    );
 
-    switch( update_type ) {
+    switch (update_type) {
       case 'update': {
-
         // Ensure the has_selection default state, is governed by post type's import_meta flag.
-        let post_type_import_meta = $('#dt_import_details_record_type_settings_checkbox').prop('checked');
+        let post_type_import_meta = $(
+          '#dt_import_details_record_type_settings_checkbox',
+        ).prop('checked');
         let has_selections = post_type_import_meta;
         let updated_tiles = {};
-        $(dt_import_tiles_fields_content_div).find('table').each(function (idx, table) {
+        $(dt_import_tiles_fields_content_div)
+          .find('table')
+          .each(function (idx, table) {
+            // Identify table tile id and meta settings status.
+            const tile_select_settings_checkbox = $(table).find(
+              'input.dt-tile-select-settings-checkbox',
+            );
+            if (tile_select_settings_checkbox) {
+              let tile_import_meta = $(tile_select_settings_checkbox).prop(
+                'checked',
+              );
+              let tile_id = $(tile_select_settings_checkbox).data('tile_id');
+              let selected_fields = [];
 
-          // Identify table tile id and meta settings status.
-          const tile_select_settings_checkbox = $(table).find('input.dt-tile-select-settings-checkbox');
-          if ( tile_select_settings_checkbox ) {
-            let tile_import_meta = $(tile_select_settings_checkbox).prop('checked');
-            let tile_id = $(tile_select_settings_checkbox).data('tile_id');
-            let selected_fields = [];
-
-            // We have a selection if a tile import meta check is detected.
-            if ( tile_import_meta ) {
-              has_selections = true;
-            }
-
-            // Proceed with identifying selected fields.
-            $(table).find('input.dt-field-checkbox').each(function (field_idx, input) {
-
-              // Only concern ourselves with selected fields.
-              if ( $(input).prop('checked') ) {
-                let field_id = $(input).data('field_id');
-                selected_fields.push(field_id);
+              // We have a selection if a tile import meta check is detected.
+              if (tile_import_meta) {
                 has_selections = true;
               }
-            });
 
-            // Only select tiles which have either import meta checked or has selected fields.
-            if ( ( tile_import_meta && tile_import_meta === true ) || selected_fields.length > 0 ) {
-              updated_tiles[tile_id] = {
-                'import_meta': tile_import_meta,
-                'fields': selected_fields
-              };
+              // Proceed with identifying selected fields.
+              $(table)
+                .find('input.dt-field-checkbox')
+                .each(function (field_idx, input) {
+                  // Only concern ourselves with selected fields.
+                  if ($(input).prop('checked')) {
+                    let field_id = $(input).data('field_id');
+                    selected_fields.push(field_id);
+                    has_selections = true;
+                  }
+                });
+
+              // Only select tiles which have either import meta checked or has selected fields.
+              if (
+                (tile_import_meta && tile_import_meta === true) ||
+                selected_fields.length > 0
+              ) {
+                updated_tiles[tile_id] = {
+                  import_meta: tile_import_meta,
+                  fields: selected_fields,
+                };
+              }
             }
-          }
-        });
+          });
 
         // Update global selections shape.
         config_selections[post_type] = {
-          'import_meta': post_type_import_meta,
-          'tiles': updated_tiles
+          import_meta: post_type_import_meta,
+          tiles: updated_tiles,
         };
 
         // If no tile selections have been identified for given post type; delete global config entry.
-        if ( !has_selections ) {
+        if (!has_selections) {
           delete config_selections[post_type];
         }
-        $(dt_import_uploaded_config_selections).text( JSON.stringify( config_selections ) );
+        $(dt_import_uploaded_config_selections).text(
+          JSON.stringify(config_selections),
+        );
         break;
       }
       case 'delete': {
-        if ( config_selections[post_type] ) {
+        if (config_selections[post_type]) {
           delete config_selections[post_type];
-          $(dt_import_uploaded_config_selections).text( JSON.stringify( config_selections ) );
+          $(dt_import_uploaded_config_selections).text(
+            JSON.stringify(config_selections),
+          );
         }
         break;
       }
     }
 
-    if(callback) {
+    if (callback) {
       callback();
     }
   }
 
   function update_config_selections_display() {
-    let dt_import_selections_content_div = $('#dt_import_selections_content_div');
-    let dt_import_uploaded_config = JSON.parse( atob( $('#dt_import_uploaded_config_raw').text(), true ) );
-    let dt_import_uploaded_config_selections = JSON.parse( $('#dt_import_uploaded_config_selections').text() );
-    let dt_import_config_setting_keys = JSON.parse( $('#dt_import_config_setting_keys').text() );
+    let dt_import_selections_content_div = $(
+      '#dt_import_selections_content_div',
+    );
+    let dt_import_uploaded_config = JSON.parse(
+      atob($('#dt_import_uploaded_config_raw').text(), true),
+    );
+    let dt_import_uploaded_config_selections = JSON.parse(
+      $('#dt_import_uploaded_config_selections').text(),
+    );
+    let dt_import_config_setting_keys = JSON.parse(
+      $('#dt_import_config_setting_keys').text(),
+    );
     let dt_settings = dt_import_uploaded_config['dt_settings'];
 
     let html = ``;
 
     // Iterate over selected post types and their corresponding tiles & fields.
-    for (const [post_type, config_selection] of Object.entries(dt_import_uploaded_config_selections)) {
-      let post_type_settings = dt_settings[dt_import_config_setting_keys['post_types_settings_key']]['values'][post_type];
-      let custom_post_type_settings = dt_settings[dt_import_config_setting_keys['custom_post_types_settings_key']]['values'][post_type];
-      let tile_settings = dt_settings[dt_import_config_setting_keys['tiles_settings_key']]['values'][post_type];
-      let custom_tile_settings = dt_settings[dt_import_config_setting_keys['custom_tiles_settings_key']]['values'][post_type];
-      let field_settings = dt_settings[dt_import_config_setting_keys['fields_settings_key']]['values'][post_type];
-      let custom_field_settings = dt_settings[dt_import_config_setting_keys['custom_fields_settings_key']]['values'][post_type];
+    for (const [post_type, config_selection] of Object.entries(
+      dt_import_uploaded_config_selections,
+    )) {
+      let post_type_settings =
+        dt_settings[dt_import_config_setting_keys['post_types_settings_key']][
+          'values'
+        ][post_type];
+      let custom_post_type_settings =
+        dt_settings[
+          dt_import_config_setting_keys['custom_post_types_settings_key']
+        ]['values'][post_type];
+      let tile_settings =
+        dt_settings[dt_import_config_setting_keys['tiles_settings_key']][
+          'values'
+        ][post_type];
+      let custom_tile_settings =
+        dt_settings[dt_import_config_setting_keys['custom_tiles_settings_key']][
+          'values'
+        ][post_type];
+      let field_settings =
+        dt_settings[dt_import_config_setting_keys['fields_settings_key']][
+          'values'
+        ][post_type];
+      let custom_field_settings =
+        dt_settings[
+          dt_import_config_setting_keys['custom_fields_settings_key']
+        ]['values'][post_type];
 
-      if ( post_type_settings && tile_settings && field_settings ) {
-        let post_type_name = post_type_settings['label_plural'] ? post_type_settings['label_plural'] : post_type;
-        if ( custom_post_type_settings?.label_plural ) {
+      if (post_type_settings && tile_settings && field_settings) {
+        let post_type_name = post_type_settings['label_plural']
+          ? post_type_settings['label_plural']
+          : post_type;
+        if (custom_post_type_settings?.label_plural) {
           post_type_name = custom_post_type_settings['label_plural'];
         }
 
         html += `
         <span style="font-weight: bold;">${window.dt_admin_shared.escape(post_type_name)}</span>
-        <span style="float: right;">${ config_selection['import_meta'] ? '<i class="mdi mdi-card-bulleted-outline" style="font-size: 15px;"></i>' : '' }</span>
+        <span style="float: right;">${config_selection['import_meta'] ? '<i class="mdi mdi-card-bulleted-outline" style="font-size: 15px;"></i>' : ''}</span>
         <hr>
         `;
 
         // Proceed with the building of selected tiles & fields.
-        for (const [tile, tile_config_selection] of Object.entries(config_selection['tiles'])) {
+        for (const [tile, tile_config_selection] of Object.entries(
+          config_selection['tiles'],
+        )) {
           let tile_import_meta = tile_config_selection['import_meta'] === true;
           const fields = tile_config_selection['fields'];
-          let tile_label = ( tile === 'no_tile' ) ? 'No Tile' : tile_settings[tile]['label'];
-          if ( custom_tile_settings?.[tile]?.['label'] ) {
+          let tile_label =
+            tile === 'no_tile' ? 'No Tile' : tile_settings[tile]['label'];
+          if (custom_tile_settings?.[tile]?.['label']) {
             tile_label = custom_tile_settings[tile]['label'];
           }
 
-          if ( fields.length > 0 || tile_import_meta ) {
+          if (fields.length > 0 || tile_import_meta) {
             html += `
             <table class="widefat striped" style="margin-bottom: 20px;">
               <thead>
                   <tr>
-                      <th>${window.dt_admin_shared.escape(tile_label)} <span style="float: right;">${ tile_import_meta ? '<i class="mdi mdi-card-bulleted-outline" style="font-size: 15px;"></i>' : '' }</span></th>
+                      <th>${window.dt_admin_shared.escape(tile_label)} <span style="float: right;">${tile_import_meta ? '<i class="mdi mdi-card-bulleted-outline" style="font-size: 15px;"></i>' : ''}</span></th>
                   </tr>
               </thead>
               <tbody>`;
 
             fields.forEach((field_id) => {
-              let field_name = field_settings[field_id]['name'] ? field_settings[field_id]['name'] : field_id;
-              if ( custom_field_settings[field_id]?.name ) {
+              let field_name = field_settings[field_id]['name']
+                ? field_settings[field_id]['name']
+                : field_id;
+              if (custom_field_settings[field_id]?.name) {
                 field_name = custom_field_settings[field_id]['name'];
               }
 
@@ -709,4 +918,4 @@ jQuery(document).ready(function ($) {
   /**
    * DT IMPORTS
    */
-})
+});

--- a/dt-core/admin/js/dt-utilities-workflows.js
+++ b/dt-core/admin/js/dt-utilities-workflows.js
@@ -1,1424 +1,1709 @@
 jQuery(function ($) {
-
-    /*** Event Listeners ***/
-    $(document).on('click', '.workflows-post-types-section-buttons', function (e) {
+  /*** Event Listeners ***/
+  $(document).on(
+    'click',
+    '.workflows-post-types-section-buttons',
+    function (e) {
       handle_workflow_post_type_select(e);
-    });
+    },
+  );
 
-    $(document).on('click', '.workflows-management-section-workflow-name', function (e) {
+  $(document).on(
+    'click',
+    '.workflows-management-section-workflow-name',
+    function (e) {
       handle_workflow_manage_select(e);
-    });
+    },
+  );
 
-    $(document).on('click', '#workflows_management_section_new_but', function () {
-      handle_new_workflow_request();
-    });
+  $(document).on('click', '#workflows_management_section_new_but', function () {
+    handle_new_workflow_request();
+  });
 
-    $(document).on('click', '#workflows_design_section_step1_next_but', function () {
+  $(document).on(
+    'click',
+    '#workflows_design_section_step1_next_but',
+    function () {
       handle_workflow_step1_next_request();
-    });
+    },
+  );
 
-    $(document).on('click', '#workflows_design_section_step2_next_but', function () {
+  $(document).on(
+    'click',
+    '#workflows_design_section_step2_next_but',
+    function () {
       handle_workflow_step2_next_request();
-    });
+    },
+  );
 
-    $(document).on('change', '#workflows_design_section_step2_fields', function () {
-      handle_workflow_step_fields_select(true, $('#workflows_design_section_step2_fields'), $('#workflows_design_section_step2_conditions'), $('#workflows_design_section_step2_condition_value_div'), $('#workflows_design_section_step2_condition_value_id'), $('#workflows_design_section_step2_condition_value_object_id'));
-    });
+  $(document).on(
+    'change',
+    '#workflows_design_section_step2_fields',
+    function () {
+      handle_workflow_step_fields_select(
+        true,
+        $('#workflows_design_section_step2_fields'),
+        $('#workflows_design_section_step2_conditions'),
+        $('#workflows_design_section_step2_condition_value_div'),
+        $('#workflows_design_section_step2_condition_value_id'),
+        $('#workflows_design_section_step2_condition_value_object_id'),
+      );
+    },
+  );
 
-    $(document).on('change', '#workflows_design_section_step2_conditions', function () {
+  $(document).on(
+    'change',
+    '#workflows_design_section_step2_conditions',
+    function () {
       handle_workflow_step2_conditions_select();
-    });
+    },
+  );
 
-    $(document).on('click', '#workflows_design_section_step2_condition_add', function () {
+  $(document).on(
+    'click',
+    '#workflows_design_section_step2_condition_add',
+    function () {
       let field_id = $('#workflows_design_section_step2_fields').val();
-      let field_name = $('#workflows_design_section_step2_fields option:selected').text();
+      let field_name = $(
+        '#workflows_design_section_step2_fields option:selected',
+      ).text();
 
       let condition_id = $('#workflows_design_section_step2_conditions').val();
-      let condition_name = $('#workflows_design_section_step2_conditions option:selected').text();
+      let condition_name = $(
+        '#workflows_design_section_step2_conditions option:selected',
+      ).text();
 
-      let condition_value_element = $('#' + $('#workflows_design_section_step2_condition_value_id').val());
+      let condition_value_element = $(
+        '#' + $('#workflows_design_section_step2_condition_value_id').val(),
+      );
       let condition_value_id = null;
       let condition_value_name = null;
 
       // Determine dynamic field element type, in order to know how best to extract values!
-      if (condition_value_element.hasClass('dt-typeahead')) { // Typeahead
-        condition_value_id = $('#workflows_design_section_step2_condition_value_object_id').val();
+      if (condition_value_element.hasClass('dt-typeahead')) {
+        // Typeahead
+        condition_value_id = $(
+          '#workflows_design_section_step2_condition_value_object_id',
+        ).val();
         condition_value_name = condition_value_element.val();
-
-      } else if (condition_value_element.is('select')) { // Select Dropdown
+      } else if (condition_value_element.is('select')) {
+        // Select Dropdown
         condition_value_id = condition_value_element.val();
-        condition_value_name = condition_value_element.find('option:selected').text();
-
-      } else if (condition_value_element.hasClass('dt-datepicker')) { // Date Range Picker
-        condition_value_id = $('#workflows_design_section_step2_condition_value_object_id').val();
+        condition_value_name = condition_value_element
+          .find('option:selected')
+          .text();
+      } else if (condition_value_element.hasClass('dt-datepicker')) {
+        // Date Range Picker
+        condition_value_id = $(
+          '#workflows_design_section_step2_condition_value_object_id',
+        ).val();
         condition_value_name = condition_value_element.val();
-
-      } else { // Regular Textfield
-        condition_value_id = condition_value_name = condition_value_element.val();
+      } else {
+        // Regular Textfield
+        condition_value_id = condition_value_name =
+          condition_value_element.val();
       }
 
-      handle_workflow_step_event_add_request(true, field_id, field_name, condition_id, condition_name, condition_value_id, condition_value_name, $('#workflows_design_section_step2_exception_message'), function () {
-        // Reset values following addition
-        $('#workflows_design_section_step2_fields').val('');
-        $('#workflows_design_section_step2_conditions').val('');
-        let value_div = $('#workflows_design_section_step2_condition_value_div');
-        value_div.html('--- dynamic condition value field ---');
-        value_div.fadeIn('fast');
-        $('#workflows_design_section_step2_exception_message').html('');
-      });
-    });
+      handle_workflow_step_event_add_request(
+        true,
+        field_id,
+        field_name,
+        condition_id,
+        condition_name,
+        condition_value_id,
+        condition_value_name,
+        $('#workflows_design_section_step2_exception_message'),
+        function () {
+          // Reset values following addition
+          $('#workflows_design_section_step2_fields').val('');
+          $('#workflows_design_section_step2_conditions').val('');
+          let value_div = $(
+            '#workflows_design_section_step2_condition_value_div',
+          );
+          value_div.html('--- dynamic condition value field ---');
+          value_div.fadeIn('fast');
+          $('#workflows_design_section_step2_exception_message').html('');
+        },
+      );
+    },
+  );
 
-    $(document).on('click', '.workflows-design-section-step2-condition-remove', function (e) {
+  $(document).on(
+    'click',
+    '.workflows-design-section-step2-condition-remove',
+    function (e) {
       handle_workflow_step_event_remove_request(e);
-    });
+    },
+  );
 
-    $(document).on('click', '#workflows_design_section_step3_next_but', function () {
+  $(document).on(
+    'click',
+    '#workflows_design_section_step3_next_but',
+    function () {
       handle_workflow_step3_next_request();
-    });
+    },
+  );
 
-    $(document).on('change', '#workflows_design_section_step3_fields', function () {
-      handle_workflow_step_fields_select(false, $('#workflows_design_section_step3_fields'), $('#workflows_design_section_step3_actions'), $('#workflows_design_section_step3_action_value_div'), $('#workflows_design_section_step3_action_value_id'), $('#workflows_design_section_step3_action_value_object_id'));
-    });
+  $(document).on(
+    'change',
+    '#workflows_design_section_step3_fields',
+    function () {
+      handle_workflow_step_fields_select(
+        false,
+        $('#workflows_design_section_step3_fields'),
+        $('#workflows_design_section_step3_actions'),
+        $('#workflows_design_section_step3_action_value_div'),
+        $('#workflows_design_section_step3_action_value_id'),
+        $('#workflows_design_section_step3_action_value_object_id'),
+      );
+    },
+  );
 
-    $(document).on('change', '#workflows_design_section_step3_actions', function () {
+  $(document).on(
+    'change',
+    '#workflows_design_section_step3_actions',
+    function () {
       handle_workflow_step3_actions_select();
-    });
+    },
+  );
 
-    $(document).on('click', '#workflows_design_section_step3_action_add', function () {
+  $(document).on(
+    'click',
+    '#workflows_design_section_step3_action_add',
+    function () {
       let field_id = $('#workflows_design_section_step3_fields').val();
-      let field_name = $('#workflows_design_section_step3_fields option:selected').text();
+      let field_name = $(
+        '#workflows_design_section_step3_fields option:selected',
+      ).text();
 
       let action_id = $('#workflows_design_section_step3_actions').val();
-      let action_name = $('#workflows_design_section_step3_actions option:selected').text();
+      let action_name = $(
+        '#workflows_design_section_step3_actions option:selected',
+      ).text();
 
-      let action_value_element = $('#' + $('#workflows_design_section_step3_action_value_id').val());
+      let action_value_element = $(
+        '#' + $('#workflows_design_section_step3_action_value_id').val(),
+      );
       let action_value_id = null;
       let action_value_name = null;
 
       // Determine dynamic field element type, in order to know how best to extract values!
-      if (action_value_element.hasClass('dt-typeahead')) { // Typeahead
-        action_value_id = $('#workflows_design_section_step3_action_value_object_id').val();
+      if (action_value_element.hasClass('dt-typeahead')) {
+        // Typeahead
+        action_value_id = $(
+          '#workflows_design_section_step3_action_value_object_id',
+        ).val();
         action_value_name = action_value_element.val();
-
-      } else if (action_value_element.is('select')) { // Select Dropdown
+      } else if (action_value_element.is('select')) {
+        // Select Dropdown
         action_value_id = action_value_element.val();
         action_value_name = action_value_element.find('option:selected').text();
-
-      } else if (action_value_element.hasClass('dt-datepicker')) { // Date Range Picker
+      } else if (action_value_element.hasClass('dt-datepicker')) {
+        // Date Range Picker
 
         // No need for value entry if unset action!
         if (action_id === 'unset') {
           action_value_id = '--';
           action_value_name = '--';
-
         } else {
-          action_value_id = $('#workflows_design_section_step3_action_value_object_id').val();
-          action_value_name = action_value_id === 'current' ? 'Current' : action_value_element.val();
+          action_value_id = $(
+            '#workflows_design_section_step3_action_value_object_id',
+          ).val();
+          action_value_name =
+            action_value_id === 'current'
+              ? 'Current'
+              : action_value_element.val();
         }
-
-      } else { // Regular Textfield
+      } else {
+        // Regular Textfield
         action_value_id = action_value_name = action_value_element.val();
       }
 
-      handle_workflow_step_event_add_request(false, field_id, field_name, action_id, action_name, action_value_id, action_value_name, $('#workflows_design_section_step3_exception_message'), function () {
-        // Reset values following addition
-        $('#workflows_design_section_step3_fields').val('');
-        $('#workflows_design_section_step3_actions').val('');
-        let value_div = $('#workflows_design_section_step3_action_value_div');
-        value_div.html('--- dynamic action value field ---');
-        value_div.fadeIn('fast');
-        $('#workflows_design_section_step3_exception_message').html('');
-      });
-    });
+      handle_workflow_step_event_add_request(
+        false,
+        field_id,
+        field_name,
+        action_id,
+        action_name,
+        action_value_id,
+        action_value_name,
+        $('#workflows_design_section_step3_exception_message'),
+        function () {
+          // Reset values following addition
+          $('#workflows_design_section_step3_fields').val('');
+          $('#workflows_design_section_step3_actions').val('');
+          let value_div = $('#workflows_design_section_step3_action_value_div');
+          value_div.html('--- dynamic action value field ---');
+          value_div.fadeIn('fast');
+          $('#workflows_design_section_step3_exception_message').html('');
+        },
+      );
+    },
+  );
 
-    $(document).on('click', '.workflows-design-section-step3-action-remove', function (e) {
+  $(document).on(
+    'click',
+    '.workflows-design-section-step3-action-remove',
+    function (e) {
       handle_workflow_step_event_remove_request(e);
-    });
+    },
+  );
 
-    $(document).on('click', '#workflows_design_section_save_but', function () {
-      handle_workflow_save_request();
-    });
+  $(document).on('click', '#workflows_design_section_save_but', function () {
+    handle_workflow_save_request();
+  });
 
-    $(document).on('click', '#workflows_design_section_delete_but', function () {
-      handle_workflow_delete_request();
-    });
+  $(document).on('click', '#workflows_design_section_delete_but', function () {
+    handle_workflow_delete_request();
+  });
 
-    /*** Event Listeners ***/
+  /*** Event Listeners ***/
 
-    /*** Event Listeners - Header Functions ***/
-    function handle_workflow_post_type_select(evt) {
+  /*** Event Listeners - Header Functions ***/
+  function handle_workflow_post_type_select(evt) {
+    // Fetch post type details
+    let post_type_but = $(evt.currentTarget);
+    let td_parent = $(evt.currentTarget.parentNode);
+    let post_type_id = td_parent
+      .find('#workflows_post_types_section_post_type_id')
+      .val();
+    let post_type_name = td_parent
+      .find('#workflows_post_types_section_post_type_name')
+      .val();
 
-      // Fetch post type details
-      let post_type_but = $(evt.currentTarget);
-      let td_parent = $(evt.currentTarget.parentNode);
-      let post_type_id = td_parent.find('#workflows_post_types_section_post_type_id').val();
-      let post_type_name = td_parent.find('#workflows_post_types_section_post_type_name').val();
+    // Assuming we have a valid selection, post request
+    if (post_type_id && post_type_name) {
+      $('#workflows_post_types_section_form_post_type_id').val(post_type_id);
+      $('#workflows_post_types_section_form_post_type_name').val(
+        post_type_name,
+      );
 
-      // Assuming we have a valid selection, post request
-      if (post_type_id && post_type_name) {
-        $('#workflows_post_types_section_form_post_type_id').val(post_type_id);
-        $('#workflows_post_types_section_form_post_type_name').val(post_type_name);
-
-        // Submit selection
-        $('#workflows_post_types_section_form').submit();
-      }
+      // Submit selection
+      $('#workflows_post_types_section_form').submit();
     }
+  }
 
-    function handle_workflow_manage_select(evt) {
-      let workflow_id = $(evt.currentTarget).data('workflowId');
-      let workflow_name = $(evt.currentTarget).data('workflowName');
+  function handle_workflow_manage_select(evt) {
+    let workflow_id = $(evt.currentTarget).data('workflowId');
+    let workflow_name = $(evt.currentTarget).data('workflowName');
 
-      if (workflow_id) {
-
-        // Update hidden workflow id
-        $('#workflows_design_section_hidden_workflow_id').val(workflow_id);
-
-        $('#workflows_design_section_div').fadeOut('slow', function () {
-
-          // Reset associated component views
-          new_workflow_view_reset(function () {
-
-            // Display new workflow canvas
-            $('#workflows_design_section_div').fadeIn('fast', function () {
-
-              // Parse hidden workflows in search of the one!
-              let workflow = find_parsed_workflow(true, workflow_id);
-              if (workflow) {
-
-                display_regular_workflow(workflow);
-
-              } else if (workflow_id.startsWith('default_')) {
-
-                workflow = find_parsed_workflow(false, workflow_id.split('default_')[1]);
-                display_default_workflow(workflow);
-
-              }
-
-              // If still unable to locate a valid workflow, default to just the first step!
-              if (!workflow) {
-                $('#workflows_design_section_step1').fadeIn('fast', function () {
-                });
-              }
-            });
-          });
-        });
-      }
-    }
-
-    function handle_new_workflow_request() {
-
+    if (workflow_id) {
       // Update hidden workflow id
-      $('#workflows_design_section_hidden_workflow_id').val(Math.floor(Date.now() / 1000));
+      $('#workflows_design_section_hidden_workflow_id').val(workflow_id);
 
       $('#workflows_design_section_div').fadeOut('slow', function () {
-
         // Reset associated component views
         new_workflow_view_reset(function () {
-
           // Display new workflow canvas
           $('#workflows_design_section_div').fadeIn('fast', function () {
+            // Parse hidden workflows in search of the one!
+            let workflow = find_parsed_workflow(true, workflow_id);
+            if (workflow) {
+              display_regular_workflow(workflow);
+            } else if (workflow_id.startsWith('default_')) {
+              workflow = find_parsed_workflow(
+                false,
+                workflow_id.split('default_')[1],
+              );
+              display_default_workflow(workflow);
+            }
 
-            // Display step 1
-            $('#workflows_design_section_step1').fadeIn('fast', function () {
-            });
-          });
-        });
-      });
-    }
-
-    function handle_workflow_step1_next_request() {
-      $('#workflows_design_section_step2').slideDown('fast', function () {
-      });
-    }
-
-    function handle_workflow_step2_next_request() {
-      $('#workflows_design_section_step3').slideDown('fast', function () {
-      });
-    }
-
-    function handle_workflow_step_fields_select(is_condition, fields_select, events_select, event_value_div, event_value_id, event_value_object_id) {
-      // Remove current options
-      events_select.find('option[value != ""]').remove();
-
-      if (fields_select.val()) {
-
-        // If valid events found, reset options!
-        let events = fetch_event_options(fields_select.val(), is_condition);
-        if (events) {
-
-          // Append new options
-          events.forEach(function (event, idx) {
-            if (event['id'] && event['name']) {
-              let option = `<option value="${window.dt_admin_shared.escape(event['id'])}">${window.dt_admin_shared.escape(event['name'])}</option>`;
-              events_select.append(option);
+            // If still unable to locate a valid workflow, default to just the first step!
+            if (!workflow) {
+              $('#workflows_design_section_step1').fadeIn(
+                'fast',
+                function () {},
+              );
             }
           });
-        }
-
-        // Determine event value field state
-        determine_event_value_state(fields_select.val(), event_value_div, event_value_id, event_value_object_id);
-
-      }
-
-      // Reset condition selection
-      events_select.val("");
-    }
-
-    function handle_workflow_step2_conditions_select() {
-      let condition = $('#workflows_design_section_step2_conditions').val();
-
-      // Ensure value fields are disabled for is/not_set conditions
-      if ((String(condition) === 'is_set') || (String(condition) === 'not_set')) {
-        $('#workflows_design_section_step2_condition_value_div').fadeOut('fast');
-      } else {
-        $('#workflows_design_section_step2_condition_value_div').fadeIn('fast');
-      }
-    }
-
-    function handle_workflow_step_event_add_request(is_condition, field_id, field_name, event_id, event_name, event_value_id, event_value_name, exception_element, callback) {
-
-      let added_new_row = false;
-      if (field_id && field_name && event_id && event_name) {
-
-        if (is_condition) {
-
-          let add_condition = false;
-
-          // Ignore value on is/not_set conditions
-          if ((String(event_id) === 'is_set') || (String(event_id) === 'not_set')) {
-            event_value_id = '';
-            event_value_name = '';
-            add_condition = true;
-
-          } else {
-            add_condition = ((event_value_id !== null) && (event_value_id !== ''));
-          }
-
-          if (add_condition) {
-            add_new_condition_row(field_id, field_name, event_id, event_name, event_value_id, event_value_name);
-            added_new_row = true;
-          }
-
-        } else if (event_value_id) {
-          add_new_action_row(field_id, field_name, event_id, event_name, event_value_id, event_value_name);
-          added_new_row = true;
-        }
-      }
-
-      // Only trigger callback following successful row addition
-      if (added_new_row) {
-        callback();
-      } else {
-        exception_element.html(`Please select a valid field, ${(is_condition ? 'condition' : 'action')} and value!`);
-      }
-    }
-
-    function handle_workflow_step_event_remove_request(evt) {
-      // Obtain handle onto deleted row
-      let row = evt.currentTarget.parentNode.parentNode.parentNode;
-
-      // Remove row from parent table
-      row.parentNode.removeChild(row);
-    }
-
-    function handle_workflow_step3_actions_select() {
-      let action = $('#workflows_design_section_step3_actions').val();
-
-      // Display valid list of custom actions, accordingly
-      if (String(action) === 'custom') {
-        handle_custom_action_select();
-
-      } else {
-        // Revert back to value field shape based on selected field
-        determine_event_value_state($('#workflows_design_section_step3_fields').val(), $('#workflows_design_section_step3_action_value_div'), $('#workflows_design_section_step3_action_value_id'), $('#workflows_design_section_step3_action_value_object_id'));
-      }
-    }
-
-    function handle_workflow_step3_next_request() {
-      $('#workflows_design_section_step4').slideDown('fast', function () {
-
-        // Display workflow save option
-        $('#workflows_design_section_save_but').fadeIn('fast', function () {
         });
       });
     }
+  }
 
-    /*** Event Listeners - Header Functions ***/
+  function handle_new_workflow_request() {
+    // Update hidden workflow id
+    $('#workflows_design_section_hidden_workflow_id').val(
+      Math.floor(Date.now() / 1000),
+    );
 
+    $('#workflows_design_section_div').fadeOut('slow', function () {
+      // Reset associated component views
+      new_workflow_view_reset(function () {
+        // Display new workflow canvas
+        $('#workflows_design_section_div').fadeIn('fast', function () {
+          // Display step 1
+          $('#workflows_design_section_step1').fadeIn('fast', function () {});
+        });
+      });
+    });
+  }
 
-    /*** Header Functions - Helpers ***/
-    function handle_custom_action_select() {
-      $('#workflows_design_section_step3_action_value_div').fadeOut('fast', function () {
+  function handle_workflow_step1_next_request() {
+    $('#workflows_design_section_step2').slideDown('fast', function () {});
+  }
 
+  function handle_workflow_step2_next_request() {
+    $('#workflows_design_section_step3').slideDown('fast', function () {});
+  }
+
+  function handle_workflow_step_fields_select(
+    is_condition,
+    fields_select,
+    events_select,
+    event_value_div,
+    event_value_id,
+    event_value_object_id,
+  ) {
+    // Remove current options
+    events_select.find('option[value != ""]').remove();
+
+    if (fields_select.val()) {
+      // If valid events found, reset options!
+      let events = fetch_event_options(fields_select.val(), is_condition);
+      if (events) {
+        // Append new options
+        events.forEach(function (event, idx) {
+          if (event['id'] && event['name']) {
+            let option = `<option value="${window.dt_admin_shared.escape(event['id'])}">${window.dt_admin_shared.escape(event['name'])}</option>`;
+            events_select.append(option);
+          }
+        });
+      }
+
+      // Determine event value field state
+      determine_event_value_state(
+        fields_select.val(),
+        event_value_div,
+        event_value_id,
+        event_value_object_id,
+      );
+    }
+
+    // Reset condition selection
+    events_select.val('');
+  }
+
+  function handle_workflow_step2_conditions_select() {
+    let condition = $('#workflows_design_section_step2_conditions').val();
+
+    // Ensure value fields are disabled for is/not_set conditions
+    if (String(condition) === 'is_set' || String(condition) === 'not_set') {
+      $('#workflows_design_section_step2_condition_value_div').fadeOut('fast');
+    } else {
+      $('#workflows_design_section_step2_condition_value_div').fadeIn('fast');
+    }
+  }
+
+  function handle_workflow_step_event_add_request(
+    is_condition,
+    field_id,
+    field_name,
+    event_id,
+    event_name,
+    event_value_id,
+    event_value_name,
+    exception_element,
+    callback,
+  ) {
+    let added_new_row = false;
+    if (field_id && field_name && event_id && event_name) {
+      if (is_condition) {
+        let add_condition = false;
+
+        // Ignore value on is/not_set conditions
+        if (String(event_id) === 'is_set' || String(event_id) === 'not_set') {
+          event_value_id = '';
+          event_value_name = '';
+          add_condition = true;
+        } else {
+          add_condition = event_value_id !== null && event_value_id !== '';
+        }
+
+        if (add_condition) {
+          add_new_condition_row(
+            field_id,
+            field_name,
+            event_id,
+            event_name,
+            event_value_id,
+            event_value_name,
+          );
+          added_new_row = true;
+        }
+      } else if (event_value_id) {
+        add_new_action_row(
+          field_id,
+          field_name,
+          event_id,
+          event_name,
+          event_value_id,
+          event_value_name,
+        );
+        added_new_row = true;
+      }
+    }
+
+    // Only trigger callback following successful row addition
+    if (added_new_row) {
+      callback();
+    } else {
+      exception_element.html(
+        `Please select a valid field, ${is_condition ? 'condition' : 'action'} and value!`,
+      );
+    }
+  }
+
+  function handle_workflow_step_event_remove_request(evt) {
+    // Obtain handle onto deleted row
+    let row = evt.currentTarget.parentNode.parentNode.parentNode;
+
+    // Remove row from parent table
+    row.parentNode.removeChild(row);
+  }
+
+  function handle_workflow_step3_actions_select() {
+    let action = $('#workflows_design_section_step3_actions').val();
+
+    // Display valid list of custom actions, accordingly
+    if (String(action) === 'custom') {
+      handle_custom_action_select();
+    } else {
+      // Revert back to value field shape based on selected field
+      determine_event_value_state(
+        $('#workflows_design_section_step3_fields').val(),
+        $('#workflows_design_section_step3_action_value_div'),
+        $('#workflows_design_section_step3_action_value_id'),
+        $('#workflows_design_section_step3_action_value_object_id'),
+      );
+    }
+  }
+
+  function handle_workflow_step3_next_request() {
+    $('#workflows_design_section_step4').slideDown('fast', function () {
+      // Display workflow save option
+      $('#workflows_design_section_save_but').fadeIn('fast', function () {});
+    });
+  }
+
+  /*** Event Listeners - Header Functions ***/
+
+  /*** Header Functions - Helpers ***/
+  function handle_custom_action_select() {
+    $('#workflows_design_section_step3_action_value_div').fadeOut(
+      'fast',
+      function () {
         // Build custom actions select element
-        let custom_actions_select_element = generate_custom_actions_list(window.dt_workflows.workflows_design_section_hidden_custom_actions);
+        let custom_actions_select_element = generate_custom_actions_list(
+          window.dt_workflows.workflows_design_section_hidden_custom_actions,
+        );
         if (custom_actions_select_element) {
           let value_div = $('#workflows_design_section_step3_action_value_div');
 
           // Capture id of generated element for future reference
-          $('#workflows_design_section_step3_action_value_id').val(custom_actions_select_element['id']);
+          $('#workflows_design_section_step3_action_value_id').val(
+            custom_actions_select_element['id'],
+          );
 
           // Display available custom actions
           value_div.html(custom_actions_select_element['html']);
           value_div.fadeIn('fast');
         }
-      });
-    }
-
-    function generate_custom_actions_list(actions) {
-      if (actions) {
-
-        let response = {};
-        response['id'] = Date.now();
-
-        let html = `<select style="min-width: 100%; max-width: 100px;" id="${window.dt_admin_shared.escape(response['id'])}">`;
-        html += '<option disabled selected value="">--- select custom action ---</option>';
-
-        // Iterate over custom actions...
-        for (const [key, action] of Object.entries(actions)) {
-          if (action['id'] && action['name']) {
-            html += `<option value="${window.dt_admin_shared.escape(action['id'])}">${window.dt_admin_shared.escape(action['name'])}</option>`;
-          }
-        }
-
-        html += '</select>';
-
-        response['html'] = html;
-
-        return response;
-      }
-      return null;
-    }
-
-    function find_parsed_workflow(is_regular_workflow, workflow_id) {
-      if (is_regular_workflow) {
-        let parsed_workflows = JSON.parse($('#workflows_management_section_hidden_option_post_type_workflows').val());
-        if (parsed_workflows && parsed_workflows['workflows']) {
-          return parsed_workflows['workflows'][workflow_id];
-        }
-      } else {
-        let parsed_workflows = JSON.parse($('#workflows_management_section_hidden_filtered_workflows_defaults').val());
-
-        let workflow = null;
-        if (parsed_workflows) {
-          parsed_workflows.forEach(function (item) {
-            if (String(item['id']) === String(workflow_id)) {
-              workflow = item;
-            }
-          });
-        }
-        return workflow;
-      }
-
-      return null;
-    }
-
-    function update_default_workflow_state(workflow) {
-      if (workflow) {
-
-        // Fetch latest default workflow option values
-        let parsed_default_options = JSON.parse($('#workflows_management_section_hidden_option_default_workflows').val());
-
-        // Update relevant values
-        let option = (parsed_default_options['workflows']) ? parsed_default_options['workflows'][workflow['id']] : null;
-        if (option) {
-          workflow['enabled'] = option['enabled'];
-        }
-      }
-
-      return workflow;
-    }
-
-    function display_regular_workflow(workflow) {
-      if (workflow) {
-        display_workflow(true, workflow);
-      }
-    }
-
-    function display_default_workflow(workflow) {
-      /*
-       * Apart from setting the default workflow's enabled state,
-       * they will be shown in a read-only capacity, only!
-       *
-       * However, ensure to override configured attributes with most
-       * recent values; where needed!
-       */
-
-      if (workflow) {
-        display_workflow(false, update_default_workflow_state(workflow));
-      }
-    }
-
-    function display_workflow(unlocked, workflow) {
-      // Set step 1 elements and display
-      set_elements_step1(workflow, function () {
-        adjust_elements_step1_locked_state(unlocked, function () {
-          $('#workflows_design_section_step1').fadeIn('fast', function () {
-          });
-        });
-      });
-
-      // Set step 2 elements and display
-      set_elements_step2(workflow, function () {
-        adjust_elements_step2_locked_state(unlocked, handle_workflow_step1_next_request);
-      });
-
-      // Set step 3 elements and display
-      set_elements_step3(workflow, function () {
-        adjust_elements_step3_locked_state(unlocked, handle_workflow_step2_next_request);
-      });
-
-      // Set step 4 elements and display
-      set_elements_step4(workflow, function () {
-        adjust_elements_step4_locked_state(unlocked, handle_workflow_step3_next_request);
-      });
-
-      // Only show workflow-delete option for custom workflows
-      let delete_but = $('#workflows_design_section_delete_but');
-      unlocked ? delete_but.show() : delete_but.hide();
-    }
-
-    function adjust_elements_step1_locked_state(unlock, callback) {
-      $('#workflows_design_section_step1_trigger_created').prop('disabled', !unlock);
-      $('#workflows_design_section_step1_trigger_updated').prop('disabled', !unlock);
-
-      let next_but = $('#workflows_design_section_step1_next_but');
-      unlock ? next_but.show() : next_but.hide();
-
-      callback();
-    }
-
-    function adjust_elements_step2_locked_state(unlock, callback) {
-      let fields_tr = $('#workflows_design_section_step2_fields_tr');
-      let conditions_tr = $('#workflows_design_section_step2_conditions_tr');
-      let condition_value_tr = $('#workflows_design_section_step2_condition_value_tr');
-      let condition_remove_but = $('.workflows-design-section-step2-condition-remove');
-      let next_but = $('#workflows_design_section_step2_next_but');
-
-      unlock ? fields_tr.show() : fields_tr.hide();
-      unlock ? conditions_tr.show() : conditions_tr.hide();
-      unlock ? condition_value_tr.show() : condition_value_tr.hide();
-      unlock ? condition_remove_but.show() : condition_remove_but.hide();
-      unlock ? next_but.show() : next_but.hide();
-
-      callback();
-    }
-
-    function adjust_elements_step3_locked_state(unlock, callback) {
-      let fields_tr = $('#workflows_design_section_step3_fields_tr');
-      let actions_tr = $('#workflows_design_section_step3_actions_tr');
-      let action_value_tr = $('#workflows_design_section_step3_action_value_tr');
-      let action_remove_but = $('.workflows-design-section-step3-action-remove');
-      let next_but = $('#workflows_design_section_step3_next_but');
-
-      unlock ? fields_tr.show() : fields_tr.hide();
-      unlock ? actions_tr.show() : actions_tr.hide();
-      unlock ? action_value_tr.show() : action_value_tr.hide();
-      unlock ? action_remove_but.show() : action_remove_but.hide();
-      unlock ? next_but.show() : next_but.hide();
-
-      callback();
-    }
-
-    function adjust_elements_step4_locked_state(unlock, callback) {
-      $('#workflows_design_section_step4_title').prop('readonly', !unlock);
-
-      callback();
-    }
-
-    function new_workflow_view_reset(callback) {
-
-      // Reset workflow steps
-      $('#workflows_design_section_save_but').fadeOut('fast', function () {
-        $('#workflows_design_section_step4').fadeOut('fast', function () {
-
-          // Reset step 4 elements!
-          adjust_elements_step4_locked_state(true, reset_step4_elements);
-
-          $('#workflows_design_section_step3').fadeOut('fast', function () {
-
-            // Reset step 3 elements!
-            adjust_elements_step3_locked_state(true, reset_step3_elements);
-
-            $('#workflows_design_section_step2').fadeOut('fast', function () {
-
-              // Reset step 2 elements!
-              adjust_elements_step2_locked_state(true, reset_step2_elements);
-
-              $('#workflows_design_section_step1').fadeOut('fast', function () {
-
-                // Reset step 1 elements!
-                adjust_elements_step1_locked_state(true, reset_step1_elements);
-
-                // Execute callback
-                callback();
-              });
-            });
-          });
-        });
-      });
-    }
-
-    function reset_step1_elements() {
-      $('#workflows_design_section_step1_trigger_created').prop('checked', true);
-    }
-
-    function reset_step2_elements() {
-      let fields_select = $('#workflows_design_section_step2_fields');
-      let conditions_select = $('#workflows_design_section_step2_conditions');
-      let conditions_table = $('#workflows_design_section_step2_conditions_table');
-
-      reset_elements(fields_select, conditions_select, conditions_table, function () {
-        let value_div = $('#workflows_design_section_step2_condition_value_div');
-        value_div.html('--- dynamic condition value field ---');
-        value_div.fadeIn('fast');
-        $('#workflows_design_section_step2_exception_message').html('');
-      });
-    }
-
-    function reset_step3_elements() {
-      let fields_select = $('#workflows_design_section_step3_fields');
-      let actions_select = $('#workflows_design_section_step3_actions');
-      let actions_table = $('#workflows_design_section_step3_actions_table');
-
-      reset_elements(fields_select, actions_select, actions_table, function () {
-        let value_div = $('#workflows_design_section_step3_action_value_div');
-        value_div.html('--- dynamic action value field ---');
-        value_div.fadeIn('fast');
-        $('#workflows_design_section_step3_exception_message').html('');
-      });
-    }
-
-    function reset_step4_elements() {
-      $('#workflows_design_section_step4_title').val('');
-      $('#workflows_design_section_step4_enabled').prop('checked', true);
-      $('#workflows_design_section_step4_exception_message').html('');
-    }
-
-    function reset_elements(fields_select, events_select, events_table, callback) {
-      let selected_post_type = $('#workflows_design_section_hidden_selected_post_type_id').val();
-      let post_types = window.dt_workflows.workflows_design_section_hidden_post_types;
-
-      // Remove previous options prior to re-populating
-      fields_select.find('option[value != ""]').remove();
-      events_select.find('option[value != ""]').remove();
-      events_table.find('tbody tr').remove();
-
-      // Re-populate field options
-      let post_type = post_types[selected_post_type];
-      if (post_type) {
-
-        // Sort fields into ascending order
-        let fields = post_type['fields'];
-        fields.sort(function (a, b) {
-          return sort_by_string(a['name'].toUpperCase(), b['name'].toUpperCase());
-        });
-
-        // Add sorted field names
-        fields.forEach(function (field, idx) {
-          if (field['id'] && field['name']) {
-            let option = `<option value="${window.dt_admin_shared.escape(field['id'])}">${window.dt_admin_shared.escape(field['name'])}</option>`;
-            fields_select.append(option);
-          }
-        });
-      }
-
-      // Reset select option selections
-      fields_select.val("");
-      events_select.val("");
-
-      // Trigger callback
-      callback();
-
-    }
-
-    function fetch_event_options(field_id, is_condition) {
-      let selected_post_type = $('#workflows_design_section_hidden_selected_post_type_id').val();
-      let post_types = window.dt_workflows.workflows_design_section_hidden_post_types;
-      let post_field_types = window.dt_workflows.workflows_design_section_hidden_post_field_types;
-
-      let events = [];
-
-      // Need to determine field type in order to identify associated event options
-      let post_type = post_types[selected_post_type];
-      if (post_type) {
-
-        let fields = post_type['fields'];
-        fields.forEach(function (field, idx) {
-          if (field['id'] === field_id) {
-
-            // Return according to field type!
-            if (is_condition) {
-              events = fetch_condition_options(field['type']);
-            } else {
-              events = fetch_action_options(field['type']);
-            }
-          }
-        });
-      }
-
-      return events;
-    }
-
-    function fetch_condition_options(field_type) {
-      let conditions = [];
-
-      let labels = {
-        equals: "Equals",
-        not_equals: "Doesn't equal",
-        contains: "Contains",
-        not_contain: "Doesn't contain",
-        is_set: "Has any value and not empty",
-        not_set: "Has no value or is empty",
-        greater: "Greater than",
-        less: "Less than",
-        greater_equals: "Greater than or equals",
-        less_equals: "Less than or equals",
-      }
-
-      switch (field_type) {
-        case "text":
-          conditions.push(
-            {
-              'id': 'equals',
-              'name': labels.equals
-            },
-            {
-              'id': 'not_equals',
-              'name': labels.not_equals
-            },
-            {
-              'id': 'contains',
-              'name': labels.contains
-            },
-            {
-              'id': 'not_contain',
-              'name': labels.not_contain
-            },
-            {
-              'id': 'is_set',
-              'name': labels.is_set
-            },
-            {
-              'id': 'not_set',
-              'name': labels.not_set
-            }
-          );
-          break;
-        case "number":
-        case "date":
-          conditions.push(
-            {
-              'id': 'equals',
-              'name': labels.equals
-            },
-            {
-              'id': 'not_equals',
-              'name': labels.not_equals
-            },
-            {
-              'id': 'greater',
-              'name': labels.greater
-            },
-            {
-              'id': 'less',
-              'name': labels.less
-            },
-            {
-              'id': 'greater_equals',
-              'name': labels.greater_equals
-            },
-            {
-              'id': 'less_equals',
-              'name': labels.less_equals
-            },
-            {
-              'id': 'is_set',
-              'name': labels.is_set
-            },
-            {
-              'id': 'not_set',
-              'name': labels.not_set
-            }
-          );
-          break;
-        case "boolean":
-          conditions.push(
-            {
-              'id': 'equals',
-              'name': labels.equals
-            },
-            {
-              'id': 'not_equals',
-              'name': labels.not_equals
-            },
-            {
-              'id': 'is_set',
-              'name': labels.is_set
-            },
-            {
-              'id': 'not_set',
-              'name': labels.not_set
-            }
-          );
-          break;
-        case "tags":
-        case "multi_select":
-        case "key_select":
-        case "array":
-        case "task":
-        case "communication_channel":
-        case "location":
-        case "location_meta":
-        case "connection":
-        case "user_select":
-        case "post_user_meta":
-        case "datetime_series":
-        case "hash":
-          conditions.push(
-            {
-              'id': 'contains',
-              'name': labels.contains
-            },
-            {
-              'id': 'not_contain',
-              'name': labels.not_contain
-            },
-            {
-              'id': 'is_set',
-              'name': labels.is_set
-            },
-            {
-              'id': 'not_set',
-              'name': labels.not_set
-            }
-          );
-          break;
-      }
-
-      return conditions;
-    }
-
-    function fetch_action_options(field_type) {
-      let actions = [];
-
-      switch (field_type) {
-        case "text":
-        case "number":
-        case "boolean":
-        case "key_select":
-        case "user_select":
-          actions.push(
-            {
-              'id': 'update',
-              'name': 'Update To'
-            }
-          );
-          break;
-        case "date":
-          actions.push(
-            {
-              'id': 'update',
-              'name': 'Update To'
-            },
-            {
-              'id': 'unset',
-              'name': 'Unset'
-            }
-          );
-          break;
-        case "tags":
-        case "array":
-        case "task":
-        case "communication_channel":
-        case "location":
-        case "location_meta":
-        case "post_user_meta":
-        case "datetime_series":
-        case "hash":
-          actions.push(
-            {
-              'id': 'append',
-              'name': 'Appended With'
-            },
-            {
-              'id': 'remove',
-              'name': 'Removal Of'
-            }
-          );
-          break;
-        case "multi_select":
-          actions.push(
-            {
-              'id': 'append',
-              'name': 'Add'
-            },
-            {
-              'id': 'remove',
-              'name': 'Remove'
-            }
-          );
-          break;
-        case "connection":
-          actions.push(
-            {
-              'id': 'connect',
-              'name': 'Connect To'
-            },
-            {
-              'id': 'remove',
-              'name': 'Removal Of'
-            }
-          );
-          break;
-      }
-
-      // Append custom option if any custom actions are detected
-      let custom_actions = window.dt_workflows.workflows_design_section_hidden_custom_actions;
-      if (custom_actions && custom_actions.length > 0) {
-        actions.push(
-          {
-            'id': 'custom',
-            'name': 'Custom Action'
-          }
-        );
-      }
-
-      return actions;
-    }
-
-    function add_new_condition_row(field_id, field_name, condition_id, condition_name, condition_value_id, condition_value_name) {
-      let html = '<tr>';
-
-      // Field
-      html += '<td style="vertical-align: middle;">';
-      html += `<input id="workflows_design_section_step2_conditions_table_field_id" type="hidden" value="${window.dt_admin_shared.escape(field_id)}">`;
-      html += `<input id="workflows_design_section_step2_conditions_table_field_name" type="hidden" value="${window.dt_admin_shared.escape(field_name)}">`;
-      html += window.dt_admin_shared.escape(field_name);
-      html += '</td>';
-
-      // Condition
-      html += '<td style="vertical-align: middle;">';
-      html += `<input id="workflows_design_section_step2_conditions_table_condition_id" type="hidden" value="${window.dt_admin_shared.escape(condition_id)}">`;
-      html += `<input id="workflows_design_section_step2_conditions_table_condition_name" type="hidden" value="${window.dt_admin_shared.escape(condition_name)}">`;
-      html += window.dt_admin_shared.escape(condition_name);
-      html += '</td>';
-
-      // Value
-      html += '<td style="vertical-align: middle;">';
-      html += `<input id="workflows_design_section_step2_conditions_table_condition_value" type="hidden" value="${window.dt_admin_shared.escape(condition_value_id)}">`;
-      html += `<input id="workflows_design_section_step2_conditions_table_condition_value_name" type="hidden" value="${window.dt_admin_shared.escape(condition_value_name)}">`;
-      html += window.dt_admin_shared.escape(condition_value_name);
-      html += '</td>';
-
-      // Removal Button
-      html += '<td style="vertical-align: middle;">';
-      html += '<span style="float:right;">';
-      html += '<a id="workflows_design_section_step2_condition_remove" class="button float-right workflows-design-section-step2-condition-remove">Remove</a>';
-      html += '</span>';
-      html += '</td>';
-
-      html += '</tr>';
-
-      // Add newly formed row!
-      $('#workflows_design_section_step2_conditions_table tbody').append(html);
-    }
-
-    function add_new_action_row(field_id, field_name, action_id, action_name, action_value_id, action_value_name) {
-      let html = '<tr>';
-
-      // Field
-      html += '<td style="vertical-align: middle;">';
-      html += `<input id="workflows_design_section_step3_actions_table_field_id" type="hidden" value="${window.dt_admin_shared.escape(field_id)}">`;
-      html += `<input id="workflows_design_section_step3_actions_table_field_name" type="hidden" value="${window.dt_admin_shared.escape(field_name)}">`;
-      html += window.dt_admin_shared.escape(field_name);
-      html += '</td>';
-
-      // Condition
-      html += '<td style="vertical-align: middle;">';
-      html += `<input id="workflows_design_section_step3_actions_table_action_id" type="hidden" value="${window.dt_admin_shared.escape(action_id)}">`;
-      html += `<input id="workflows_design_section_step3_actions_table_action_name" type="hidden" value="${window.dt_admin_shared.escape(action_name)}">`;
-      html += window.dt_admin_shared.escape(action_name);
-      html += '</td>';
-
-      // Value
-      html += '<td style="vertical-align: middle;">';
-      html += `<input id="workflows_design_section_step3_actions_table_action_value" type="hidden" value="${window.dt_admin_shared.escape(action_value_id)}">`;
-      html += `<input id="workflows_design_section_step3_actions_table_action_value_name" type="hidden" value="${window.dt_admin_shared.escape(action_value_name)}">`;
-      html += window.dt_admin_shared.escape(action_value_name);
-      html += '</td>';
-
-      // Removal Button
-      html += '<td style="vertical-align: middle;">';
-      html += '<span style="float:right;">';
-      html += '<a id="workflows_design_section_step3_action_remove" class="button float-right workflows-design-section-step3-action-remove">Remove</a>';
-      html += '</span>';
-      html += '</td>';
-
-      html += '</tr>';
-
-      // Add newly formed row!
-      $('#workflows_design_section_step3_actions_table tbody').append(html);
-    }
-
-    function sort_by_string(a, b) {
-      if (a < b) {
-        return -1;
-      }
-      if (a > b) {
-        return 1;
-      }
-
-      // strings must be equal
-      return 0;
-    }
-
-    function handle_workflow_delete_request() {
-      let post_type_id = $('#workflows_design_section_hidden_selected_post_type_id').val();
-      let hidden_workflow_id = $('#workflows_design_section_hidden_workflow_id');
-      let is_regular_workflow = !hidden_workflow_id.val().startsWith('default_');
-      let workflow_id = is_regular_workflow ? hidden_workflow_id.val():hidden_workflow_id.val().split('default_')[1];
-      let workflow_name = $('#workflows_design_section_step4_title').val();
-
-      if (confirm("Are you sure you wish to delete workflow: " + workflow_name)) {
-        let delete_payload = {
-          'post_type_id': post_type_id,
-          'is_regular_workflow': is_regular_workflow,
-          'workflow_id': workflow_id
-        };
-
-        // Package and post delete payload.
-        $('#workflows_design_section_delete_form_payload').val(JSON.stringify(delete_payload));
-        $('#workflows_design_section_delete_form').submit();
-      }
-    }
-
-    function handle_workflow_save_request() {
-
-      // Fetch the various workflow values, to be packaged later
-      let post_type_id = $('#workflows_design_section_hidden_selected_post_type_id').val();
-      let post_type_name = $('#workflows_design_section_hidden_selected_post_type_name').val();
-
-      let hidden_workflow_id = $('#workflows_design_section_hidden_workflow_id');
-      let is_regular_workflow = !hidden_workflow_id.val().startsWith('default_');
-
-      let workflow_id = is_regular_workflow ? hidden_workflow_id.val() : hidden_workflow_id.val().split('default_')[1];
-      let workflow_name = $('#workflows_design_section_step4_title').val();
-      let workflow_enabled = $('#workflows_design_section_step4_enabled').is(':checked');
-
-      let trigger = fetch_trigger_value();
-
-      let conditions = fetch_event_values(
-        'workflows_design_section_step2_conditions_table',
-        'workflows_design_section_step2_conditions_table_field_id',
-        'workflows_design_section_step2_conditions_table_field_name',
-        'workflows_design_section_step2_conditions_table_condition_id',
-        'workflows_design_section_step2_conditions_table_condition_name',
-        'workflows_design_section_step2_conditions_table_condition_value',
-        'workflows_design_section_step2_conditions_table_condition_value_name'
-      );
-
-      let actions = fetch_event_values(
-        'workflows_design_section_step3_actions_table',
-        'workflows_design_section_step3_actions_table_field_id',
-        'workflows_design_section_step3_actions_table_field_name',
-        'workflows_design_section_step3_actions_table_action_id',
-        'workflows_design_section_step3_actions_table_action_name',
-        'workflows_design_section_step3_actions_table_action_value',
-        'workflows_design_section_step3_actions_table_action_value_name'
-      );
-
-      // If all is valid, package into post type workflow object
-      if (post_type_id && post_type_name && workflow_id && workflow_name && trigger && (actions.length > 0)) {
-
-        // Package!
-        let post_type_workflow_obj = {
-          'post_type_id': post_type_id,
-          'post_type_name': post_type_name,
-
-          'is_regular_workflow': is_regular_workflow,
-          'workflow_id': workflow_id,
-          'workflow_name': workflow_name,
-          'workflow_enabled': workflow_enabled,
-
-          'trigger': trigger,
-          'conditions': conditions,
-          'actions': actions
-        };
-        $('#workflows_design_section_form_post_type_workflow').val(JSON.stringify(post_type_workflow_obj));
-
-        // Post!
-        $('#workflows_design_section_form').submit();
-
-      } else {
-        $('#workflows_design_section_step4_exception_message').html('Please ensure a valid workflow name and actions have been selected!');
-      }
-    }
-
-    function fetch_trigger_value() {
-      if ($('#workflows_design_section_step1_trigger_created').is(':checked')) {
-        return 'created';
-
-      } else if ($('#workflows_design_section_step1_trigger_updated').is(':checked')) {
-        return 'updated';
-      }
-
-      return '';
-    }
-
-    function fetch_event_values(id_table, id_field_id, id_field_name, id_event_id, id_event_name, id_event_value, id_event_value_name) {
-      let events = [];
-
-      // Iterate over specified table
-      $('#' + id_table + ' > tbody > tr').each(function (idx, tr) {
-
-        let field_id = $(tr).find('#' + id_field_id).val();
-        let field_name = $(tr).find('#' + id_field_name).val();
-
-        let event_id = $(tr).find('#' + id_event_id).val();
-        let event_name = $(tr).find('#' + id_event_name).val();
-
-        let event_value = $(tr).find('#' + id_event_value).val();
-        let event_value_name = $(tr).find('#' + id_event_value_name).val();
-
-        // Allow blank values on is/not_set conditions
-        let add_event = (String(event_id) === 'is_set') || (String(event_id) === 'not_set') ? true : ((event_value !== null) && (event_value !== ''));
-
-        // Are values valid?
-        if (field_id && field_name && event_id && event_name && add_event) {
-          events.push({
-            'id': event_id,
-            'name': event_name,
-            'value': event_value,
-            'value_name': event_value_name,
-            'field_id': field_id,
-            'field_name': field_name
-          });
-        }
-      });
-
-      return events;
-    }
-
-    function set_elements_step1(workflow, callback) {
-      let trigger = workflow['trigger'];
-      if (trigger === 'created') {
-        $('#workflows_design_section_step1_trigger_created').prop('checked', true);
-
-      } else if (trigger === 'updated') {
-        $('#workflows_design_section_step1_trigger_updated').prop('checked', true);
-      }
-
-      callback();
-    }
-
-    function set_elements_step2(workflow, callback) {
-      let conditions = workflow['conditions'];
-      if (conditions) {
-        conditions.forEach(function (condition) {
-          add_new_condition_row(
-            condition['field_id'],
-            condition['field_name'],
-            condition['id'],
-            condition['name'],
-            condition['value'],
-            condition['value_name']
-          );
-        });
-      }
-
-      callback();
-    }
-
-    function set_elements_step3(workflow, callback) {
-      let actions = workflow['actions'];
-      if (actions) {
-        actions.forEach(function (action) {
-          add_new_action_row(
-            action['field_id'],
-            action['field_name'],
-            action['id'],
-            action['name'],
-            action['value'],
-            action['value_name']
-          );
-        });
-      }
-
-      callback();
-    }
-
-    function set_elements_step4(workflow, callback) {
-      let name = workflow['name'];
-      let enabled = workflow['enabled'];
-
-      $('#workflows_design_section_step4_title').val(name);
-      $('#workflows_design_section_step4_enabled').prop('checked', enabled);
-
-      callback();
-    }
-
-    function determine_event_value_state(field_id, event_value_div, event_value_id, event_value_object_id) {
-      let selected_post_type = $('#workflows_design_section_hidden_selected_post_type_id').val();
-      let post_types = window.dt_workflows.workflows_design_section_hidden_post_types;
-
-      // Determine field's type
-      let post_type = post_types[selected_post_type];
-      if (post_type) {
-
-        let fields = post_type['fields'];
-        fields.forEach(function (field, idx) {
-          if (field['id'] === field_id) {
-
-            // Once field id has been found, determine value field state to be adopted
-            let event_value_field = fetch_event_value_field(post_type['base_url'], field, event_value_object_id);
-            if (event_value_field) {
-
-              // Capture generated event value field's id; to be used during event add request
-              event_value_id.val(event_value_field['id']);
-
-              event_value_div.fadeOut('fast', function () {
-                event_value_div.html(event_value_field['html']);
-
-                // Handle typeahead dynamic fields
-                if (event_value_field['typeahead']) {
-                  handle_event_value_field_typeaheads(post_type['wp_nonce'], event_value_field, event_value_object_id);
-                }
-
-                // Handle datepicker dynamic fields
-                if (event_value_field['datepicker']) {
-                  handle_event_value_field_datepickers(event_value_field, event_value_object_id);
-                }
-
-                // Display dynamic fields
-                event_value_div.fadeIn('fast', function () {
-                });
-              });
-            }
-          }
-        });
-      }
-    }
-
-    function handle_event_value_field_typeaheads(wp_nonce, field, event_value_object_id) {
-
-      if (field['typeahead']) {
-        let typeahead = field['typeahead'];
-
-        // Instantiate the typeahead element
-        let dynamic_field = $('#' + field['id']);
-        let config = {
-          accent: true,
-          minLength: 0,
-          maxItem: 10,
-          dynamic: true,
-          searchOnFocus: true,
-          source: typeahead['endpoint'](wp_nonce),
-          callback: {
-            onClick: function (node, a, item, event) {
-              let id = typeahead['id_func'](item);
-              if (id) {
-                event_value_object_id.val(id);
-              }
-            }
-          }
-        };
-
-        // Determine which item results ordering is to be adopted; if any.
-        if (typeahead['general'] && typeahead['general']['order'] && !window.lodash.isEmpty(typeahead['general']['order'])) {
-          config['order'] = typeahead['general']['order'];
-
-        } else if ((typeahead['general'] === undefined) || (typeahead['general']['order'] === undefined)) {
-          config['order'] = 'asc';
-        }
-
-        // Instantiate...!
-        dynamic_field.typeahead(config);
-      }
-    }
-
-    function handle_event_value_field_datepickers(field, event_value_object_id) {
-
-      let dynamic_field = $('#' + field['id']);
-      let checkbox_field = $('#' + field['id'] + '_current');
-
-      // Instantiate date range picker dynamic field.
-      dynamic_field.daterangepicker({
-        singleDatePicker: true,
-        timePicker: false,
-        locale: {
-          format: 'YYYY-MM-DD'
-        }
-      }, function (start, end, label) {
-        // As we are in single date picker mode, just focus on start date and convert to epoch timestamp.
-        if (start) {
-
-          // Capture timestamp within hidden object id field for further processing downstream.
-          event_value_object_id.val(start.unix());
-        }
-      });
-
-      // Empty field value by default, so as to prompt a selection.
-      dynamic_field.val('');
-
-      // Bind to apply and cancel events and reset
-      dynamic_field.on('apply.daterangepicker', function (ev, picker) {
-        event_value_object_id.val(picker.startDate.unix());
-        checkbox_field.prop('checked', false);
-      });
-
-      dynamic_field.on('cancel.daterangepicker', function (ev, picker) {
-        dynamic_field.val('');
-      });
-
-      checkbox_field.on('change', function () {
-        if ($(this).is(':checked')) {
-          dynamic_field.val(''); // clear datepicker value
-        }
-        event_value_object_id.val('current');
-      })
-    }
-
-    function fetch_event_value_field(base_url, field, event_value_object_id) {
-      switch (field['type']) {
-        case "text":
-        case "number":
-        case "tags":
-        case "communication_channel":
-          return generate_event_value_textfield();
-        case "date":
-          return generate_event_value_datepicker();
-        case "boolean":
-          return generate_event_value_boolean();
-        case "multi_select":
-        case "key_select":
-          return generate_event_value_defaults(field['defaults']);
-        case "location":
-          return generate_event_value_locations(base_url);
-        case "location_meta":
-          return generate_event_value_location_meta(event_value_object_id);
-        case "connection":
-          return generate_event_value_connections(base_url, field);
-        case "user_select":
-          return generate_event_value_user_select(base_url);
-        case "array":
-        case "task":
-        case "post_user_meta":
-        case "datetime_series":
-        case "hash":
-          // Ignored!
-          break;
-      }
-
-      return null;
-    }
-
-    function generate_event_value_textfield() {
-      let response = {};
-      response['id'] = Date.now();
-      response['html'] = `<input type="text" placeholder="Enter a value..." style="min-width: 100%;" id="${window.dt_admin_shared.escape(response['id'])}">`;
-
-      return response;
-    }
-
-    function generate_event_value_datepicker() {
-      let response = {};
-      response['id'] = Date.now();
-      response['html'] = `<input type="text" class="dt-datepicker" placeholder="Enter a date..." style="min-width: 100%;" id="${window.dt_admin_shared.escape(response['id'])}">`;
-      response['html'] += `<label><input type="checkbox" id="${window.dt_admin_shared.escape(response['id'])}_current" > Use current date`;
-      response['datepicker'] = {};
-
-      return response;
-    }
-
-    function generate_event_value_boolean() {
+      },
+    );
+  }
+
+  function generate_custom_actions_list(actions) {
+    if (actions) {
       let response = {};
       response['id'] = Date.now();
 
-      let html = `<select style="min-width: 100%;" id="${window.dt_admin_shared.escape(response['id'])}">`;
-      html += '<option value="true" selected>True</option>';
-      html += '<option value="false">False</option>';
+      let html = `<select style="min-width: 100%; max-width: 100px;" id="${window.dt_admin_shared.escape(response['id'])}">`;
+      html +=
+        '<option disabled selected value="">--- select custom action ---</option>';
+
+      // Iterate over custom actions...
+      for (const [key, action] of Object.entries(actions)) {
+        if (action['id'] && action['name']) {
+          html += `<option value="${window.dt_admin_shared.escape(action['id'])}">${window.dt_admin_shared.escape(action['name'])}</option>`;
+        }
+      }
+
       html += '</select>';
 
       response['html'] = html;
 
       return response;
     }
+    return null;
+  }
 
-    function generate_event_value_defaults(defaults) {
-      if (defaults) {
-
-        let response = {};
-        response['id'] = Date.now();
-
-        let html = `<select style="min-width: 100%; max-width: 100px;" id="${window.dt_admin_shared.escape(response['id'])}">`;
-        html += '<option disabled selected value="">--- select value ---</option>';
-
-        // Iterate over field defaults...
-        for (const [key, value] of Object.entries(defaults)) {
-          html += `<option value="${window.dt_admin_shared.escape(key)}">${window.dt_admin_shared.escape(value['label'])}</option>`;
-        }
-
-        html += '</select>';
-
-        response['html'] = html;
-
-        return response;
+  function find_parsed_workflow(is_regular_workflow, workflow_id) {
+    if (is_regular_workflow) {
+      let parsed_workflows = JSON.parse(
+        $(
+          '#workflows_management_section_hidden_option_post_type_workflows',
+        ).val(),
+      );
+      if (parsed_workflows && parsed_workflows['workflows']) {
+        return parsed_workflows['workflows'][workflow_id];
       }
-      return null;
+    } else {
+      let parsed_workflows = JSON.parse(
+        $(
+          '#workflows_management_section_hidden_filtered_workflows_defaults',
+        ).val(),
+      );
+
+      let workflow = null;
+      if (parsed_workflows) {
+        parsed_workflows.forEach(function (item) {
+          if (String(item['id']) === String(workflow_id)) {
+            workflow = item;
+          }
+        });
+      }
+      return workflow;
     }
 
-    function generate_event_value_location_meta(event_value_object_id) {
+    return null;
+  }
+
+  function update_default_workflow_state(workflow) {
+    if (workflow) {
+      // Fetch latest default workflow option values
+      let parsed_default_options = JSON.parse(
+        $(
+          '#workflows_management_section_hidden_option_default_workflows',
+        ).val(),
+      );
+
+      // Update relevant values
+      let option = parsed_default_options['workflows']
+        ? parsed_default_options['workflows'][workflow['id']]
+        : null;
+      if (option) {
+        workflow['enabled'] = option['enabled'];
+      }
+    }
+
+    return workflow;
+  }
+
+  function display_regular_workflow(workflow) {
+    if (workflow) {
+      display_workflow(true, workflow);
+    }
+  }
+
+  function display_default_workflow(workflow) {
+    /*
+     * Apart from setting the default workflow's enabled state,
+     * they will be shown in a read-only capacity, only!
+     *
+     * However, ensure to override configured attributes with most
+     * recent values; where needed!
+     */
+
+    if (workflow) {
+      display_workflow(false, update_default_workflow_state(workflow));
+    }
+  }
+
+  function display_workflow(unlocked, workflow) {
+    // Set step 1 elements and display
+    set_elements_step1(workflow, function () {
+      adjust_elements_step1_locked_state(unlocked, function () {
+        $('#workflows_design_section_step1').fadeIn('fast', function () {});
+      });
+    });
+
+    // Set step 2 elements and display
+    set_elements_step2(workflow, function () {
+      adjust_elements_step2_locked_state(
+        unlocked,
+        handle_workflow_step1_next_request,
+      );
+    });
+
+    // Set step 3 elements and display
+    set_elements_step3(workflow, function () {
+      adjust_elements_step3_locked_state(
+        unlocked,
+        handle_workflow_step2_next_request,
+      );
+    });
+
+    // Set step 4 elements and display
+    set_elements_step4(workflow, function () {
+      adjust_elements_step4_locked_state(
+        unlocked,
+        handle_workflow_step3_next_request,
+      );
+    });
+
+    // Only show workflow-delete option for custom workflows
+    let delete_but = $('#workflows_design_section_delete_but');
+    unlocked ? delete_but.show() : delete_but.hide();
+  }
+
+  function adjust_elements_step1_locked_state(unlock, callback) {
+    $('#workflows_design_section_step1_trigger_created').prop(
+      'disabled',
+      !unlock,
+    );
+    $('#workflows_design_section_step1_trigger_updated').prop(
+      'disabled',
+      !unlock,
+    );
+
+    let next_but = $('#workflows_design_section_step1_next_but');
+    unlock ? next_but.show() : next_but.hide();
+
+    callback();
+  }
+
+  function adjust_elements_step2_locked_state(unlock, callback) {
+    let fields_tr = $('#workflows_design_section_step2_fields_tr');
+    let conditions_tr = $('#workflows_design_section_step2_conditions_tr');
+    let condition_value_tr = $(
+      '#workflows_design_section_step2_condition_value_tr',
+    );
+    let condition_remove_but = $(
+      '.workflows-design-section-step2-condition-remove',
+    );
+    let next_but = $('#workflows_design_section_step2_next_but');
+
+    unlock ? fields_tr.show() : fields_tr.hide();
+    unlock ? conditions_tr.show() : conditions_tr.hide();
+    unlock ? condition_value_tr.show() : condition_value_tr.hide();
+    unlock ? condition_remove_but.show() : condition_remove_but.hide();
+    unlock ? next_but.show() : next_but.hide();
+
+    callback();
+  }
+
+  function adjust_elements_step3_locked_state(unlock, callback) {
+    let fields_tr = $('#workflows_design_section_step3_fields_tr');
+    let actions_tr = $('#workflows_design_section_step3_actions_tr');
+    let action_value_tr = $('#workflows_design_section_step3_action_value_tr');
+    let action_remove_but = $('.workflows-design-section-step3-action-remove');
+    let next_but = $('#workflows_design_section_step3_next_but');
+
+    unlock ? fields_tr.show() : fields_tr.hide();
+    unlock ? actions_tr.show() : actions_tr.hide();
+    unlock ? action_value_tr.show() : action_value_tr.hide();
+    unlock ? action_remove_but.show() : action_remove_but.hide();
+    unlock ? next_but.show() : next_but.hide();
+
+    callback();
+  }
+
+  function adjust_elements_step4_locked_state(unlock, callback) {
+    $('#workflows_design_section_step4_title').prop('readonly', !unlock);
+
+    callback();
+  }
+
+  function new_workflow_view_reset(callback) {
+    // Reset workflow steps
+    $('#workflows_design_section_save_but').fadeOut('fast', function () {
+      $('#workflows_design_section_step4').fadeOut('fast', function () {
+        // Reset step 4 elements!
+        adjust_elements_step4_locked_state(true, reset_step4_elements);
+
+        $('#workflows_design_section_step3').fadeOut('fast', function () {
+          // Reset step 3 elements!
+          adjust_elements_step3_locked_state(true, reset_step3_elements);
+
+          $('#workflows_design_section_step2').fadeOut('fast', function () {
+            // Reset step 2 elements!
+            adjust_elements_step2_locked_state(true, reset_step2_elements);
+
+            $('#workflows_design_section_step1').fadeOut('fast', function () {
+              // Reset step 1 elements!
+              adjust_elements_step1_locked_state(true, reset_step1_elements);
+
+              // Execute callback
+              callback();
+            });
+          });
+        });
+      });
+    });
+  }
+
+  function reset_step1_elements() {
+    $('#workflows_design_section_step1_trigger_created').prop('checked', true);
+  }
+
+  function reset_step2_elements() {
+    let fields_select = $('#workflows_design_section_step2_fields');
+    let conditions_select = $('#workflows_design_section_step2_conditions');
+    let conditions_table = $(
+      '#workflows_design_section_step2_conditions_table',
+    );
+
+    reset_elements(
+      fields_select,
+      conditions_select,
+      conditions_table,
+      function () {
+        let value_div = $(
+          '#workflows_design_section_step2_condition_value_div',
+        );
+        value_div.html('--- dynamic condition value field ---');
+        value_div.fadeIn('fast');
+        $('#workflows_design_section_step2_exception_message').html('');
+      },
+    );
+  }
+
+  function reset_step3_elements() {
+    let fields_select = $('#workflows_design_section_step3_fields');
+    let actions_select = $('#workflows_design_section_step3_actions');
+    let actions_table = $('#workflows_design_section_step3_actions_table');
+
+    reset_elements(fields_select, actions_select, actions_table, function () {
+      let value_div = $('#workflows_design_section_step3_action_value_div');
+      value_div.html('--- dynamic action value field ---');
+      value_div.fadeIn('fast');
+      $('#workflows_design_section_step3_exception_message').html('');
+    });
+  }
+
+  function reset_step4_elements() {
+    $('#workflows_design_section_step4_title').val('');
+    $('#workflows_design_section_step4_enabled').prop('checked', true);
+    $('#workflows_design_section_step4_exception_message').html('');
+  }
+
+  function reset_elements(
+    fields_select,
+    events_select,
+    events_table,
+    callback,
+  ) {
+    let selected_post_type = $(
+      '#workflows_design_section_hidden_selected_post_type_id',
+    ).val();
+    let post_types =
+      window.dt_workflows.workflows_design_section_hidden_post_types;
+
+    // Remove previous options prior to re-populating
+    fields_select.find('option[value != ""]').remove();
+    events_select.find('option[value != ""]').remove();
+    events_table.find('tbody tr').remove();
+
+    // Re-populate field options
+    let post_type = post_types[selected_post_type];
+    if (post_type) {
+      // Sort fields into ascending order
+      let fields = post_type['fields'];
+      fields.sort(function (a, b) {
+        return sort_by_string(a['name'].toUpperCase(), b['name'].toUpperCase());
+      });
+
+      // Add sorted field names
+      fields.forEach(function (field, idx) {
+        if (field['id'] && field['name']) {
+          let option = `<option value="${window.dt_admin_shared.escape(field['id'])}">${window.dt_admin_shared.escape(field['name'])}</option>`;
+          fields_select.append(option);
+        }
+      });
+    }
+
+    // Reset select option selections
+    fields_select.val('');
+    events_select.val('');
+
+    // Trigger callback
+    callback();
+  }
+
+  function fetch_event_options(field_id, is_condition) {
+    let selected_post_type = $(
+      '#workflows_design_section_hidden_selected_post_type_id',
+    ).val();
+    let post_types =
+      window.dt_workflows.workflows_design_section_hidden_post_types;
+    let post_field_types =
+      window.dt_workflows.workflows_design_section_hidden_post_field_types;
+
+    let events = [];
+
+    // Need to determine field type in order to identify associated event options
+    let post_type = post_types[selected_post_type];
+    if (post_type) {
+      let fields = post_type['fields'];
+      fields.forEach(function (field, idx) {
+        if (field['id'] === field_id) {
+          // Return according to field type!
+          if (is_condition) {
+            events = fetch_condition_options(field['type']);
+          } else {
+            events = fetch_action_options(field['type']);
+          }
+        }
+      });
+    }
+
+    return events;
+  }
+
+  function fetch_condition_options(field_type) {
+    let conditions = [];
+
+    let labels = {
+      equals: 'Equals',
+      not_equals: "Doesn't equal",
+      contains: 'Contains',
+      not_contain: "Doesn't contain",
+      is_set: 'Has any value and not empty',
+      not_set: 'Has no value or is empty',
+      greater: 'Greater than',
+      less: 'Less than',
+      greater_equals: 'Greater than or equals',
+      less_equals: 'Less than or equals',
+    };
+
+    switch (field_type) {
+      case 'text':
+        conditions.push(
+          {
+            id: 'equals',
+            name: labels.equals,
+          },
+          {
+            id: 'not_equals',
+            name: labels.not_equals,
+          },
+          {
+            id: 'contains',
+            name: labels.contains,
+          },
+          {
+            id: 'not_contain',
+            name: labels.not_contain,
+          },
+          {
+            id: 'is_set',
+            name: labels.is_set,
+          },
+          {
+            id: 'not_set',
+            name: labels.not_set,
+          },
+        );
+        break;
+      case 'number':
+      case 'date':
+        conditions.push(
+          {
+            id: 'equals',
+            name: labels.equals,
+          },
+          {
+            id: 'not_equals',
+            name: labels.not_equals,
+          },
+          {
+            id: 'greater',
+            name: labels.greater,
+          },
+          {
+            id: 'less',
+            name: labels.less,
+          },
+          {
+            id: 'greater_equals',
+            name: labels.greater_equals,
+          },
+          {
+            id: 'less_equals',
+            name: labels.less_equals,
+          },
+          {
+            id: 'is_set',
+            name: labels.is_set,
+          },
+          {
+            id: 'not_set',
+            name: labels.not_set,
+          },
+        );
+        break;
+      case 'boolean':
+        conditions.push(
+          {
+            id: 'equals',
+            name: labels.equals,
+          },
+          {
+            id: 'not_equals',
+            name: labels.not_equals,
+          },
+          {
+            id: 'is_set',
+            name: labels.is_set,
+          },
+          {
+            id: 'not_set',
+            name: labels.not_set,
+          },
+        );
+        break;
+      case 'tags':
+      case 'multi_select':
+      case 'key_select':
+      case 'array':
+      case 'task':
+      case 'communication_channel':
+      case 'location':
+      case 'location_meta':
+      case 'connection':
+      case 'user_select':
+      case 'post_user_meta':
+      case 'datetime_series':
+      case 'hash':
+        conditions.push(
+          {
+            id: 'contains',
+            name: labels.contains,
+          },
+          {
+            id: 'not_contain',
+            name: labels.not_contain,
+          },
+          {
+            id: 'is_set',
+            name: labels.is_set,
+          },
+          {
+            id: 'not_set',
+            name: labels.not_set,
+          },
+        );
+        break;
+    }
+
+    return conditions;
+  }
+
+  function fetch_action_options(field_type) {
+    let actions = [];
+
+    switch (field_type) {
+      case 'text':
+      case 'number':
+      case 'boolean':
+      case 'key_select':
+      case 'user_select':
+        actions.push({
+          id: 'update',
+          name: 'Update To',
+        });
+        break;
+      case 'date':
+        actions.push(
+          {
+            id: 'update',
+            name: 'Update To',
+          },
+          {
+            id: 'unset',
+            name: 'Unset',
+          },
+        );
+        break;
+      case 'tags':
+      case 'array':
+      case 'task':
+      case 'communication_channel':
+      case 'location':
+      case 'location_meta':
+      case 'post_user_meta':
+      case 'datetime_series':
+      case 'hash':
+        actions.push(
+          {
+            id: 'append',
+            name: 'Appended With',
+          },
+          {
+            id: 'remove',
+            name: 'Removal Of',
+          },
+        );
+        break;
+      case 'multi_select':
+        actions.push(
+          {
+            id: 'append',
+            name: 'Add',
+          },
+          {
+            id: 'remove',
+            name: 'Remove',
+          },
+        );
+        break;
+      case 'connection':
+        actions.push(
+          {
+            id: 'connect',
+            name: 'Connect To',
+          },
+          {
+            id: 'remove',
+            name: 'Removal Of',
+          },
+        );
+        break;
+    }
+
+    // Append custom option if any custom actions are detected
+    let custom_actions =
+      window.dt_workflows.workflows_design_section_hidden_custom_actions;
+    if (custom_actions && custom_actions.length > 0) {
+      actions.push({
+        id: 'custom',
+        name: 'Custom Action',
+      });
+    }
+
+    return actions;
+  }
+
+  function add_new_condition_row(
+    field_id,
+    field_name,
+    condition_id,
+    condition_name,
+    condition_value_id,
+    condition_value_name,
+  ) {
+    let html = '<tr>';
+
+    // Field
+    html += '<td style="vertical-align: middle;">';
+    html += `<input id="workflows_design_section_step2_conditions_table_field_id" type="hidden" value="${window.dt_admin_shared.escape(field_id)}">`;
+    html += `<input id="workflows_design_section_step2_conditions_table_field_name" type="hidden" value="${window.dt_admin_shared.escape(field_name)}">`;
+    html += window.dt_admin_shared.escape(field_name);
+    html += '</td>';
+
+    // Condition
+    html += '<td style="vertical-align: middle;">';
+    html += `<input id="workflows_design_section_step2_conditions_table_condition_id" type="hidden" value="${window.dt_admin_shared.escape(condition_id)}">`;
+    html += `<input id="workflows_design_section_step2_conditions_table_condition_name" type="hidden" value="${window.dt_admin_shared.escape(condition_name)}">`;
+    html += window.dt_admin_shared.escape(condition_name);
+    html += '</td>';
+
+    // Value
+    html += '<td style="vertical-align: middle;">';
+    html += `<input id="workflows_design_section_step2_conditions_table_condition_value" type="hidden" value="${window.dt_admin_shared.escape(condition_value_id)}">`;
+    html += `<input id="workflows_design_section_step2_conditions_table_condition_value_name" type="hidden" value="${window.dt_admin_shared.escape(condition_value_name)}">`;
+    html += window.dt_admin_shared.escape(condition_value_name);
+    html += '</td>';
+
+    // Removal Button
+    html += '<td style="vertical-align: middle;">';
+    html += '<span style="float:right;">';
+    html +=
+      '<a id="workflows_design_section_step2_condition_remove" class="button float-right workflows-design-section-step2-condition-remove">Remove</a>';
+    html += '</span>';
+    html += '</td>';
+
+    html += '</tr>';
+
+    // Add newly formed row!
+    $('#workflows_design_section_step2_conditions_table tbody').append(html);
+  }
+
+  function add_new_action_row(
+    field_id,
+    field_name,
+    action_id,
+    action_name,
+    action_value_id,
+    action_value_name,
+  ) {
+    let html = '<tr>';
+
+    // Field
+    html += '<td style="vertical-align: middle;">';
+    html += `<input id="workflows_design_section_step3_actions_table_field_id" type="hidden" value="${window.dt_admin_shared.escape(field_id)}">`;
+    html += `<input id="workflows_design_section_step3_actions_table_field_name" type="hidden" value="${window.dt_admin_shared.escape(field_name)}">`;
+    html += window.dt_admin_shared.escape(field_name);
+    html += '</td>';
+
+    // Condition
+    html += '<td style="vertical-align: middle;">';
+    html += `<input id="workflows_design_section_step3_actions_table_action_id" type="hidden" value="${window.dt_admin_shared.escape(action_id)}">`;
+    html += `<input id="workflows_design_section_step3_actions_table_action_name" type="hidden" value="${window.dt_admin_shared.escape(action_name)}">`;
+    html += window.dt_admin_shared.escape(action_name);
+    html += '</td>';
+
+    // Value
+    html += '<td style="vertical-align: middle;">';
+    html += `<input id="workflows_design_section_step3_actions_table_action_value" type="hidden" value="${window.dt_admin_shared.escape(action_value_id)}">`;
+    html += `<input id="workflows_design_section_step3_actions_table_action_value_name" type="hidden" value="${window.dt_admin_shared.escape(action_value_name)}">`;
+    html += window.dt_admin_shared.escape(action_value_name);
+    html += '</td>';
+
+    // Removal Button
+    html += '<td style="vertical-align: middle;">';
+    html += '<span style="float:right;">';
+    html +=
+      '<a id="workflows_design_section_step3_action_remove" class="button float-right workflows-design-section-step3-action-remove">Remove</a>';
+    html += '</span>';
+    html += '</td>';
+
+    html += '</tr>';
+
+    // Add newly formed row!
+    $('#workflows_design_section_step3_actions_table tbody').append(html);
+  }
+
+  function sort_by_string(a, b) {
+    if (a < b) {
+      return -1;
+    }
+    if (a > b) {
+      return 1;
+    }
+
+    // strings must be equal
+    return 0;
+  }
+
+  function handle_workflow_delete_request() {
+    let post_type_id = $(
+      '#workflows_design_section_hidden_selected_post_type_id',
+    ).val();
+    let hidden_workflow_id = $('#workflows_design_section_hidden_workflow_id');
+    let is_regular_workflow = !hidden_workflow_id.val().startsWith('default_');
+    let workflow_id = is_regular_workflow
+      ? hidden_workflow_id.val()
+      : hidden_workflow_id.val().split('default_')[1];
+    let workflow_name = $('#workflows_design_section_step4_title').val();
+
+    if (confirm('Are you sure you wish to delete workflow: ' + workflow_name)) {
+      let delete_payload = {
+        post_type_id: post_type_id,
+        is_regular_workflow: is_regular_workflow,
+        workflow_id: workflow_id,
+      };
+
+      // Package and post delete payload.
+      $('#workflows_design_section_delete_form_payload').val(
+        JSON.stringify(delete_payload),
+      );
+      $('#workflows_design_section_delete_form').submit();
+    }
+  }
+
+  function handle_workflow_save_request() {
+    // Fetch the various workflow values, to be packaged later
+    let post_type_id = $(
+      '#workflows_design_section_hidden_selected_post_type_id',
+    ).val();
+    let post_type_name = $(
+      '#workflows_design_section_hidden_selected_post_type_name',
+    ).val();
+
+    let hidden_workflow_id = $('#workflows_design_section_hidden_workflow_id');
+    let is_regular_workflow = !hidden_workflow_id.val().startsWith('default_');
+
+    let workflow_id = is_regular_workflow
+      ? hidden_workflow_id.val()
+      : hidden_workflow_id.val().split('default_')[1];
+    let workflow_name = $('#workflows_design_section_step4_title').val();
+    let workflow_enabled = $('#workflows_design_section_step4_enabled').is(
+      ':checked',
+    );
+
+    let trigger = fetch_trigger_value();
+
+    let conditions = fetch_event_values(
+      'workflows_design_section_step2_conditions_table',
+      'workflows_design_section_step2_conditions_table_field_id',
+      'workflows_design_section_step2_conditions_table_field_name',
+      'workflows_design_section_step2_conditions_table_condition_id',
+      'workflows_design_section_step2_conditions_table_condition_name',
+      'workflows_design_section_step2_conditions_table_condition_value',
+      'workflows_design_section_step2_conditions_table_condition_value_name',
+    );
+
+    let actions = fetch_event_values(
+      'workflows_design_section_step3_actions_table',
+      'workflows_design_section_step3_actions_table_field_id',
+      'workflows_design_section_step3_actions_table_field_name',
+      'workflows_design_section_step3_actions_table_action_id',
+      'workflows_design_section_step3_actions_table_action_name',
+      'workflows_design_section_step3_actions_table_action_value',
+      'workflows_design_section_step3_actions_table_action_value_name',
+    );
+
+    // If all is valid, package into post type workflow object
+    if (
+      post_type_id &&
+      post_type_name &&
+      workflow_id &&
+      workflow_name &&
+      trigger &&
+      actions.length > 0
+    ) {
+      // Package!
+      let post_type_workflow_obj = {
+        post_type_id: post_type_id,
+        post_type_name: post_type_name,
+
+        is_regular_workflow: is_regular_workflow,
+        workflow_id: workflow_id,
+        workflow_name: workflow_name,
+        workflow_enabled: workflow_enabled,
+
+        trigger: trigger,
+        conditions: conditions,
+        actions: actions,
+      };
+      $('#workflows_design_section_form_post_type_workflow').val(
+        JSON.stringify(post_type_workflow_obj),
+      );
+
+      // Post!
+      $('#workflows_design_section_form').submit();
+    } else {
+      $('#workflows_design_section_step4_exception_message').html(
+        'Please ensure a valid workflow name and actions have been selected!',
+      );
+    }
+  }
+
+  function fetch_trigger_value() {
+    if ($('#workflows_design_section_step1_trigger_created').is(':checked')) {
+      return 'created';
+    } else if (
+      $('#workflows_design_section_step1_trigger_updated').is(':checked')
+    ) {
+      return 'updated';
+    }
+
+    return '';
+  }
+
+  function fetch_event_values(
+    id_table,
+    id_field_id,
+    id_field_name,
+    id_event_id,
+    id_event_name,
+    id_event_value,
+    id_event_value_name,
+  ) {
+    let events = [];
+
+    // Iterate over specified table
+    $('#' + id_table + ' > tbody > tr').each(function (idx, tr) {
+      let field_id = $(tr)
+        .find('#' + id_field_id)
+        .val();
+      let field_name = $(tr)
+        .find('#' + id_field_name)
+        .val();
+
+      let event_id = $(tr)
+        .find('#' + id_event_id)
+        .val();
+      let event_name = $(tr)
+        .find('#' + id_event_name)
+        .val();
+
+      let event_value = $(tr)
+        .find('#' + id_event_value)
+        .val();
+      let event_value_name = $(tr)
+        .find('#' + id_event_value_name)
+        .val();
+
+      // Allow blank values on is/not_set conditions
+      let add_event =
+        String(event_id) === 'is_set' || String(event_id) === 'not_set'
+          ? true
+          : event_value !== null && event_value !== '';
+
+      // Are values valid?
+      if (field_id && field_name && event_id && event_name && add_event) {
+        events.push({
+          id: event_id,
+          name: event_name,
+          value: event_value,
+          value_name: event_value_name,
+          field_id: field_id,
+          field_name: field_name,
+        });
+      }
+    });
+
+    return events;
+  }
+
+  function set_elements_step1(workflow, callback) {
+    let trigger = workflow['trigger'];
+    if (trigger === 'created') {
+      $('#workflows_design_section_step1_trigger_created').prop(
+        'checked',
+        true,
+      );
+    } else if (trigger === 'updated') {
+      $('#workflows_design_section_step1_trigger_updated').prop(
+        'checked',
+        true,
+      );
+    }
+
+    callback();
+  }
+
+  function set_elements_step2(workflow, callback) {
+    let conditions = workflow['conditions'];
+    if (conditions) {
+      conditions.forEach(function (condition) {
+        add_new_condition_row(
+          condition['field_id'],
+          condition['field_name'],
+          condition['id'],
+          condition['name'],
+          condition['value'],
+          condition['value_name'],
+        );
+      });
+    }
+
+    callback();
+  }
+
+  function set_elements_step3(workflow, callback) {
+    let actions = workflow['actions'];
+    if (actions) {
+      actions.forEach(function (action) {
+        add_new_action_row(
+          action['field_id'],
+          action['field_name'],
+          action['id'],
+          action['name'],
+          action['value'],
+          action['value_name'],
+        );
+      });
+    }
+
+    callback();
+  }
+
+  function set_elements_step4(workflow, callback) {
+    let name = workflow['name'];
+    let enabled = workflow['enabled'];
+
+    $('#workflows_design_section_step4_title').val(name);
+    $('#workflows_design_section_step4_enabled').prop('checked', enabled);
+
+    callback();
+  }
+
+  function determine_event_value_state(
+    field_id,
+    event_value_div,
+    event_value_id,
+    event_value_object_id,
+  ) {
+    let selected_post_type = $(
+      '#workflows_design_section_hidden_selected_post_type_id',
+    ).val();
+    let post_types =
+      window.dt_workflows.workflows_design_section_hidden_post_types;
+
+    // Determine field's type
+    let post_type = post_types[selected_post_type];
+    if (post_type) {
+      let fields = post_type['fields'];
+      fields.forEach(function (field, idx) {
+        if (field['id'] === field_id) {
+          // Once field id has been found, determine value field state to be adopted
+          let event_value_field = fetch_event_value_field(
+            post_type['base_url'],
+            field,
+            event_value_object_id,
+          );
+          if (event_value_field) {
+            // Capture generated event value field's id; to be used during event add request
+            event_value_id.val(event_value_field['id']);
+
+            event_value_div.fadeOut('fast', function () {
+              event_value_div.html(event_value_field['html']);
+
+              // Handle typeahead dynamic fields
+              if (event_value_field['typeahead']) {
+                handle_event_value_field_typeaheads(
+                  post_type['wp_nonce'],
+                  event_value_field,
+                  event_value_object_id,
+                );
+              }
+
+              // Handle datepicker dynamic fields
+              if (event_value_field['datepicker']) {
+                handle_event_value_field_datepickers(
+                  event_value_field,
+                  event_value_object_id,
+                );
+              }
+
+              // Display dynamic fields
+              event_value_div.fadeIn('fast', function () {});
+            });
+          }
+        }
+      });
+    }
+  }
+
+  function handle_event_value_field_typeaheads(
+    wp_nonce,
+    field,
+    event_value_object_id,
+  ) {
+    if (field['typeahead']) {
+      let typeahead = field['typeahead'];
+
+      // Instantiate the typeahead element
+      let dynamic_field = $('#' + field['id']);
+      let config = {
+        accent: true,
+        minLength: 0,
+        maxItem: 10,
+        dynamic: true,
+        searchOnFocus: true,
+        source: typeahead['endpoint'](wp_nonce),
+        callback: {
+          onClick: function (node, a, item, event) {
+            let id = typeahead['id_func'](item);
+            if (id) {
+              event_value_object_id.val(id);
+            }
+          },
+        },
+      };
+
+      // Determine which item results ordering is to be adopted; if any.
+      if (
+        typeahead['general'] &&
+        typeahead['general']['order'] &&
+        !window.lodash.isEmpty(typeahead['general']['order'])
+      ) {
+        config['order'] = typeahead['general']['order'];
+      } else if (
+        typeahead['general'] === undefined ||
+        typeahead['general']['order'] === undefined
+      ) {
+        config['order'] = 'asc';
+      }
+
+      // Instantiate...!
+      dynamic_field.typeahead(config);
+    }
+  }
+
+  function handle_event_value_field_datepickers(field, event_value_object_id) {
+    let dynamic_field = $('#' + field['id']);
+    let checkbox_field = $('#' + field['id'] + '_current');
+
+    // Instantiate date range picker dynamic field.
+    dynamic_field.daterangepicker(
+      {
+        singleDatePicker: true,
+        timePicker: false,
+        locale: {
+          format: 'YYYY-MM-DD',
+        },
+      },
+      function (start, end, label) {
+        // As we are in single date picker mode, just focus on start date and convert to epoch timestamp.
+        if (start) {
+          // Capture timestamp within hidden object id field for further processing downstream.
+          event_value_object_id.val(start.unix());
+        }
+      },
+    );
+
+    // Empty field value by default, so as to prompt a selection.
+    dynamic_field.val('');
+
+    // Bind to apply and cancel events and reset
+    dynamic_field.on('apply.daterangepicker', function (ev, picker) {
+      event_value_object_id.val(picker.startDate.unix());
+      checkbox_field.prop('checked', false);
+    });
+
+    dynamic_field.on('cancel.daterangepicker', function (ev, picker) {
+      dynamic_field.val('');
+    });
+
+    checkbox_field.on('change', function () {
+      if ($(this).is(':checked')) {
+        dynamic_field.val(''); // clear datepicker value
+      }
+      event_value_object_id.val('current');
+    });
+  }
+
+  function fetch_event_value_field(base_url, field, event_value_object_id) {
+    switch (field['type']) {
+      case 'text':
+      case 'number':
+      case 'tags':
+      case 'communication_channel':
+        return generate_event_value_textfield();
+      case 'date':
+        return generate_event_value_datepicker();
+      case 'boolean':
+        return generate_event_value_boolean();
+      case 'multi_select':
+      case 'key_select':
+        return generate_event_value_defaults(field['defaults']);
+      case 'location':
+        return generate_event_value_locations(base_url);
+      case 'location_meta':
+        return generate_event_value_location_meta(event_value_object_id);
+      case 'connection':
+        return generate_event_value_connections(base_url, field);
+      case 'user_select':
+        return generate_event_value_user_select(base_url);
+      case 'array':
+      case 'task':
+      case 'post_user_meta':
+      case 'datetime_series':
+      case 'hash':
+        // Ignored!
+        break;
+    }
+
+    return null;
+  }
+
+  function generate_event_value_textfield() {
+    let response = {};
+    response['id'] = Date.now();
+    response['html'] =
+      `<input type="text" placeholder="Enter a value..." style="min-width: 100%;" id="${window.dt_admin_shared.escape(response['id'])}">`;
+
+    return response;
+  }
+
+  function generate_event_value_datepicker() {
+    let response = {};
+    response['id'] = Date.now();
+    response['html'] =
+      `<input type="text" class="dt-datepicker" placeholder="Enter a date..." style="min-width: 100%;" id="${window.dt_admin_shared.escape(response['id'])}">`;
+    response['html'] +=
+      `<label><input type="checkbox" id="${window.dt_admin_shared.escape(response['id'])}_current" > Use current date`;
+    response['datepicker'] = {};
+
+    return response;
+  }
+
+  function generate_event_value_boolean() {
+    let response = {};
+    response['id'] = Date.now();
+
+    let html = `<select style="min-width: 100%;" id="${window.dt_admin_shared.escape(response['id'])}">`;
+    html += '<option value="true" selected>True</option>';
+    html += '<option value="false">False</option>';
+    html += '</select>';
+
+    response['html'] = html;
+
+    return response;
+  }
+
+  function generate_event_value_defaults(defaults) {
+    if (defaults) {
       let response = {};
       response['id'] = Date.now();
 
-      let html = '<div class="typeahead__container"><div class="typeahead__field"><div class="typeahead__query">';
-      html += `<input type="text" class="dt-typeahead" autocomplete="off" placeholder="Start typing a location..." style="min-width: 100%;" id="${window.dt_admin_shared.escape(response['id'])}">`;
-      html += '</div></div></div>';
+      let html = `<select style="min-width: 100%; max-width: 100px;" id="${window.dt_admin_shared.escape(response['id'])}">`;
+      html +=
+        '<option disabled selected value="">--- select value ---</option>';
+
+      // Iterate over field defaults...
+      for (const [key, value] of Object.entries(defaults)) {
+        html += `<option value="${window.dt_admin_shared.escape(key)}">${window.dt_admin_shared.escape(value['label'])}</option>`;
+      }
+
+      html += '</select>';
+
       response['html'] = html;
 
-      // Determine mapping configuration to be used.
-      let config = {};
-      let mappings = window.dt_workflows.mappings;
+      return response;
+    }
+    return null;
+  }
 
-      // -- Google
-      let google_predictions = [];
-      if (mappings['google']['enabled']) {
-        config['endpoint'] = {
-          'filter': false,
-          'display': ['description'],
-          'template': '<span>{{description}}</span>',
-          'by_ajax': false,
-          'ajax': null,
-          'by_data': true,
-          'data': function () {
+  function generate_event_value_location_meta(event_value_object_id) {
+    let response = {};
+    response['id'] = Date.now();
 
-            // Obtain handle to input locations search field.
-            let input = $('#' + response['id']);
-            if (input) {
+    let html =
+      '<div class="typeahead__container"><div class="typeahead__field"><div class="typeahead__query">';
+    html += `<input type="text" class="dt-typeahead" autocomplete="off" placeholder="Start typing a location..." style="min-width: 100%;" id="${window.dt_admin_shared.escape(response['id'])}">`;
+    html += '</div></div></div>';
+    response['html'] = html;
 
-              // Execute predictions google api search.
-              let auto_complete_service = new window.google.maps.places.AutocompleteService();
-              let promise = auto_complete_service.getPlacePredictions({'input': input.val()}, function (predictions, status) {
+    // Determine mapping configuration to be used.
+    let config = {};
+    let mappings = window.dt_workflows.mappings;
+
+    // -- Google
+    let google_predictions = [];
+    if (mappings['google']['enabled']) {
+      config['endpoint'] = {
+        filter: false,
+        display: ['description'],
+        template: '<span>{{description}}</span>',
+        by_ajax: false,
+        ajax: null,
+        by_data: true,
+        data: function () {
+          // Obtain handle to input locations search field.
+          let input = $('#' + response['id']);
+          if (input) {
+            // Execute predictions google api search.
+            let auto_complete_service =
+              new window.google.maps.places.AutocompleteService();
+            let promise = auto_complete_service.getPlacePredictions(
+              { input: input.val() },
+              function (predictions, status) {
                 if (status === 'OK') {
                   google_predictions = predictions;
                 }
-              });
-            }
-
-            // Return current location predictions.
-            return google_predictions;
+              },
+            );
           }
-        };
 
-        config['id_func'] = function (item) {
-          if (item && item['place_id']) {
+          // Return current location predictions.
+          return google_predictions;
+        },
+      };
 
-            // Geocode item place details, for further information extraction; E.g. Lat/Lng.
-            let geocode_service = new window.google.maps.Geocoder()
-            geocode_service.geocode({'placeId': item['place_id']}, function (results, status) {
+      config['id_func'] = function (item) {
+        if (item && item['place_id']) {
+          // Geocode item place details, for further information extraction; E.g. Lat/Lng.
+          let geocode_service = new window.google.maps.Geocoder();
+          geocode_service.geocode(
+            { placeId: item['place_id'] },
+            function (results, status) {
               if (status === 'OK' && results && results.length > 0) {
-
                 // Ensure we can get a handle on lat/lng values.
                 if (results[0]['geometry']['location']) {
                   let location = results[0]['geometry']['location'];
@@ -1456,254 +1741,275 @@ jQuery(function ($) {
 
                   // Package findings within json object, for downstream processing.
                   let location_pkg = {
-                    'label': label,
-                    'level': level,
-                    'lat': lat,
-                    'lng': lng
+                    label: label,
+                    level: level,
+                    lat: lat,
+                    lng: lng,
                   };
 
                   // Stringify and persist location package.
-                  event_value_object_id.val(JSON.stringify(location_pkg).replaceAll("\"", "'"));
+                  event_value_object_id.val(
+                    JSON.stringify(location_pkg).replaceAll('"', "'"),
+                  );
                 }
               }
-            });
-          }
+            },
+          );
+        }
 
-          /**
-           * Return null, to halt flow; as actual update will occur within geocode service callback
-           * function.
-           */
+        /**
+         * Return null, to halt flow; as actual update will occur within geocode service callback
+         * function.
+         */
 
-          return null;
-        };
-
-        config['general'] = {
-          'order': ''
-        };
-
-      // -- Mapbox
-      } else if (mappings['mapbox']['enabled']) {
-        config['endpoint'] = {
-          'filter': false,
-          'display': ['place_name', 'id'],
-          'template': '<span>{{place_name}}</span>',
-          'by_ajax': true,
-          'ajax': {
-            url: mappings['mapbox']['endpoint'] + '{{query}}' + mappings['mapbox']['settings'] + mappings['mapbox']['key'],
-            callback: {
-              done: function (response) {
-                return (response['features']) ? response['features'] : [];
-              }
-            }
-          },
-          'by_data': false,
-          'data': null
-        };
-
-        config['id_func'] = function (item) {
-          if (item && item['place_name'] && item['place_type'] && item['center']) {
-
-            // Package findings within json object, for downstream processing.
-            let location_pkg = {
-              'label': item['place_name'],
-              'level': item['place_type'][0],
-              'lat': item['center'][1],
-              'lng': item['center'][0]
-            };
-
-            // Stringify and persist location package.
-            return JSON.stringify(location_pkg).replaceAll("\"", "'");
-          }
-          return null;
-        };
-
-        config['general'] = {
-          'order': ''
-        };
-
-      // -- Default
-      } else {
-        config['endpoint'] = {
-          'filter': false,
-          'display': [],
-          'template': '<span></span>',
-          'by_ajax': false,
-          'ajax': null,
-          'by_data': false,
-          'data': null
-        };
-
-        config['id_func'] = function (item) {
-          return null;
-        };
-
-        config['general'] = {
-          'order': ''
-        };
-      }
-
-      // Typeahead object
-      response['typeahead'] = {
-        endpoint: function (wp_nonce) {
-          let source = {
-            locations: {
-              filter: config['endpoint']['filter'],
-              display: config['endpoint']['display'],
-              template: config['endpoint']['template']
-            }
-          }
-
-          // Determine additional bolt-ons.
-          if (config['endpoint']['by_ajax']) {
-            source['locations']['ajax'] = config['endpoint']['ajax'];
-          }
-          if (config['endpoint']['by_data']) {
-            source['locations']['data'] = config['endpoint']['data'];
-          }
-
-          // Return final source config shape.
-          return source;
-        },
-        id_func: config['id_func'],
-        general: config['general']
+        return null;
       };
 
-      return response;
+      config['general'] = {
+        order: '',
+      };
+
+      // -- Mapbox
+    } else if (mappings['mapbox']['enabled']) {
+      config['endpoint'] = {
+        filter: false,
+        display: ['place_name', 'id'],
+        template: '<span>{{place_name}}</span>',
+        by_ajax: true,
+        ajax: {
+          url:
+            mappings['mapbox']['endpoint'] +
+            '{{query}}' +
+            mappings['mapbox']['settings'] +
+            mappings['mapbox']['key'],
+          callback: {
+            done: function (response) {
+              return response['features'] ? response['features'] : [];
+            },
+          },
+        },
+        by_data: false,
+        data: null,
+      };
+
+      config['id_func'] = function (item) {
+        if (
+          item &&
+          item['place_name'] &&
+          item['place_type'] &&
+          item['center']
+        ) {
+          // Package findings within json object, for downstream processing.
+          let location_pkg = {
+            label: item['place_name'],
+            level: item['place_type'][0],
+            lat: item['center'][1],
+            lng: item['center'][0],
+          };
+
+          // Stringify and persist location package.
+          return JSON.stringify(location_pkg).replaceAll('"', "'");
+        }
+        return null;
+      };
+
+      config['general'] = {
+        order: '',
+      };
+
+      // -- Default
+    } else {
+      config['endpoint'] = {
+        filter: false,
+        display: [],
+        template: '<span></span>',
+        by_ajax: false,
+        ajax: null,
+        by_data: false,
+        data: null,
+      };
+
+      config['id_func'] = function (item) {
+        return null;
+      };
+
+      config['general'] = {
+        order: '',
+      };
     }
 
-    function generate_event_value_locations(base_url) {
+    // Typeahead object
+    response['typeahead'] = {
+      endpoint: function (wp_nonce) {
+        let source = {
+          locations: {
+            filter: config['endpoint']['filter'],
+            display: config['endpoint']['display'],
+            template: config['endpoint']['template'],
+          },
+        };
+
+        // Determine additional bolt-ons.
+        if (config['endpoint']['by_ajax']) {
+          source['locations']['ajax'] = config['endpoint']['ajax'];
+        }
+        if (config['endpoint']['by_data']) {
+          source['locations']['data'] = config['endpoint']['data'];
+        }
+
+        // Return final source config shape.
+        return source;
+      },
+      id_func: config['id_func'],
+      general: config['general'],
+    };
+
+    return response;
+  }
+
+  function generate_event_value_locations(base_url) {
+    let response = {};
+    response['id'] = Date.now();
+
+    let html =
+      '<div class="typeahead__container"><div class="typeahead__field"><div class="typeahead__query">';
+    html += `<input type="text" class="dt-typeahead" autocomplete="off" placeholder="Start typing a location..." style="min-width: 100%;" id="${window.dt_admin_shared.escape(response['id'])}">`;
+    html += '</div></div></div>';
+    response['html'] = html;
+
+    response['typeahead'] = {
+      endpoint: function (wp_nonce) {
+        return {
+          locations: {
+            display: ['name', 'ID'],
+            template: '<span>{{name}}</span>',
+            ajax: {
+              url:
+                base_url +
+                'dt/v1/mapping_module/search_location_grid_by_name?filter=all',
+              data: {
+                s: '{{query}}',
+              },
+              beforeSend: function (xhr) {
+                xhr.setRequestHeader('X-WP-Nonce', wp_nonce);
+              },
+              callback: {
+                done: function (response) {
+                  return response['location_grid']
+                    ? response['location_grid']
+                    : [];
+                },
+              },
+            },
+          },
+        };
+      },
+      id_func: function (item) {
+        if (item && item['ID']) {
+          return item['ID'];
+        }
+        return null;
+      },
+    };
+
+    return response;
+  }
+
+  function generate_event_value_connections(base_url, field) {
+    if (field && field['id'] && field['post_type']) {
       let response = {};
       response['id'] = Date.now();
 
-      let html = '<div class="typeahead__container"><div class="typeahead__field"><div class="typeahead__query">';
-      html += `<input type="text" class="dt-typeahead" autocomplete="off" placeholder="Start typing a location..." style="min-width: 100%;" id="${window.dt_admin_shared.escape(response['id'])}">`;
+      let html =
+        '<div class="typeahead__container"><div class="typeahead__field"><div class="typeahead__query">';
+      html += `<input type="text" class="dt-typeahead" autocomplete="off" placeholder="Start typing connection details..." style="min-width: 100%;" id="${window.dt_admin_shared.escape(response['id'])}">`;
       html += '</div></div></div>';
       response['html'] = html;
 
       response['typeahead'] = {
         endpoint: function (wp_nonce) {
           return {
-            locations: {
-              display: ["name", "ID"],
-              template: "<span>{{name}}</span>",
+            connections: {
+              display: ['name', 'ID'],
+              template: '<span>{{name}}</span>',
               ajax: {
-                url: base_url + 'dt/v1/mapping_module/search_location_grid_by_name?filter=all',
+                url:
+                  base_url +
+                  'dt-posts/v2/' +
+                  field['post_type'] +
+                  '/compact?field_key=' +
+                  field['id'],
                 data: {
-                  s: '{{query}}'
+                  s: '{{query}}',
                 },
                 beforeSend: function (xhr) {
-                  xhr.setRequestHeader("X-WP-Nonce", wp_nonce);
+                  xhr.setRequestHeader('X-WP-Nonce', wp_nonce);
                 },
                 callback: {
                   done: function (response) {
-                    return (response['location_grid']) ? response['location_grid'] : [];
-                  }
-                }
-              }
-            }
-          }
+                    return response['posts'] ? response['posts'] : [];
+                  },
+                },
+              },
+            },
+          };
         },
         id_func: function (item) {
           if (item && item['ID']) {
             return item['ID'];
           }
           return null;
-        }
-      };
-
-      return response;
-    }
-
-    function generate_event_value_connections(base_url, field) {
-      if (field && field['id'] && field['post_type']) {
-
-        let response = {};
-        response['id'] = Date.now();
-
-        let html = '<div class="typeahead__container"><div class="typeahead__field"><div class="typeahead__query">';
-        html += `<input type="text" class="dt-typeahead" autocomplete="off" placeholder="Start typing connection details..." style="min-width: 100%;" id="${window.dt_admin_shared.escape(response['id'])}">`;
-        html += '</div></div></div>';
-        response['html'] = html;
-
-        response['typeahead'] = {
-          endpoint: function (wp_nonce) {
-            return {
-              connections: {
-                display: ["name", "ID"],
-                template: "<span>{{name}}</span>",
-                ajax: {
-                  url: base_url + 'dt-posts/v2/' + field['post_type'] + '/compact?field_key=' + field['id'],
-                  data: {
-                    s: '{{query}}'
-                  },
-                  beforeSend: function (xhr) {
-                    xhr.setRequestHeader("X-WP-Nonce", wp_nonce);
-                  },
-                  callback: {
-                    done: function (response) {
-                      return (response['posts']) ? response['posts'] : [];
-                    }
-                  }
-                }
-              }
-            }
-          },
-          id_func: function (item) {
-            if (item && item['ID']) {
-              return item['ID'];
-            }
-            return null;
-          }
-        };
-
-        return response;
-      }
-      return null;
-    }
-
-    function generate_event_value_user_select(base_url) {
-      let response = {};
-      response['id'] = Date.now();
-
-      let html = '<div class="typeahead__container"><div class="typeahead__field"><div class="typeahead__query">';
-      html += `<input type="text" class="dt-typeahead" autocomplete="off" placeholder="Start typing user details..." style="min-width: 100%;" id="${window.dt_admin_shared.escape(response['id'])}">`;
-      html += '</div></div></div>';
-      response['html'] = html;
-
-      response['typeahead'] = {
-        endpoint: function (wp_nonce) {
-          return {
-            users: {
-              display: ["name", "ID"],
-              template: "<span>{{name}}</span>",
-              ajax: {
-                url: base_url + 'dt/v1/users/get_users?get_all',
-                data: {
-                  s: '{{query}}'
-                },
-                beforeSend: function (xhr) {
-                  xhr.setRequestHeader("X-WP-Nonce", wp_nonce);
-                },
-                callback: {
-                  done: function (response) {
-                    return response;
-                  }
-                }
-              }
-            }
-          }
         },
-        id_func: function (item) {
-          if (item && item['ID']) {
-            return 'user-' + item['ID'];
-          }
-          return null;
-        }
       };
 
       return response;
     }
-
-    /*** Header Functions - Helpers ***/
+    return null;
   }
-);
+
+  function generate_event_value_user_select(base_url) {
+    let response = {};
+    response['id'] = Date.now();
+
+    let html =
+      '<div class="typeahead__container"><div class="typeahead__field"><div class="typeahead__query">';
+    html += `<input type="text" class="dt-typeahead" autocomplete="off" placeholder="Start typing user details..." style="min-width: 100%;" id="${window.dt_admin_shared.escape(response['id'])}">`;
+    html += '</div></div></div>';
+    response['html'] = html;
+
+    response['typeahead'] = {
+      endpoint: function (wp_nonce) {
+        return {
+          users: {
+            display: ['name', 'ID'],
+            template: '<span>{{name}}</span>',
+            ajax: {
+              url: base_url + 'dt/v1/users/get_users?get_all',
+              data: {
+                s: '{{query}}',
+              },
+              beforeSend: function (xhr) {
+                xhr.setRequestHeader('X-WP-Nonce', wp_nonce);
+              },
+              callback: {
+                done: function (response) {
+                  return response;
+                },
+              },
+            },
+          },
+        };
+      },
+      id_func: function (item) {
+        if (item && item['ID']) {
+          return 'user-' + item['ID'];
+        }
+        return null;
+      },
+    };
+
+    return response;
+  }
+
+  /*** Header Functions - Helpers ***/
+});

--- a/dt-core/admin/multi-role/js/edit-post.js
+++ b/dt-core/admin/multi-role/js/edit-post.js
@@ -1,157 +1,157 @@
-( function() {
+(function () {
+  // Bail if we don't have the JSON, which is passed in via `wp_localize_script()`.
+  if (window.lodash.isUndefined(dt_multi_role_cp_data)) {
+    return;
+  }
 
-	// Bail if we don't have the JSON, which is passed in via `wp_localize_script()`.
-	if ( window.lodash.isUndefined( dt_multi_role_cp_data ) ) {
-		return;
-	}
+  /* === Models === */
 
-	/* === Models === */
+  // Section model (each section belongs to a manager).
+  var Section = Backbone.Model.extend({
+    defaults: {
+      name: '',
+      label: '',
+      description: '',
+      icon: '',
+      selected: false,
+    },
+  });
 
-	// Section model (each section belongs to a manager).
-	var Section = Backbone.Model.extend( {
-		defaults : {
-			name        : '',
-			label       : '',
-			description : '',
-			icon        : '',
-			selected    : false
-		}
-	} );
+  // Control model (each control belongs to a manager and section).
+  var Control = Backbone.Model.extend({
+    defaults: {
+      name: '',
+      type: '',
+      label: '',
+      description: '',
+      value: '',
+      choices: {},
+      attr: '',
+      section: '',
+    },
+  });
 
-	// Control model (each control belongs to a manager and section).
-	var Control = Backbone.Model.extend( {
-		defaults : {
-			name        : '',
-			type        : '',
-			label       : '',
-			description : '',
-			value       : '',
-			choices     : {},
-			attr        : '',
-			section     : ''
-		}
-	} );
+  /* === Collections === */
 
-	/* === Collections === */
+  // Collection of sections.
+  var Sections = Backbone.Collection.extend({
+    model: Section,
+  });
 
-	// Collection of sections.
-	var Sections = Backbone.Collection.extend( {
-		model : Section
-	} );
+  /* === Views === */
 
-	/* === Views === */
+  // Section view.  Handles the output of a section.
+  var Section_View = Backbone.View.extend({
+    tagName: 'div',
+    template: wp.template('members-cp-section'),
+    attributes: function () {
+      return {
+        id: 'members-cp-section-' + this.model.get('name'),
+        class: 'members-cp-section',
+        'aria-hidden': !this.model.get('selected'),
+      };
+    },
+    initialize: function (options) {
+      this.model.on('change', this.onchange, this);
+    },
+    render: function () {
+      this.el.innerHTML = this.template(this.model.toJSON());
 
-	// Section view.  Handles the output of a section.
-	var Section_View = Backbone.View.extend( {
-		tagName : 'div',
-		template : wp.template( 'members-cp-section' ),
-		attributes : function() {
-			return {
-				'id'          : 'members-cp-section-' + this.model.get( 'name' ),
-				'class'       : 'members-cp-section',
-				'aria-hidden' : ! this.model.get( 'selected' )
-			};
-		},
-		initialize : function( options ) {
-			this.model.on( 'change', this.onchange, this );
-		},
-		render : function() {
+      return this;
+    },
+    onchange: function () {
+      // Set the view's `aria-hidden` attribute based on whether the model is selected.
+      this.el.setAttribute('aria-hidden', !this.model.get('selected'));
+    },
+  });
 
-			this.el.innerHTML = this.template( this.model.toJSON() );
+  // Nav view.
+  var Nav_View = Backbone.View.extend({
+    template: wp.template('members-cp-nav'),
+    tagName: 'li',
+    attributes: function () {
+      return {
+        'aria-selected': this.model.get('selected'),
+      };
+    },
+    initialize: function () {
+      this.model.on('change', this.render, this);
+      this.model.on('change', this.onchange, this);
+    },
+    render: function () {
+      this.el.innerHTML = this.template(this.model.toJSON());
 
-			return this;
-		},
-		onchange : function() {
+      return this;
+    },
+    events: {
+      'click a': 'onselect',
+    },
+    onchange: function () {
+      // Set the `aria-selected` attibute based on the model selected state.
+      this.el.setAttribute('aria-selected', this.model.get('selected'));
+    },
+    onselect: function (event) {
+      event.preventDefault();
 
-			// Set the view's `aria-hidden` attribute based on whether the model is selected.
-			this.el.setAttribute( 'aria-hidden', ! this.model.get( 'selected' ) );
-		},
-	} );
+      // Loop through each of the models in the collection and set them to inactive.
+      window.lodash.each(
+        this.model.collection.models,
+        function (m) {
+          m.set('selected', false);
+        },
+        this,
+      );
 
-	// Nav view.
-	var Nav_View = Backbone.View.extend( {
-		template : wp.template( 'members-cp-nav' ),
-		tagName : 'li',
-		attributes : function() {
-			return {
-				'aria-selected' : this.model.get( 'selected' )
-			};
-		},
-		initialize : function() {
-			this.model.on( 'change', this.render, this );
-			this.model.on( 'change', this.onchange, this );
-		},
-		render : function() {
+      // Set this view's model to selected.
+      this.model.set('selected', true);
+    },
+  });
 
-			this.el.innerHTML = this.template( this.model.toJSON() );
+  // Control view. Handles the output of a control.
+  var Control_View = Backbone.View.extend({
+    tagName: 'div',
+    template: wp.template('members-cp-control'),
+    attributes: function () {
+      return {
+        id: 'members-cp-control-' + this.model.get('name'),
+        class: 'members-cp-control',
+      };
+    },
+    render: function () {
+      this.el.innerHTML = this.template(this.model.toJSON());
+      return this;
+    },
+  });
 
-			return this;
-		},
-		events : {
-			'click a' : 'onselect'
-		},
-		onchange : function() {
+  var sections = new Sections();
 
-			// Set the `aria-selected` attibute based on the model selected state.
-			this.el.setAttribute( 'aria-selected', this.model.get( 'selected' ) );
-		},
-		onselect : function( event ) {
-			event.preventDefault();
+  window.lodash.each(dt_multi_role_cp_data.sections),
+    function (data) {
+      sections.add(new Section(data));
+    };
 
-			// Loop through each of the models in the collection and set them to inactive.
-			window.lodash.each( this.model.collection.models, function( m ) {
+  sections.forEach(function (section, i) {
+    var nav_view = new Nav_View({ model: section });
+    var section_view = new Section_View({ model: section });
 
-				m.set( 'selected', false );
-			}, this );
+    document
+      .querySelector('#members-cp .members-cp-nav')
+      .appendChild(nav_view.render().el);
+    document
+      .querySelector('#members-cp .members-cp-content')
+      .appendChild(section_view.render().el);
 
-			// Set this view's model to selected.
-			this.model.set( 'selected', true );
-		}
-	} );
+    // If the first model, set it to selected.
+    section.set('selected', 0 == i);
+  }, this);
 
-	// Control view. Handles the output of a control.
-	var Control_View = Backbone.View.extend( {
-		tagName : 'div',
-		template : wp.template( 'members-cp-control' ),
-		attributes : function() {
-			return {
-				'id'    : 'members-cp-control-' + this.model.get( 'name' ),
-				'class' : 'members-cp-control'
-			};
-		},
-		render : function() {
+  window.lodash.each(dt_multi_role_cp_data.controls, function (data) {
+    var control = new Control(data);
 
-			this.el.innerHTML = this.template( this.model.toJSON() );
-			return this;
-		}
-	} );
+    var view = new Control_View({ model: control });
 
-	var sections = new Sections();
-
-	window.lodash.each( dt_multi_role_cp_data.sections ), function( data ) {
-
-		sections.add( new Section( data ) );
-	}
-
-	sections.forEach( function( section, i ) {
-
-		var nav_view     = new Nav_View(     { model : section } );
-		var section_view = new Section_View( { model : section } );
-
-		document.querySelector( '#members-cp .members-cp-nav' ).appendChild( nav_view.render().el );
-		document.querySelector( '#members-cp .members-cp-content' ).appendChild( section_view.render().el );
-
-		// If the first model, set it to selected.
-		section.set( 'selected', 0 == i );
-	}, this );
-
-	window.lodash.each( dt_multi_role_cp_data.controls, function( data ) {
-
-		var control = new Control( data );
-
-		var view = new Control_View( { model : control } );
-
-		document.getElementById( '#members-cp-section-' + control.get( 'section' ) ).appendChild( view.render().el );
-	} );
-
-}() );
+    document
+      .getElementById('#members-cp-section-' + control.get('section'))
+      .appendChild(view.render().el);
+  });
+})();

--- a/dt-core/admin/multi-role/js/edit-role.js
+++ b/dt-core/admin/multi-role/js/edit-role.js
@@ -1,409 +1,424 @@
-jQuery( document ).ready( function() {
-
-	/* ====== Delete Role Link (on Roles and Edit Role screens) ====== */
-
-	// When the delete role link is clicked, give a "AYS?" popup to confirm.
-	jQuery( '.members-delete-role-link' ).click(
-		function() {
-			return window.confirm( dt_multi_role_i18n.ays_delete_role );
-		}
-	);
-
-	/* ====== Role Name and Slug ====== */
-
-	/**
-	 * Takes the given text and copies it to the role slug `<span>` after sanitizing it
-	 * as a role.
-	 *
-	 * @since  0.1.0
-	 * @access public
-	 * @param  string  $slug
-	 * @return void
-	 */
-	function dt_multi_role_print_role_slug( slug ) {
-
-		// Sanitize the role.
-		slug = slug.toLowerCase().trim().replace( /<.*?>/g, '' ).replace( /\s/g, '_' ).replace( /[^a-zA-Z0-9_]/g, '' );
-
-		// Add the text.
-		jQuery( '.role-slug' ).text( slug );
-	}
-
-	// Check the role name input box for key presses.
-	jQuery( 'input[name="role_name"]' ).keyup(
-		function() {
-
-			// If there's no value stored in the role input box, print this input's
-			// value in the role slug span.
-			if ( ! jQuery( 'input[name="role"]' ).val() )
-				dt_multi_role_print_role_slug( this.value );
-		}
-	); // .keyup
-
-	// Hide the role input box and role OK button.
-	jQuery( 'input[name="role"], .role-ok-button' ).hide();
-
-	// When the role edit button is clicked.
-	jQuery( document ).on( 'click', '.role-edit-button.closed',
-		function() {
-
-			// Toggle the button class and change the text.
-			jQuery( this ).removeClass( 'closed' ).addClass( 'open' ).text( dt_multi_role_i18n.button_role_ok );
-
-			// Show role input.
-			jQuery( 'input[name="role"]' ).show();
-
-			// Focus on the role input.
-			jQuery( 'input[name="role"]' ).trigger( 'focus' );
-
-			// Copy the role slug to the role input edit value.
-			jQuery( 'input[name="role"]' ).attr( 'value', jQuery( '.role-slug' ).text() );
-		}
-	);
-
-	// When the role OK button is pressed.
-	jQuery( document ).on( 'click', '.role-edit-button.open',
-		function() {
-
-			// Toggle the button class and change the text.
-			jQuery( this ).removeClass( 'open' ).addClass( 'closed' ).text( dt_multi_role_i18n.button_role_edit );
-
-			// Hide role input.
-			jQuery( 'input[name="role"]' ).hide();
-
-			// Get the role input value.
-			var role = jQuery( 'input[name="role"]' ).val();
-
-			// If we have a value, print the slug.
-			if ( role )
-				dt_multi_role_print_role_slug( role );
-
-			// Else, use the role name input value.
-			else
-				dt_multi_role_print_role_slug( jQuery( 'input[name="role_name"]' ).val() );
-		}
-	); // .click()
-
-	// Simulate clicking the OK button if the user presses "Enter" in the role field.
-	jQuery( 'input[name="role"]' ).keypress(
-		function( e ) {
-
-			// 13 is the key code for "Enter".
-			if ( 13 === e.keyCode ) {
-
-				// Click the edit role button and trigger a focus.
-				jQuery( '.role-edit-button' ).click().trigger( 'focus' );
-
-				// Prevent default behavior and return false.
-				e.preventDefault();
-				return false;
-			}
-		}
-	); // .keypress()
-
-	// Hide the add new role button if we don't at least have a role name.
-	if ( ! jQuery( '.users_page_role-new input[name="role_name"]' ).val() )
-		jQuery( '.users_page_role-new #publish' ).prop( 'disabled', true );
-
-	// Look for changes to the role name input.
-	jQuery( '.users_page_role-new input[name="role_name"]' ).on( 'input',
-		function() {
-
-			// If there's a role name, enable the add new role button.
-			if ( jQuery( this ).val() )
-				jQuery( '.users_page_role-new #publish' ).prop( 'disabled', false );
-
-			// Else, disable the button.
-			else
-				jQuery( '.users_page_role-new #publish' ).prop( 'disabled', true );
-		}
-	);
-
-	/* ====== Tab Sections and Controls ====== */
-
-	// Create Underscore templates.
-	var section_template = wp.template( 'members-cap-section' );
-	var control_template = wp.template( 'members-cap-control' );
-
-	// Check that the `dt_multi_role_sections` and `dt_multi_role_controls` variables were
-	// passed in via `wp_localize_script()`.
-	if ( typeof dt_multi_role_sections !== 'undefined' && typeof dt_multi_role_controls !== 'undefined' ) {
-
-		// Loop through the sections and append the template for each.
-		window.lodash.each( dt_multi_role_sections, function( data ) {
-			jQuery( '.members-tab-wrap' ).append( section_template( data ) );
-		} );
-
-		// Loop through the controls and append the template for each.
-		window.lodash.each( dt_multi_role_controls, function( data ) {
-			jQuery( '#members-tab-' + data.section + ' tbody' ).append( control_template( data ) );
-		} );
-	}
-
-	/* ====== Tabs ====== */
-
-	// Hides the tab content.
-	jQuery( '.members-cap-tabs .members-tab-content' ).hide();
-
-	// Shows the first tab's content.
-	jQuery( '.members-cap-tabs .members-tab-content:first-child' ).show();
-
-	// Makes the 'aria-selected' attribute true for the first tab nav item.
-	jQuery( '.members-tab-nav :first-child' ).attr( 'aria-selected', 'true' );
-
-	// Copies the current tab item title to the box header.
-	jQuery( '.members-which-tab' ).text( jQuery( '.members-tab-nav :first-child a' ).text() );
-
-	// When a tab nav item is clicked.
-	jQuery( '.members-tab-nav li a' ).click(
-		function( j ) {
-
-			// Prevent the default browser action when a link is clicked.
-			j.preventDefault();
-
-			// Get the `href` attribute of the item.
-			var href = jQuery( this ).attr( 'href' );
-
-			// Hide all tab content.
-			jQuery( this ).parents( '.members-cap-tabs' ).find( '.members-tab-content' ).hide();
-
-			// Find the tab content that matches the tab nav item and show it.
-			jQuery( this ).parents( '.members-cap-tabs' ).find( href ).show();
-
-			// Set the `aria-selected` attribute to false for all tab nav items.
-			jQuery( this ).parents( '.members-cap-tabs' ).find( '.members-tab-title' ).attr( 'aria-selected', 'false' );
-
-			// Set the `aria-selected` attribute to true for this tab nav item.
-			jQuery( this ).parent().attr( 'aria-selected', 'true' );
-
-			// Copy the current tab item title to the box header.
-			jQuery( '.members-which-tab' ).text( jQuery( this ).text() );
-		}
-	); // click()
-
-	/* ====== Capability Checkboxes (inside tab content) ====== */
-
-	/**
-	 * Counts the number of granted and denied capabilities that are checked and updates
-	 * the count in the submit role meta box.
-	 *
-	 * @since  0.1.0
-	 * @access public
-	 * @return void
-	 */
-	function dt_multi_role_count_caps() {
-
-		// Count the granted and denied caps that are checked.
-		var granted_count = jQuery( "#members-tab-all input[data-grant-cap]:checked" ).length;
-		var denied_count  = jQuery( "#members-tab-all input[data-deny-cap]:checked" ).length;
-
-		// Count the new (added from new cap meta box) granted and denied caps that are checked.
-		var new_granted_count = jQuery( '#members-tab-custom input[name="grant-new-caps[]"]:checked' ).length;
-		var new_denied_count  = jQuery( '#members-tab-custom input[name="deny-new-caps[]"]:checked' ).length;
-
-		// Update the submit meta box cap count.
-		jQuery( '#submitdiv .granted-count' ).text( granted_count + new_granted_count );
-		jQuery( '#submitdiv .denied-count' ).text( denied_count + new_denied_count );
-	}
-
-	/**
-	 * When a grant/deny checkbox has a change, this function makes sure that any duplicates
-	 * also receive that change.  It also unchecks the grant/deny opposite checkbox if needed.
-	 *
-	 * @since  0.1.0
-	 * @access public
-	 * @param  object  $checkbox
-	 * @return void
-	 */
-	function dt_multi_role_check_uncheck( checkbox ) {
-
-		var type     = 'grant';
-		var opposite = 'deny';
-
-		// If this is a deny checkbox.
-		if ( jQuery( checkbox ).attr( 'data-deny-cap' ) ) {
-
-			type     = 'deny';
-			opposite = 'grant';
-		}
-
-		// Get the capability for this checkbox.
-		var cap = jQuery( checkbox ).attr( 'data-' + type + '-cap' );
-
-		// If the checkbox is checked.
-		if ( jQuery( checkbox ).prop( 'checked' ) ) {
-
-			// Check any duplicate checkboxes.
-			jQuery( 'input[data-' + type + '-cap="' + cap + '"]' ).not( checkbox ).prop( 'checked', true );
-
-			// Uncheck any deny checkboxes with the same cap.
-			jQuery( 'input[data-' + opposite + '-cap="' + cap + '"]' ).prop( 'checked', false );
-
-		// If the checkbox is not checked.
-		} else {
-
-			// Uncheck any duplicate checkboxes.
-			jQuery( 'input[data-' + type + '-cap="' + cap + '"]' ).not( checkbox ).prop( 'checked', false );
-		}
-	}
-
-	// Count the granted and denied caps that are checked.
-	dt_multi_role_count_caps();
-
-	// When a change is triggered for any grant/deny checkbox. Note that we're using `.on()`
-	// here because we're dealing with dynamically-generated HTML.
-	jQuery( document ).on( 'change',
-		'.members-cap-checklist input[data-grant-cap], .members-cap-checklist input[data-deny-cap]',
-		function() {
-
-			// Check/Uncheck boxes.
-			dt_multi_role_check_uncheck( this );
-
-			// Count the granted and denied caps that are checked.
-			dt_multi_role_count_caps();
-		}
-	); // .on( 'change' )
-
-	// When a cap button is clicked. Note that we're using `.on()` here because we're dealing
-	// with dynamically-generated HTML.
-	//
-	// Note that we only need to trigger `change()` once for our functionality.
-	jQuery( document ).on( 'click', '.editable-role .members-cap-checklist button',
-		function() {
-
-			// Get the button parent element.
-			var parent = jQuery( this ).closest( '.members-cap-checklist' );
-
-			// Find the grant and deny checkbox inputs.
-			var grant = jQuery( parent ).find( 'input[data-grant-cap]' );
-			var deny  = jQuery( parent ).find( 'input[data-deny-cap]' );
-
-			// If the grant checkbox is checked.
-			if ( jQuery( grant ).prop( 'checked' ) ) {
-
-				jQuery( grant ).prop( 'checked', false );
-				jQuery( deny ).prop( 'checked', true ).change();
-
-			// If the deny checkbox is checked.
-			} else if ( jQuery( deny ).prop( 'checked' ) ) {
-
-				jQuery( grant ).prop( 'checked', false );
-				jQuery( deny ).prop( 'checked', false ).change();
-
-			// If neither checkbox is checked.
-			} else {
-
-				jQuery( grant ).prop( 'checked', true ).change();
-			}
-		}
-	); // on()
-
-	// Remove focus from button when hovering another button.
-	jQuery( document ).on( 'hover', '.editable-role .members-cap-checklist button',
-		function() {
-			jQuery( '.members-cap-checklist button:focus' ).not( this ).blur();
-		}
-	);
-
-	/* ====== Meta Boxes ====== */
-
-	// Add the postbox toggle functionality.
-	// Note: `pagenow` is a global variable set by WordPress.
-	postboxes.add_postbox_toggles( pagenow );
-
-	/* ====== New Cap Meta Box ====== */
-
-	// Give the meta box toggle button a type of `button` so that it doesn't submit the form
-	// when we hit the "Enter" key in our input or toggle open/close the meta box.
-	jQuery( '#newcapdiv button.handlediv' ).attr( 'type', 'button' );
-
-	// Disable the new cap button so that it's not clicked until there's a cap.
-	jQuery( '#members-add-new-cap' ).prop( 'disabled', true );
-
-	// When the user starts typing a new cap.
-	jQuery( '#members-new-cap-field' ).on( 'input',
-		function() {
-
-			// If there's a value in the input, enable the add new button.
-			if ( jQuery( this ).val() ) {
-
-				jQuery( '#members-add-new-cap' ).prop( 'disabled', false );
-
-			// If there's no value, disable the button.
-			} else {
-				jQuery( '#members-add-new-cap' ).prop( 'disabled', true );
-			}
-		}
-	); // .on( 'input' )
-
-	// Simulate clicking the add new cap button if the user presses "Enter" in the new cap field.
-	jQuery( '#members-new-cap-field' ).keypress(
-		function( e ) {
-
-			// 13 is the key code for "Enter".
-			if ( 13 === e.keyCode ) {
-				jQuery( '#members-add-new-cap' ).click();
-				e.preventDefault();
-				return false;
-			}
-		}
-	); // .keypress()
-
-	// When the new cap button is clicked.
-	jQuery( '#members-add-new-cap' ).click(
-		function() {
-
-			// Get the new cap value.
-			var new_cap = jQuery( '#members-new-cap-field' ).val();
-
-			// Sanitize the new cap.
-			// Note that this will be sanitized on the PHP side as well before save.
-			new_cap = new_cap.trim().replace( /<.*?>/g, '' ).replace( /\s/g, '_' ).replace( /[^a-zA-Z0-9_]/g, '' );
-
-			// If there's a new cap value.
-			if ( new_cap ) {
-
-				// Trigger a click event on the "custom" tab in the edit caps box.
-				jQuery( 'a[href="#members-tab-custom"]' ).trigger( 'click' );
-
-				// Replace text placeholder with cap.
-				dt_multi_role_i18n.label_grant_cap = dt_multi_role_i18n.label_grant_cap.replace( /%s/g, '<code>' + new_cap + '</code>' );
-				dt_multi_role_i18n.label_deny_cap  = dt_multi_role_i18n.label_deny_cap.replace( /%s/g,  '<code>' + new_cap + '</code>' );
-
-				// Set up some data to pass to our Underscore template.
-				var data = {
-					cap            : new_cap,
-					readonly       : '',
-					name           : { grant : 'grant-new-caps[]', deny : 'deny-new-caps[]' },
-					is_granted_cap : true,
-					is_denied_cap  : false,
-					label          : { grant : dt_multi_role_i18n.label_grant_cap, deny : dt_multi_role_i18n.label_deny_cap }
-				};
-
-				// Prepend our template to the "custom" edit caps tab content.
-				jQuery( '#members-tab-custom tbody' ).prepend( control_template( data ) );
-
-				// Get the new cap table row.
-				var parent = jQuery( '[data-grant-cap="' + new_cap + '"]' ).parents( '.members-cap-checklist' );
-
-				// Add the highlight class.
-				jQuery( parent ).addClass( 'members-highlight' );
-
-				// Remove the class after a set time for a highlight effect.
-				setTimeout( function() {
-					jQuery( parent ).removeClass( 'members-highlight' );
-				}, 500 );
-
-				// Set the new cap input value to an empty string.
-				jQuery( '#members-new-cap-field' ).val( '' );
-
-				// Disable the add new cap button.
-				jQuery( '#members-add-new-cap' ).prop( 'disabled', true );
-
-				// Trigger a change on our new grant cap checkbox.
-				jQuery( '.members-cap-checklist input[data-grant-cap="' + new_cap + '"]' ).trigger( 'change' );
-			}
-		}
-	); // .click()
-
-} ); // ready()
+jQuery(document).ready(function () {
+  /* ====== Delete Role Link (on Roles and Edit Role screens) ====== */
+
+  // When the delete role link is clicked, give a "AYS?" popup to confirm.
+  jQuery('.members-delete-role-link').click(function () {
+    return window.confirm(dt_multi_role_i18n.ays_delete_role);
+  });
+
+  /* ====== Role Name and Slug ====== */
+
+  /**
+   * Takes the given text and copies it to the role slug `<span>` after sanitizing it
+   * as a role.
+   *
+   * @since  0.1.0
+   * @access public
+   * @param  string  $slug
+   * @return void
+   */
+  function dt_multi_role_print_role_slug(slug) {
+    // Sanitize the role.
+    slug = slug
+      .toLowerCase()
+      .trim()
+      .replace(/<.*?>/g, '')
+      .replace(/\s/g, '_')
+      .replace(/[^a-zA-Z0-9_]/g, '');
+
+    // Add the text.
+    jQuery('.role-slug').text(slug);
+  }
+
+  // Check the role name input box for key presses.
+  jQuery('input[name="role_name"]').keyup(function () {
+    // If there's no value stored in the role input box, print this input's
+    // value in the role slug span.
+    if (!jQuery('input[name="role"]').val())
+      dt_multi_role_print_role_slug(this.value);
+  }); // .keyup
+
+  // Hide the role input box and role OK button.
+  jQuery('input[name="role"], .role-ok-button').hide();
+
+  // When the role edit button is clicked.
+  jQuery(document).on('click', '.role-edit-button.closed', function () {
+    // Toggle the button class and change the text.
+    jQuery(this)
+      .removeClass('closed')
+      .addClass('open')
+      .text(dt_multi_role_i18n.button_role_ok);
+
+    // Show role input.
+    jQuery('input[name="role"]').show();
+
+    // Focus on the role input.
+    jQuery('input[name="role"]').trigger('focus');
+
+    // Copy the role slug to the role input edit value.
+    jQuery('input[name="role"]').attr('value', jQuery('.role-slug').text());
+  });
+
+  // When the role OK button is pressed.
+  jQuery(document).on('click', '.role-edit-button.open', function () {
+    // Toggle the button class and change the text.
+    jQuery(this)
+      .removeClass('open')
+      .addClass('closed')
+      .text(dt_multi_role_i18n.button_role_edit);
+
+    // Hide role input.
+    jQuery('input[name="role"]').hide();
+
+    // Get the role input value.
+    var role = jQuery('input[name="role"]').val();
+
+    // If we have a value, print the slug.
+    if (role) dt_multi_role_print_role_slug(role);
+    // Else, use the role name input value.
+    else dt_multi_role_print_role_slug(jQuery('input[name="role_name"]').val());
+  }); // .click()
+
+  // Simulate clicking the OK button if the user presses "Enter" in the role field.
+  jQuery('input[name="role"]').keypress(function (e) {
+    // 13 is the key code for "Enter".
+    if (13 === e.keyCode) {
+      // Click the edit role button and trigger a focus.
+      jQuery('.role-edit-button').click().trigger('focus');
+
+      // Prevent default behavior and return false.
+      e.preventDefault();
+      return false;
+    }
+  }); // .keypress()
+
+  // Hide the add new role button if we don't at least have a role name.
+  if (!jQuery('.users_page_role-new input[name="role_name"]').val())
+    jQuery('.users_page_role-new #publish').prop('disabled', true);
+
+  // Look for changes to the role name input.
+  jQuery('.users_page_role-new input[name="role_name"]').on(
+    'input',
+    function () {
+      // If there's a role name, enable the add new role button.
+      if (jQuery(this).val())
+        jQuery('.users_page_role-new #publish').prop('disabled', false);
+      // Else, disable the button.
+      else jQuery('.users_page_role-new #publish').prop('disabled', true);
+    },
+  );
+
+  /* ====== Tab Sections and Controls ====== */
+
+  // Create Underscore templates.
+  var section_template = wp.template('members-cap-section');
+  var control_template = wp.template('members-cap-control');
+
+  // Check that the `dt_multi_role_sections` and `dt_multi_role_controls` variables were
+  // passed in via `wp_localize_script()`.
+  if (
+    typeof dt_multi_role_sections !== 'undefined' &&
+    typeof dt_multi_role_controls !== 'undefined'
+  ) {
+    // Loop through the sections and append the template for each.
+    window.lodash.each(dt_multi_role_sections, function (data) {
+      jQuery('.members-tab-wrap').append(section_template(data));
+    });
+
+    // Loop through the controls and append the template for each.
+    window.lodash.each(dt_multi_role_controls, function (data) {
+      jQuery('#members-tab-' + data.section + ' tbody').append(
+        control_template(data),
+      );
+    });
+  }
+
+  /* ====== Tabs ====== */
+
+  // Hides the tab content.
+  jQuery('.members-cap-tabs .members-tab-content').hide();
+
+  // Shows the first tab's content.
+  jQuery('.members-cap-tabs .members-tab-content:first-child').show();
+
+  // Makes the 'aria-selected' attribute true for the first tab nav item.
+  jQuery('.members-tab-nav :first-child').attr('aria-selected', 'true');
+
+  // Copies the current tab item title to the box header.
+  jQuery('.members-which-tab').text(
+    jQuery('.members-tab-nav :first-child a').text(),
+  );
+
+  // When a tab nav item is clicked.
+  jQuery('.members-tab-nav li a').click(function (j) {
+    // Prevent the default browser action when a link is clicked.
+    j.preventDefault();
+
+    // Get the `href` attribute of the item.
+    var href = jQuery(this).attr('href');
+
+    // Hide all tab content.
+    jQuery(this)
+      .parents('.members-cap-tabs')
+      .find('.members-tab-content')
+      .hide();
+
+    // Find the tab content that matches the tab nav item and show it.
+    jQuery(this).parents('.members-cap-tabs').find(href).show();
+
+    // Set the `aria-selected` attribute to false for all tab nav items.
+    jQuery(this)
+      .parents('.members-cap-tabs')
+      .find('.members-tab-title')
+      .attr('aria-selected', 'false');
+
+    // Set the `aria-selected` attribute to true for this tab nav item.
+    jQuery(this).parent().attr('aria-selected', 'true');
+
+    // Copy the current tab item title to the box header.
+    jQuery('.members-which-tab').text(jQuery(this).text());
+  }); // click()
+
+  /* ====== Capability Checkboxes (inside tab content) ====== */
+
+  /**
+   * Counts the number of granted and denied capabilities that are checked and updates
+   * the count in the submit role meta box.
+   *
+   * @since  0.1.0
+   * @access public
+   * @return void
+   */
+  function dt_multi_role_count_caps() {
+    // Count the granted and denied caps that are checked.
+    var granted_count = jQuery(
+      '#members-tab-all input[data-grant-cap]:checked',
+    ).length;
+    var denied_count = jQuery(
+      '#members-tab-all input[data-deny-cap]:checked',
+    ).length;
+
+    // Count the new (added from new cap meta box) granted and denied caps that are checked.
+    var new_granted_count = jQuery(
+      '#members-tab-custom input[name="grant-new-caps[]"]:checked',
+    ).length;
+    var new_denied_count = jQuery(
+      '#members-tab-custom input[name="deny-new-caps[]"]:checked',
+    ).length;
+
+    // Update the submit meta box cap count.
+    jQuery('#submitdiv .granted-count').text(granted_count + new_granted_count);
+    jQuery('#submitdiv .denied-count').text(denied_count + new_denied_count);
+  }
+
+  /**
+   * When a grant/deny checkbox has a change, this function makes sure that any duplicates
+   * also receive that change.  It also unchecks the grant/deny opposite checkbox if needed.
+   *
+   * @since  0.1.0
+   * @access public
+   * @param  object  $checkbox
+   * @return void
+   */
+  function dt_multi_role_check_uncheck(checkbox) {
+    var type = 'grant';
+    var opposite = 'deny';
+
+    // If this is a deny checkbox.
+    if (jQuery(checkbox).attr('data-deny-cap')) {
+      type = 'deny';
+      opposite = 'grant';
+    }
+
+    // Get the capability for this checkbox.
+    var cap = jQuery(checkbox).attr('data-' + type + '-cap');
+
+    // If the checkbox is checked.
+    if (jQuery(checkbox).prop('checked')) {
+      // Check any duplicate checkboxes.
+      jQuery('input[data-' + type + '-cap="' + cap + '"]')
+        .not(checkbox)
+        .prop('checked', true);
+
+      // Uncheck any deny checkboxes with the same cap.
+      jQuery('input[data-' + opposite + '-cap="' + cap + '"]').prop(
+        'checked',
+        false,
+      );
+
+      // If the checkbox is not checked.
+    } else {
+      // Uncheck any duplicate checkboxes.
+      jQuery('input[data-' + type + '-cap="' + cap + '"]')
+        .not(checkbox)
+        .prop('checked', false);
+    }
+  }
+
+  // Count the granted and denied caps that are checked.
+  dt_multi_role_count_caps();
+
+  // When a change is triggered for any grant/deny checkbox. Note that we're using `.on()`
+  // here because we're dealing with dynamically-generated HTML.
+  jQuery(document).on(
+    'change',
+    '.members-cap-checklist input[data-grant-cap], .members-cap-checklist input[data-deny-cap]',
+    function () {
+      // Check/Uncheck boxes.
+      dt_multi_role_check_uncheck(this);
+
+      // Count the granted and denied caps that are checked.
+      dt_multi_role_count_caps();
+    },
+  ); // .on( 'change' )
+
+  // When a cap button is clicked. Note that we're using `.on()` here because we're dealing
+  // with dynamically-generated HTML.
+  //
+  // Note that we only need to trigger `change()` once for our functionality.
+  jQuery(document).on(
+    'click',
+    '.editable-role .members-cap-checklist button',
+    function () {
+      // Get the button parent element.
+      var parent = jQuery(this).closest('.members-cap-checklist');
+
+      // Find the grant and deny checkbox inputs.
+      var grant = jQuery(parent).find('input[data-grant-cap]');
+      var deny = jQuery(parent).find('input[data-deny-cap]');
+
+      // If the grant checkbox is checked.
+      if (jQuery(grant).prop('checked')) {
+        jQuery(grant).prop('checked', false);
+        jQuery(deny).prop('checked', true).change();
+
+        // If the deny checkbox is checked.
+      } else if (jQuery(deny).prop('checked')) {
+        jQuery(grant).prop('checked', false);
+        jQuery(deny).prop('checked', false).change();
+
+        // If neither checkbox is checked.
+      } else {
+        jQuery(grant).prop('checked', true).change();
+      }
+    },
+  ); // on()
+
+  // Remove focus from button when hovering another button.
+  jQuery(document).on(
+    'hover',
+    '.editable-role .members-cap-checklist button',
+    function () {
+      jQuery('.members-cap-checklist button:focus').not(this).blur();
+    },
+  );
+
+  /* ====== Meta Boxes ====== */
+
+  // Add the postbox toggle functionality.
+  // Note: `pagenow` is a global variable set by WordPress.
+  postboxes.add_postbox_toggles(pagenow);
+
+  /* ====== New Cap Meta Box ====== */
+
+  // Give the meta box toggle button a type of `button` so that it doesn't submit the form
+  // when we hit the "Enter" key in our input or toggle open/close the meta box.
+  jQuery('#newcapdiv button.handlediv').attr('type', 'button');
+
+  // Disable the new cap button so that it's not clicked until there's a cap.
+  jQuery('#members-add-new-cap').prop('disabled', true);
+
+  // When the user starts typing a new cap.
+  jQuery('#members-new-cap-field').on('input', function () {
+    // If there's a value in the input, enable the add new button.
+    if (jQuery(this).val()) {
+      jQuery('#members-add-new-cap').prop('disabled', false);
+
+      // If there's no value, disable the button.
+    } else {
+      jQuery('#members-add-new-cap').prop('disabled', true);
+    }
+  }); // .on( 'input' )
+
+  // Simulate clicking the add new cap button if the user presses "Enter" in the new cap field.
+  jQuery('#members-new-cap-field').keypress(function (e) {
+    // 13 is the key code for "Enter".
+    if (13 === e.keyCode) {
+      jQuery('#members-add-new-cap').click();
+      e.preventDefault();
+      return false;
+    }
+  }); // .keypress()
+
+  // When the new cap button is clicked.
+  jQuery('#members-add-new-cap').click(function () {
+    // Get the new cap value.
+    var new_cap = jQuery('#members-new-cap-field').val();
+
+    // Sanitize the new cap.
+    // Note that this will be sanitized on the PHP side as well before save.
+    new_cap = new_cap
+      .trim()
+      .replace(/<.*?>/g, '')
+      .replace(/\s/g, '_')
+      .replace(/[^a-zA-Z0-9_]/g, '');
+
+    // If there's a new cap value.
+    if (new_cap) {
+      // Trigger a click event on the "custom" tab in the edit caps box.
+      jQuery('a[href="#members-tab-custom"]').trigger('click');
+
+      // Replace text placeholder with cap.
+      dt_multi_role_i18n.label_grant_cap =
+        dt_multi_role_i18n.label_grant_cap.replace(
+          /%s/g,
+          '<code>' + new_cap + '</code>',
+        );
+      dt_multi_role_i18n.label_deny_cap =
+        dt_multi_role_i18n.label_deny_cap.replace(
+          /%s/g,
+          '<code>' + new_cap + '</code>',
+        );
+
+      // Set up some data to pass to our Underscore template.
+      var data = {
+        cap: new_cap,
+        readonly: '',
+        name: { grant: 'grant-new-caps[]', deny: 'deny-new-caps[]' },
+        is_granted_cap: true,
+        is_denied_cap: false,
+        label: {
+          grant: dt_multi_role_i18n.label_grant_cap,
+          deny: dt_multi_role_i18n.label_deny_cap,
+        },
+      };
+
+      // Prepend our template to the "custom" edit caps tab content.
+      jQuery('#members-tab-custom tbody').prepend(control_template(data));
+
+      // Get the new cap table row.
+      var parent = jQuery('[data-grant-cap="' + new_cap + '"]').parents(
+        '.members-cap-checklist',
+      );
+
+      // Add the highlight class.
+      jQuery(parent).addClass('members-highlight');
+
+      // Remove the class after a set time for a highlight effect.
+      setTimeout(function () {
+        jQuery(parent).removeClass('members-highlight');
+      }, 500);
+
+      // Set the new cap input value to an empty string.
+      jQuery('#members-new-cap-field').val('');
+
+      // Disable the add new cap button.
+      jQuery('#members-add-new-cap').prop('disabled', true);
+
+      // Trigger a change on our new grant cap checkbox.
+      jQuery(
+        '.members-cap-checklist input[data-grant-cap="' + new_cap + '"]',
+      ).trigger('change');
+    }
+  }); // .click()
+}); // ready()

--- a/dt-core/admin/multi-role/js/settings.js
+++ b/dt-core/admin/multi-role/js/settings.js
@@ -1,30 +1,38 @@
-jQuery( document ).ready( function() {
+jQuery(document).ready(function () {
+  /* ====== Plugin Settings ====== */
 
-	/* ====== Plugin Settings ====== */
+  // Hide content permissions message if disabled.
+  if (
+    false ===
+    jQuery('[name="dt_multi_role_settings[content_permissions]"]').prop(
+      'checked',
+    )
+  ) {
+    jQuery('[name="dt_multi_role_settings[content_permissions]"]')
+      .parents('tr')
+      .next('tr')
+      .hide();
+  }
 
-	// Hide content permissions message if disabled.
-	if ( false === jQuery( '[name="dt_multi_role_settings[content_permissions]"]' ).prop( 'checked' ) ) {
+  // Hide private feed message if private feed disabled.
+  if (
+    false ===
+    jQuery('[name="dt_multi_role_settings[private_feed]"]').prop('checked')
+  ) {
+    jQuery('[name="dt_multi_role_settings[private_feed]"]')
+      .parents('tr')
+      .next('tr')
+      .hide();
+  }
 
-		jQuery( '[name="dt_multi_role_settings[content_permissions]"]' ).parents( 'tr' ).next( 'tr' ).hide();
-	}
-
-	// Hide private feed message if private feed disabled.
-	if ( false === jQuery( '[name="dt_multi_role_settings[private_feed]"]' ).prop( 'checked' ) ) {
-
-		jQuery( '[name="dt_multi_role_settings[private_feed]"]' ).parents( 'tr' ).next( 'tr' ).hide();
-	}
-
-	// Show above hidden items if feature becomes enabled.
-	jQuery( '[name="dt_multi_role_settings[content_permissions]"], [name="dt_multi_role_settings[private_feed]"]' ).on( 'change',
-		function() {
-
-			if ( jQuery( this ).prop( 'checked' ) ) {
-
-				jQuery( this ).parents( 'tr' ).next( 'tr' ).show( 'slow' );
-			} else {
-
-				jQuery( this ).parents( 'tr' ).next( 'tr' ).hide( 'slow' );
-			}
-		}
-	);
-} );
+  // Show above hidden items if feature becomes enabled.
+  jQuery(
+    '[name="dt_multi_role_settings[content_permissions]"], [name="dt_multi_role_settings[private_feed]"]',
+  ).on('change', function () {
+    if (jQuery(this).prop('checked')) {
+      jQuery(this).parents('tr').next('tr').show('slow');
+    } else {
+      jQuery(this).parents('tr').next('tr').hide('slow');
+    }
+  });
+});

--- a/dt-groups/groups.js
+++ b/dt-groups/groups.js
@@ -1,37 +1,40 @@
-"use strict"
-jQuery(document).ready(function($) {
-
-  let post_id        = window.detailsSettings.post_id;
-  let post_type      = window.detailsSettings.post_type;
-  let post           = window.detailsSettings.post_fields;
+'use strict';
+jQuery(document).ready(function ($) {
+  let post_id = window.detailsSettings.post_id;
+  let post_type = window.detailsSettings.post_type;
+  let post = window.detailsSettings.post_fields;
   let field_settings = window.detailsSettings.post_settings.fields;
 
   /* Health Metrics */
   let health_keys = Object.keys(field_settings.health_metrics.default);
 
   function fillOutChurchHealthMetrics() {
-    let practiced_items = window.detailsSettings.post_fields.health_metrics || [];
+    let practiced_items =
+      window.detailsSettings.post_fields.health_metrics || [];
 
     /* Make church commitment circle green */
-    if ( practiced_items.indexOf( 'church_commitment' ) !== -1 ) {
-      $('#health-items-container').addClass( 'committed' );
+    if (practiced_items.indexOf('church_commitment') !== -1) {
+      $('#health-items-container').addClass('committed');
       $('#is-church-switch').prop('checked', true);
     }
 
     /* Color church circle items that are being practiced */
-    let items = $( 'div[id^="icon_"]' );
+    let items = $('div[id^="icon_"]');
 
-    items.each( function( k, v ) {
-        if ( practiced_items.indexOf( v.id.replace( 'icon_', '' ), practiced_items ) !== -1 ) {
-            $( this ).children( 'img' ).attr( 'class','practiced-item' );
-        }
+    items.each(function (k, v) {
+      if (
+        practiced_items.indexOf(v.id.replace('icon_', ''), practiced_items) !==
+        -1
+      ) {
+        $(this).children('img').attr('class', 'practiced-item');
+      }
     });
 
     /* Color group progress buttons */
-    let icons = $( '.group-progress-button' );
-    icons.each( function( k, v ) {
-      if ( practiced_items.indexOf( v.id, practiced_items ) !== -1 ) {
-        $( this ).addClass( 'practiced-button' );
+    let icons = $('.group-progress-button');
+    icons.each(function (k, v) {
+      if (practiced_items.indexOf(v.id, practiced_items) !== -1) {
+        $(this).addClass('practiced-button');
       }
     });
   }
@@ -39,216 +42,250 @@ jQuery(document).ready(function($) {
   fillOutChurchHealthMetrics();
   distributeItems();
 
-  $('.health-item').on( 'click', function() {
-    let fieldId = $( this ).attr( 'id' ).replace('icon_', '');
-    let already_set = window.lodash.get(post, 'health_metrics', []).includes( fieldId );
-    let update = { values: [ { value : fieldId } ] };
-    if ( already_set ){
+  $('.health-item').on('click', function () {
+    let fieldId = $(this).attr('id').replace('icon_', '');
+    let already_set = window.lodash
+      .get(post, 'health_metrics', [])
+      .includes(fieldId);
+    let update = { values: [{ value: fieldId }] };
+    if (already_set) {
       update.values[0].delete = true;
     }
-    window.API.update_post( post_type, post_id, { 'health_metrics': update })
-      .then( groupData => {
+    window.API.update_post(post_type, post_id, { health_metrics: update })
+      .then((groupData) => {
         post = groupData;
         /* Update icon */
-        if ( $( this ).attr( 'id' ) === 'church_commitment' ) {
-          $( '#health-items-container' ).toggleClass( 'committed' );
-          $( this ).toggleClass( 'practiced-button' );
+        if ($(this).attr('id') === 'church_commitment') {
+          $('#health-items-container').toggleClass('committed');
+          $(this).toggleClass('practiced-button');
           return true;
         }
         /* Toggle church health circle item color */
-        $( this ).children( 'img' ).toggleClass( 'practiced-item' );
-        $( this ).children( 'i' ).toggleClass( 'practiced-item' );
-      }).catch( err=>{
-        console.log( err );
-    });
+        $(this).children('img').toggleClass('practiced-item');
+        $(this).children('i').toggleClass('practiced-item');
+      })
+      .catch((err) => {
+        console.log(err);
+      });
   });
 
-  $('#is-church-switch').on( 'click', function() {
+  $('#is-church-switch').on('click', function () {
     let fieldId = 'church_commitment';
-    let already_set = window.lodash.get(post, 'health_metrics', []).includes( fieldId );
-    let update = { values: [ { value : fieldId } ] };
-    if ( already_set ){
+    let already_set = window.lodash
+      .get(post, 'health_metrics', [])
+      .includes(fieldId);
+    let update = { values: [{ value: fieldId }] };
+    if (already_set) {
       update.values[0].delete = true;
     }
-    window.API.update_post( post_type, post_id, { 'health_metrics': update })
-      .then( groupData => {
+    window.API.update_post(post_type, post_id, { health_metrics: update })
+      .then((groupData) => {
         post = groupData;
         /* Update commitment circle */
-        $( '#health-items-container' ).toggleClass( 'committed' );
-      }).catch( err=>{
-        console.log( err );
-    });
-  })
+        $('#health-items-container').toggleClass('committed');
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
 
   /* Dynamically distribute items in Church Health Circle
      according to amount of health metric elements */
   function distributeItems() {
     let radius = 75;
-    let items = $( '.health-item' ),
-        container = $( '#health-items-container' ),
-        item_count = items.length,
-        fade_delay = 45,
-        width = container.width(),
-        height = container.height() + 66,
-        angle = 0,
-        step = (2*Math.PI) / items.length,
-        y_offset = -35;
+    let items = $('.health-item'),
+      container = $('#health-items-container'),
+      item_count = items.length,
+      fade_delay = 45,
+      width = container.width(),
+      height = container.height() + 66,
+      angle = 0,
+      step = (2 * Math.PI) / items.length,
+      y_offset = -35;
 
-        if ( item_count >= 5 && item_count < 7 ) {
-            radius = 90;
-        }
+    if (item_count >= 5 && item_count < 7) {
+      radius = 90;
+    }
 
-        if ( item_count >= 7 & item_count < 11 ) {
-            radius = 100;
-        }
+    if ((item_count >= 7) & (item_count < 11)) {
+      radius = 100;
+    }
 
-        if ( item_count >= 11 ) {
-            radius = 110;
-        }
+    if (item_count >= 11) {
+      radius = 110;
+    }
 
-        if ( item_count == 3 ) {
-            angle = 22.5;
-        }
+    if (item_count == 3) {
+      angle = 22.5;
+    }
 
-    items.each(function() {
-        let X = Math.round( width / 2 + radius * Math.cos(angle) - $( this ).width() / 2 );
-        let y = Math.round( height / 2 + radius * Math.sin(angle) - $( this ).height() / 2 ) + y_offset;
+    items.each(function () {
+      let X = Math.round(
+        width / 2 + radius * Math.cos(angle) - $(this).width() / 2,
+      );
+      let y =
+        Math.round(
+          height / 2 + radius * Math.sin(angle) - $(this).height() / 2,
+        ) + y_offset;
 
-        if ( item_count == 1 ) {
-            X = 112.5;
-            y = 68;
-        }
+      if (item_count == 1) {
+        X = 112.5;
+        y = 68;
+      }
 
-        $(this).css({
-            left: X + 'px',
-            top: y + 'px',
-        });
-        $(this).delay(fade_delay).fadeIn( 1000, 'linear' );
-        angle += step;
-        fade_delay += 45;
+      $(this).css({
+        left: X + 'px',
+        top: y + 'px',
+      });
+      $(this).delay(fade_delay).fadeIn(1000, 'linear');
+      angle += step;
+      fade_delay += 45;
     });
   }
   /* End Health Metrics*/
 
-  let { template_dir } = window.wpApiShare
+  let { template_dir } = window.wpApiShare;
 
   /* Member List*/
-  let memberList = $('.member-list')
-  let memberCountInput = $('#member_count')
-  let leaderCountInput = $('#leader_count')
-  let populateMembersList = ()=>{
-    memberList.empty()
+  let memberList = $('.member-list');
+  let memberCountInput = $('#member_count');
+  let leaderCountInput = $('#leader_count');
+  let populateMembersList = () => {
+    memberList.empty();
 
-    post.members.forEach(m=>{
-      if ( window.lodash.find( post.leaders || [], {ID: m.ID} ) ){
-        m.leader = true
+    post.members.forEach((m) => {
+      if (window.lodash.find(post.leaders || [], { ID: m.ID })) {
+        m.leader = true;
       }
-    })
-    post.members = window.lodash.sortBy(post.members, ["leader", member => member.post_title.toLowerCase()]);
-    post.members.forEach(member=>{
+    });
+    post.members = window.lodash.sortBy(post.members, [
+      'leader',
+      (member) => member.post_title.toLowerCase(),
+    ]);
+    post.members.forEach((member) => {
       let leaderHTML = '';
       let leaderStatus = 'not-leader';
       let leaderStyle = '';
-      if( member.leader ){
+      if (member.leader) {
         leaderStatus = 'leader';
         leaderStyle = 'color:black;';
       }
 
+      const contactStatusHTML =
+        member.data && member.data.overall_status
+          ? `<i class="fi-torso small" style="color: ${window.SHAREDFUNCTIONS.escapeHTML(member.data.overall_status.color)}" title="${window.SHAREDFUNCTIONS.escapeHTML(member.data.overall_status.label)}"></i>`
+          : '<i class="fi-torso small"></i>';
 
-      const contactStatusHTML = ( member.data && member.data.overall_status )
-        ? `<i class="fi-torso small" style="color: ${window.SHAREDFUNCTIONS.escapeHTML( member.data.overall_status.color )}" title="${window.SHAREDFUNCTIONS.escapeHTML( member.data.overall_status.label )}"></i>`
-        : '<i class="fi-torso small"></i>'
-
-      const milestonesHTML = member.data.milestones.reduce((htmlString, milestone) => {
-        return milestone.icon
-          ? htmlString + `<img class="dt-icon" src="${window.SHAREDFUNCTIONS.escapeHTML( milestone.icon )}" alt="${window.SHAREDFUNCTIONS.escapeHTML( milestone.label )}" title="${window.SHAREDFUNCTIONS.escapeHTML( milestone.label )}">`
-          : htmlString
-      }, '')
-      let memberHTML = `<div class="member-row" style="" data-id="${window.SHAREDFUNCTIONS.escapeHTML( member.ID )}">
+      const milestonesHTML = member.data.milestones.reduce(
+        (htmlString, milestone) => {
+          return milestone.icon
+            ? htmlString +
+                `<img class="dt-icon" src="${window.SHAREDFUNCTIONS.escapeHTML(milestone.icon)}" alt="${window.SHAREDFUNCTIONS.escapeHTML(milestone.label)}" title="${window.SHAREDFUNCTIONS.escapeHTML(milestone.label)}">`
+            : htmlString;
+        },
+        '',
+      );
+      let memberHTML = `<div class="member-row" style="" data-id="${window.SHAREDFUNCTIONS.escapeHTML(member.ID)}">
           <div style="flex-grow: 1" class="member-status">
               ${contactStatusHTML}
-              <a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/contacts/${window.SHAREDFUNCTIONS.escapeHTML( member.ID )}">${window.SHAREDFUNCTIONS.escapeHTML(member.post_title)}</a>
+              <a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/contacts/${window.SHAREDFUNCTIONS.escapeHTML(member.ID)}">${window.SHAREDFUNCTIONS.escapeHTML(member.post_title)}</a>
               ${leaderHTML}
               ${milestonesHTML}
           </div>
-          <button class="button clear make-leader member-row-actions ${leaderStatus}" style="${leaderStyle}" data-id="${window.SHAREDFUNCTIONS.escapeHTML( member.ID )}">
+          <button class="button clear make-leader member-row-actions ${leaderStatus}" style="${leaderStyle}" data-id="${window.SHAREDFUNCTIONS.escapeHTML(member.ID)}">
             <i class="fi-foot small"></i>
           </button>
-          <button class="button clear delete-member member-row-actions" data-id="${window.SHAREDFUNCTIONS.escapeHTML( member.ID )}">
+          <button class="button clear delete-member member-row-actions" data-id="${window.SHAREDFUNCTIONS.escapeHTML(member.ID)}">
             <i class="fi-x small"></i>
           </button>
-        </div>`
-      memberList.append(memberHTML)
-    })
+        </div>`;
+      memberList.append(memberHTML);
+    });
     if (post.members.length === 0) {
-      $("#empty-members-list-message").show()
+      $('#empty-members-list-message').show();
     } else {
-      $("#empty-members-list-message").hide()
+      $('#empty-members-list-message').hide();
     }
-    memberCountInput.val( post.member_count )
-    leaderCountInput.val( post.leader_count )
-    window.masonGrid.masonry('layout')
-    document.dispatchEvent(new CustomEvent("dt-member-list-populated", {detail: post}))
-  }
-  populateMembersList()
+    memberCountInput.val(post.member_count);
+    leaderCountInput.val(post.leader_count);
+    window.masonGrid.masonry('layout');
+    document.dispatchEvent(
+      new CustomEvent('dt-member-list-populated', { detail: post }),
+    );
+  };
+  populateMembersList();
 
-  $( document ).on( "dt-post-connection-created", function( e, new_post, field_key ){
-    if ( field_key === "members" ){
-      post = new_post
-      populateMembersList()
+  $(document).on(
+    'dt-post-connection-created',
+    function (e, new_post, field_key) {
+      if (field_key === 'members') {
+        post = new_post;
+        populateMembersList();
+      }
+    },
+  );
+  $(document).on('click', '.delete-member', function () {
+    let id = $(this).data('id');
+    $(`.member-row[data-id="${id}"]`).remove();
+    window.API.update_post(post_type, post_id, {
+      members: { values: [{ value: id, delete: true }] },
+    }).then((groupRes) => {
+      post = groupRes;
+      populateMembersList();
+      window.masonGrid.masonry('layout');
+    });
+    if (window.lodash.find(post.leaders || [], { ID: id })) {
+      window.API.update_post(post_type, post_id, {
+        leaders: { values: [{ value: id, delete: true }] },
+      });
     }
-  } )
-  $(document).on("click", ".delete-member", function () {
-    let id = $(this).data('id')
-    $(`.member-row[data-id="${id}"]`).remove()
-    window.API.update_post( post_type, post_id, {'members': {values:[{value:id, delete:true}]}}).then(groupRes=>{
-      post=groupRes
-      populateMembersList()
-      window.masonGrid.masonry('layout')
-    })
-    if( window.lodash.find( post.leaders || [], {ID: id}) ) {
-      window.API.update_post( post_type, post_id, {'leaders': {values: [{value: id, delete: true}]}})
+  });
+  $(document).on('click', '.make-leader', function () {
+    $(this).children('i').attr('class', 'small');
+    let spinner = `<img src="${template_dir}/dt-assets/images/ajax-loader.gif" width="15px">`;
+    $(this).append(spinner);
+    let id = $(this).data('id');
+    let remove = false;
+    let existingLeaderIcon = $(`.member-row[data-id="${id}"] .leader`);
+    if (
+      window.lodash.find(post.leaders || [], { ID: id }) ||
+      existingLeaderIcon.length !== 0
+    ) {
+      remove = true;
     }
-  })
-  $(document).on("click", ".make-leader", function () {
-    $(this).children('i').attr('class', 'small')
-    let spinner = `<img src="${template_dir}/dt-assets/images/ajax-loader.gif" width="15px">`
-    $(this).append(spinner)
-    let id = $(this).data('id')
-    let remove = false
-    let existingLeaderIcon = $(`.member-row[data-id="${id}"] .leader`)
-    if( window.lodash.find( post.leaders || [], {ID: id}) || existingLeaderIcon.length !== 0){
-      remove = true
-    }
-    window.API.update_post( post_type, post_id, {'leaders': {values:[{value:id, delete:remove}]}}).then(groupRes=>{
-      post=groupRes
-      populateMembersList()
-      window.masonGrid.masonry('layout')
-    })
-  })
-  $('.add-new-member').on("click", function () {
+    window.API.update_post(post_type, post_id, {
+      leaders: { values: [{ value: id, delete: remove }] },
+    }).then((groupRes) => {
+      post = groupRes;
+      populateMembersList();
+      window.masonGrid.masonry('layout');
+    });
+  });
+  $('.add-new-member').on('click', function () {
     $('#add-new-group-member-modal').foundation('open');
-    window.Typeahead[`.js-typeahead-members`].adjustInputSize()
-  })
-  $( document ).on( "dt-post-connection-added", function( e, new_post, field_key ){
+    window.Typeahead[`.js-typeahead-members`].adjustInputSize();
+  });
+  $(document).on('dt-post-connection-added', function (e, new_post, field_key) {
     post = new_post;
-    if ( field_key === "members" ){
-      populateMembersList()
+    if (field_key === 'members') {
+      populateMembersList();
     }
-  })
+  });
 
   /* end Member List */
 
   /* Four Fields */
-  let loadFourFields = ()=>{
-    if ( $('#four-fields').length ) {
-      $('#four_fields_unbelievers').val( post.four_fields_unbelievers )
-      $('#four_fields_believers').val( post.four_fields_believers )
-      $('#four_fields_accountable').val( post.four_fields_accountable )
-      $('#four_fields_church_commitment').val( post.four_fields_church_commitment )
-      $('#four_fields_multiplying').val( post.four_fields_multiplying )
+  let loadFourFields = () => {
+    if ($('#four-fields').length) {
+      $('#four_fields_unbelievers').val(post.four_fields_unbelievers);
+      $('#four_fields_believers').val(post.four_fields_believers);
+      $('#four_fields_accountable').val(post.four_fields_accountable);
+      $('#four_fields_church_commitment').val(
+        post.four_fields_church_commitment,
+      );
+      $('#four_fields_multiplying').val(post.four_fields_multiplying);
     }
-  }
+  };
 
   let ffInputs = `
     <label style="margin-left:33.3%;">
@@ -275,26 +312,31 @@ jQuery(document).ready(function($) {
         <input class="four_fields" style="width: 60%;height: 25%;border: 1px solid #000;text-align: center;font-size: 24px;margin-bottom:0" type="text" name="four_fields_church_commitment" id="four_fields_church_commitment">
         ${window.SHAREDFUNCTIONS.escapeHTML(window.detailsSettings.post_settings.fields.four_fields_church_commitment.name)}
     </label>
-  `
-  $('#four-fields-inputs').append(ffInputs)
-  loadFourFields()
+  `;
+  $('#four-fields-inputs').append(ffInputs);
+  loadFourFields();
 
-  $('input.four_fields').on("blur", function(){
-    const id = $(this).attr('id')
-    const val = $(this).val()
+  $('input.four_fields').on('blur', function () {
+    const id = $(this).attr('id');
+    const val = $(this).val();
 
-    window.API.update_post( post_type, post_id, { [id]: val }).then((resp)=>{
-      $( document ).trigger( "text-input-updated", [ resp, id, val ] );
-    }).catch(window.handleAjaxError)
-  })
+    window.API.update_post(post_type, post_id, { [id]: val })
+      .then((resp) => {
+        $(document).trigger('text-input-updated', [resp, id, val]);
+      })
+      .catch(window.handleAjaxError);
+  });
   /* End Four Fields */
 
-
   //update the end date input when group is closed.
-  $( document ).on( 'select-field-updated', function (e, new_group, field_key, val) {
-    if ( field_key === "group_status" && new_group.end_date){
-      $('#end_date').val(window.SHAREDFUNCTIONS.formatDate( new_group.end_date.timestamp) )
-    }
-  })
-
-})
+  $(document).on(
+    'select-field-updated',
+    function (e, new_group, field_key, val) {
+      if (field_key === 'group_status' && new_group.end_date) {
+        $('#end_date').val(
+          window.SHAREDFUNCTIONS.formatDate(new_group.end_date.timestamp),
+        );
+      }
+    },
+  );
+});

--- a/dt-mapping/drill-down.js
+++ b/dt-mapping/drill-down.js
@@ -1,139 +1,150 @@
-"use strict";
-let rebuild_drill_down = ( response, bindFunction, grid_id, cached = true )=>{
-    let drill_down = jQuery('#'+bindFunction)
+'use strict';
+let rebuild_drill_down = (response, bindFunction, grid_id, cached = true) => {
+  let drill_down = jQuery('#' + bindFunction);
 
-    let final_list = [];
-    let current_selection = {};
-    let html = ``
+  let final_list = [];
+  let current_selection = {};
+  let html = ``;
 
-    html += `<ul style="margin-left:0" class="drill_down">`
-    let selectedGeonameLabel = '';
-    jQuery.each( response, function(i,section) {
+  html += `<ul style="margin-left:0" class="drill_down">`;
+  let selectedGeonameLabel = '';
+  jQuery.each(response, function (i, section) {
+    // check if section is a link or a dropdown list
+    if (section.link) {
+      // highlight the active button
+      let hollowClass = 'hollow';
+      if (section.active) {
+        hollowClass = '';
+        grid_id = section.selected;
+        selectedGeonameLabel = section.selected_name;
+      }
+      let disabled = !response[i + 2];
 
-        // check if section is a link or a dropdown list
-        if ( section.link ) {
+      // create button
+      html += `<li><button id="${window.lodash.escape(section.parent)}" type="button" ${disabled ? 'disabled' : ''}
+                onclick="window.DRILLDOWN.get_drill_down( '${window.lodash.escape(bindFunction)}', '${window.lodash.escape(section.selected)}', ${cached} )"
+                class="button ${hollowClass} geocode-link">${window.lodash.escape(section.selected_name)}</button></li>`;
 
-            // highlight the active button
-            let hollowClass = 'hollow'
-            if ( section.active ) {
-                hollowClass = ''
-                grid_id = section.selected
-                selectedGeonameLabel = section.selected_name
-            }
-            let disabled = !response[i+2]
-
-            // create button
-            html += `<li><button id="${window.lodash.escape( section.parent )}" type="button" ${disabled ? "disabled" : ""}
-                onclick="window.DRILLDOWN.get_drill_down( '${window.lodash.escape( bindFunction )}', '${window.lodash.escape( section.selected )}', ${cached} )"
-                class="button ${hollowClass} geocode-link">${window.lodash.escape( section.selected_name )}</button></li>`
-
-            current_selection = section
-
-        } else { // it is a list
-            // check if list is not empty
-            if (!window.DRILLDOWN.isEmpty(section.list)) {
-
-                // check if hide final drilldown is set and that there are no deeper levels
-                if (window.DRILLDOWN.isEmpty(section.deeper_levels) && window.drilldownModule.settings.hide_final_drill_down === true) {
-                    console.log('no additional dropdown triggered')
-                } else {
-                    // make select
-                    html += `<li><select id="${window.lodash.escape( section.parent )}" style="vertical-align: top"
-                    onchange="DRILLDOWN.get_drill_down( '${window.lodash.escape( bindFunction )}', this.value )"
-                    class="geocode-select">`
-
-                    // make initial option
-                    html += `<option value="${window.lodash.escape( section.parent )}"></option>`
-
-                    // make option list
-                    jQuery.each(section.list, function (ii, item) {
-                        html += `<option value="${window.lodash.escape( item.grid_id )}" `
-                        if (item.grid_id === section.selected) {
-                            html += ` selected`
-                        }
-                        html += `>${window.lodash.escape( item.name )}</option>`
-                    })
-
-                    html += `</select></li>`
-
-                    final_list = section.list;
-                }
-            }
-        }
-
-    })
-
-    html += `<li><span id="spinner" style="display:none;">${window.drilldownModule.settings.spinner_large}</span></li>`
-
-    // close unordered list
-    html += `</ul>`
-
-    // clear and apply new list
-    drill_down.empty().append(html)
-
-    // trigger supplied bind event
-    if ( typeof window.DRILLDOWN[bindFunction] !== "undefined" ) {
-        current_selection.list = final_list
-        window.DRILLDOWN[bindFunction]( grid_id, selectedGeonameLabel, current_selection )
-    }
-
-    window.DRILLDOWN.hide_spinner()
-    return final_list;
-}
-window.DRILLDOWN = {
-    get_drill_down( bindFunction, grid_id, cached = true ) {
-        window.DRILLDOWN.show_spinner()
-
-
-        if ( ! grid_id ) {
-            grid_id = window.drilldownModule.current_map || 'world'
-        }
-
-        let rest = window.drilldownModule.settings.endpoints.get_drilldown_endpoint
-        
-        if ( cached && window.drilldownModule.drilldown && window.drilldownModule.drilldown[grid_id] ){
-            rebuild_drill_down( window.drilldownModule.drilldown[grid_id], bindFunction, grid_id, cached )
+      current_selection = section;
+    } else {
+      // it is a list
+      // check if list is not empty
+      if (!window.DRILLDOWN.isEmpty(section.list)) {
+        // check if hide final drilldown is set and that there are no deeper levels
+        if (
+          window.DRILLDOWN.isEmpty(section.deeper_levels) &&
+          window.drilldownModule.settings.hide_final_drill_down === true
+        ) {
+          console.log('no additional dropdown triggered');
         } else {
-            return jQuery.ajax({
-                type: rest.method,
-                contentType: "application/json; charset=utf-8",
-                data: JSON.stringify( {  "bind_function": bindFunction, "grid_id": grid_id, "cached": cached } ),
-                dataType: "json",
-                url: window.drilldownModule.settings.root + rest.namespace + rest.route,
-                beforeSend: function(xhr) {
-                    xhr.setRequestHeader('X-WP-Nonce', rest.nonce);
-                },
-            })
-            .then( function( response ) {
-                window.drilldownModule.drilldown[grid_id] = response
-                rebuild_drill_down( response, bindFunction, grid_id, cached )
-                
-    
-            }) // end success statement
-            .fail(function (err) {
-                console.log("error")
-                console.log(err)
-                window.DRILLDOWN.hide_spinner()
-            })
+          // make select
+          html += `<li><select id="${window.lodash.escape(section.parent)}" style="vertical-align: top"
+                    onchange="DRILLDOWN.get_drill_down( '${window.lodash.escape(bindFunction)}', this.value )"
+                    class="geocode-select">`;
+
+          // make initial option
+          html += `<option value="${window.lodash.escape(section.parent)}"></option>`;
+
+          // make option list
+          jQuery.each(section.list, function (ii, item) {
+            html += `<option value="${window.lodash.escape(item.grid_id)}" `;
+            if (item.grid_id === section.selected) {
+              html += ` selected`;
+            }
+            html += `>${window.lodash.escape(item.name)}</option>`;
+          });
+
+          html += `</select></li>`;
+
+          final_list = section.list;
         }
+      }
+    }
+  });
 
+  html += `<li><span id="spinner" style="display:none;">${window.drilldownModule.settings.spinner_large}</span></li>`;
 
-    },
+  // close unordered list
+  html += `</ul>`;
 
-    isEmpty(obj) {
-        for(let key in obj) {
-            if( Object.prototype.hasOwnProperty.call(obj, key) )
-                return false;
-        }
-        return true;
-    },
+  // clear and apply new list
+  drill_down.empty().append(html);
 
-    show_spinner() {
-        jQuery('#spinner').show()
-    },
+  // trigger supplied bind event
+  if (typeof window.DRILLDOWN[bindFunction] !== 'undefined') {
+    current_selection.list = final_list;
+    window.DRILLDOWN[bindFunction](
+      grid_id,
+      selectedGeonameLabel,
+      current_selection,
+    );
+  }
 
-    hide_spinner() {
-        jQuery('#spinner').hide()
+  window.DRILLDOWN.hide_spinner();
+  return final_list;
+};
+window.DRILLDOWN = {
+  get_drill_down(bindFunction, grid_id, cached = true) {
+    window.DRILLDOWN.show_spinner();
+
+    if (!grid_id) {
+      grid_id = window.drilldownModule.current_map || 'world';
     }
 
-}
+    let rest = window.drilldownModule.settings.endpoints.get_drilldown_endpoint;
+
+    if (
+      cached &&
+      window.drilldownModule.drilldown &&
+      window.drilldownModule.drilldown[grid_id]
+    ) {
+      rebuild_drill_down(
+        window.drilldownModule.drilldown[grid_id],
+        bindFunction,
+        grid_id,
+        cached,
+      );
+    } else {
+      return jQuery
+        .ajax({
+          type: rest.method,
+          contentType: 'application/json; charset=utf-8',
+          data: JSON.stringify({
+            bind_function: bindFunction,
+            grid_id: grid_id,
+            cached: cached,
+          }),
+          dataType: 'json',
+          url:
+            window.drilldownModule.settings.root + rest.namespace + rest.route,
+          beforeSend: function (xhr) {
+            xhr.setRequestHeader('X-WP-Nonce', rest.nonce);
+          },
+        })
+        .then(function (response) {
+          window.drilldownModule.drilldown[grid_id] = response;
+          rebuild_drill_down(response, bindFunction, grid_id, cached);
+        }) // end success statement
+        .fail(function (err) {
+          console.log('error');
+          console.log(err);
+          window.DRILLDOWN.hide_spinner();
+        });
+    }
+  },
+
+  isEmpty(obj) {
+    for (let key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) return false;
+    }
+    return true;
+  },
+
+  show_spinner() {
+    jQuery('#spinner').show();
+  },
+
+  hide_spinner() {
+    jQuery('#spinner').hide();
+  },
+};

--- a/dt-mapping/geocode-api/mapbox-cookie.js
+++ b/dt-mapping/geocode-api/mapbox-cookie.js
@@ -1,32 +1,32 @@
-function get_map_start( token ) {
-  let c = window.Cookies.get(token)
-  if ( c === undefined ) {
+function get_map_start(token) {
+  let c = window.Cookies.get(token);
+  if (c === undefined) {
     return false;
   }
-  return JSON.parse(c)
+  return JSON.parse(c);
 }
 
-function set_map_start( token, bounds ) {
+function set_map_start(token, bounds) {
   let b = [
     [
-      standardize_coordinates( bounds._ne.lng ),
-      standardize_coordinates( bounds._ne.lat ),
+      standardize_coordinates(bounds._ne.lng),
+      standardize_coordinates(bounds._ne.lat),
     ],
     [
-      standardize_coordinates( bounds._sw.lng ),
-      standardize_coordinates( bounds._sw.lat ),
-    ]
-  ]
-  window.Cookies.set( token, JSON.stringify(b) )
+      standardize_coordinates(bounds._sw.lng),
+      standardize_coordinates(bounds._sw.lat),
+    ],
+  ];
+  window.Cookies.set(token, JSON.stringify(b));
 }
 
-function standardize_coordinates( coord ) {
+function standardize_coordinates(coord) {
   if (coord > 180) {
-    coord = coord - 180
-    coord = -Math.abs(coord)
+    coord = coord - 180;
+    coord = -Math.abs(coord);
   } else if (coord < -180) {
-    coord = coord + 180
-    coord = Math.abs(coord)
+    coord = coord + 180;
+    coord = Math.abs(coord);
   }
-  return coord
+  return coord;
 }

--- a/dt-mapping/geocode-api/mapbox-search-widget.js
+++ b/dt-mapping/geocode-api/mapbox-search-widget.js
@@ -1,14 +1,13 @@
 /** Mapbox search box widget */
-jQuery(document).ready(function(){
-
+jQuery(document).ready(function () {
   // load widget
-  if ( window.dtMapbox.post.length !== 0 ) {
-    window.write_results_box()
+  if (window.dtMapbox.post.length !== 0) {
+    window.write_results_box();
   }
-  jQuery( '#new-mapbox-search' ).on( "click", function() {
-    window.write_input_widget()
+  jQuery('#new-mapbox-search').on('click', function () {
+    window.write_input_widget();
   });
-})
+});
 
 // write location list from post contents
 function write_results_box() {
@@ -19,220 +18,232 @@ function write_results_box() {
           <button class="close-button" data-close aria-label="Close modal" type="button">
             <span aria-hidden="true">&times;</span>
           </button>
-        </div>`)
+        </div>`);
 
-  let lgm_results = jQuery('#location-grid-meta-results')
+  let lgm_results = jQuery('#location-grid-meta-results');
 
-  if ( ( window.dtMapbox.post.location_grid_meta !== undefined && window.dtMapbox.post.location_grid_meta.length !== 0 ) || ( window.dtMapbox.post.contact_address !== undefined && window.dtMapbox.post.contact_address.length !== 0 ) ) {
-
-    if ( window.dtMapbox.post.location_grid_meta !== undefined && window.dtMapbox.post.location_grid_meta.length !== 0 ) {
-      jQuery.each( window.dtMapbox.post.location_grid_meta, function(i,v) {
-        if ( v.grid_meta_id ){
+  if (
+    (window.dtMapbox.post.location_grid_meta !== undefined &&
+      window.dtMapbox.post.location_grid_meta.length !== 0) ||
+    (window.dtMapbox.post.contact_address !== undefined &&
+      window.dtMapbox.post.contact_address.length !== 0)
+  ) {
+    if (
+      window.dtMapbox.post.location_grid_meta !== undefined &&
+      window.dtMapbox.post.location_grid_meta.length !== 0
+    ) {
+      jQuery.each(window.dtMapbox.post.location_grid_meta, function (i, v) {
+        if (v.grid_meta_id) {
           lgm_results.append(`<div class="input-group">
-            <input type="text" class="active-location input-group-field" id="location-${window.lodash.escape( v.grid_meta_id )}" dir="auto" value="${window.lodash.escape( v.label )}" readonly />
+            <input type="text" class="active-location input-group-field" id="location-${window.lodash.escape(v.grid_meta_id)}" dir="auto" value="${window.lodash.escape(v.label)}" readonly />
             <div class="input-group-button">
-              <button type="button" class="button success delete-button-style open-mapping-grid-modal" title="${ window.lodash.escape( window.dtMapbox.translations.open_mapping ) /*Open Modal*/}" data-id="${window.lodash.escape( v.grid_meta_id )}"><i class="fi-map"></i></button>
-              <button type="button" class="button alert delete-button-style delete-button mapbox-delete-button" title="${ window.lodash.escape( window.dtMapbox.translations.delete_location ) /*Delete Location*/}" data-id="${window.lodash.escape( v.grid_meta_id )}">&times;</button>
+              <button type="button" class="button success delete-button-style open-mapping-grid-modal" title="${window.lodash.escape(window.dtMapbox.translations.open_mapping) /*Open Modal*/}" data-id="${window.lodash.escape(v.grid_meta_id)}"><i class="fi-map"></i></button>
+              <button type="button" class="button alert delete-button-style delete-button mapbox-delete-button" title="${window.lodash.escape(window.dtMapbox.translations.delete_location) /*Delete Location*/}" data-id="${window.lodash.escape(v.grid_meta_id)}">&times;</button>
             </div>
-          </div>`)
+          </div>`);
         } else {
           lgm_results.append(`<div class="input-group">
-            <input type="text" class="dt-communication-channel input-group-field" id="${window.lodash.escape( v.key )}" value="${window.lodash.escape( v.label )}" dir="auto" data-field="contact_address" />
+            <input type="text" class="dt-communication-channel input-group-field" id="${window.lodash.escape(v.key)}" value="${window.lodash.escape(v.label)}" dir="auto" data-field="contact_address" />
             <div class="input-group-button">
               <button type="button" class="button success delete-button-style open-mapping-address-modal"
-                  title="${ window.lodash.escape( window.dtMapbox.translations.open_mapping ) /*Open Modal*/}"
-                  data-id="${window.lodash.escape( v.key )}"
+                  title="${window.lodash.escape(window.dtMapbox.translations.open_mapping) /*Open Modal*/}"
+                  data-id="${window.lodash.escape(v.key)}"
                   data-field="contact_address"
-                  data-key="${window.lodash.escape( v.key )}">
+                  data-key="${window.lodash.escape(v.key)}">
                   <i class="fi-pencil"></i>
               </button>
-              <button type="button" class="button alert input-height delete-button-style channel-delete-button delete-button" title="${ window.lodash.escape( window.dtMapbox.translations.delete_location ) /*Delete Location*/}" data-id="${window.lodash.escape( v.key )}" data-field="contact_address" data-key="${window.lodash.escape( v.key )}">&times;</button>
+              <button type="button" class="button alert input-height delete-button-style channel-delete-button delete-button" title="${window.lodash.escape(window.dtMapbox.translations.delete_location) /*Delete Location*/}" data-id="${window.lodash.escape(v.key)}" data-field="contact_address" data-key="${window.lodash.escape(v.key)}">&times;</button>
             </div>
-          </div>`)
+          </div>`);
         }
-      })
+      });
     }
 
-    delete_click_listener()
-    open_modal_grid_listener()
-    open_modal_address_listener()
-    reset_tile_spacing()
+    delete_click_listener();
+    open_modal_grid_listener();
+    open_modal_address_listener();
+    reset_tile_spacing();
   } /*end valid check*/
 
-  new window.Foundation.Reveal(jQuery('#mapping-modal'))
+  new window.Foundation.Reveal(jQuery('#mapping-modal'));
 
-  if ( lgm_results.children().length === 0 ) {
-    window.write_input_widget()
+  if (lgm_results.children().length === 0) {
+    window.write_input_widget();
   }
 }
 
 // adds listener for delete buttons
 function delete_click_listener() {
-  jQuery( '.mapbox-delete-button' ).on( "click", function() {
-
+  jQuery('.mapbox-delete-button').on('click', function () {
     let data = {
       location_grid_meta: {
         values: [
           {
-            grid_meta_id: jQuery(this).data("id"),
+            grid_meta_id: jQuery(this).data('id'),
             delete: true,
-          }
-        ]
-      }
-    }
+          },
+        ],
+      },
+    };
 
-    window.API.update_post( window.dtMapbox.post_type, window.dtMapbox.post_id, data ).then(function (response) {
-      window.dtMapbox.post = response
-      window.write_results_box()
-    }).catch(err => { console.error(err) })
-
+    window.API.update_post(
+      window.dtMapbox.post_type,
+      window.dtMapbox.post_id,
+      data,
+    )
+      .then(function (response) {
+        window.dtMapbox.post = response;
+        window.write_results_box();
+      })
+      .catch((err) => {
+        console.error(err);
+      });
   });
 }
 
-function open_modal_grid_listener(){
-  jQuery('.open-mapping-grid-modal').on("click", function(e){
-    let grid_meta_id = e.currentTarget.dataset.id
+function open_modal_grid_listener() {
+  jQuery('.open-mapping-grid-modal').on('click', function (e) {
+    let grid_meta_id = e.currentTarget.dataset.id;
 
-    jQuery.each( window.dtMapbox.post.location_grid_meta, function(i,v){
-      if ( grid_meta_id === v.grid_meta_id ) {
-        return load_modal( v.lng, v.lat, v.level, v.label, v.grid_id )
+    jQuery.each(window.dtMapbox.post.location_grid_meta, function (i, v) {
+      if (grid_meta_id === v.grid_meta_id) {
+        return load_modal(v.lng, v.lat, v.level, v.label, v.grid_id);
       }
-    })
-  })
+    });
+  });
 }
 
-function open_modal_address_listener(){
-  jQuery('.open-mapping-address-modal').on("click", function(){
+function open_modal_address_listener() {
+  jQuery('.open-mapping-address-modal').on('click', function () {
+    let selected_key = jQuery(this).data('key');
+    let selected_value = jQuery(`#${selected_key}`).val();
+    if (selected_value !== '') {
+      window.write_input_widget();
 
-    let selected_key = jQuery(this).data('key')
-    let selected_value = jQuery(`#${selected_key}`).val()
-    if ( selected_value !== '' ){
-      window.write_input_widget()
+      let mabox_search_input = jQuery('#mapbox-search');
+      mabox_search_input.val(selected_value);
 
-      let mabox_search_input = jQuery('#mapbox-search')
-      mabox_search_input.val( selected_value )
-
-      if ( window.dtMapbox.google_map_key ) {
-        google_autocomplete( mabox_search_input.val() )
+      if (window.dtMapbox.google_map_key) {
+        google_autocomplete(mabox_search_input.val());
       } else {
-        mapbox_autocomplete( mabox_search_input.val() )
+        mapbox_autocomplete(mabox_search_input.val());
       }
 
-      jQuery(this).parent().parent().hide()
+      jQuery(this).parent().parent().hide();
     }
-
-  })
+  });
 }
 
-function load_modal( lng, lat, level, label, grid_id ){
-  let spinner = '<span class="loading-spinner active"></span>'
+function load_modal(lng, lat, level, label, grid_id) {
+  let spinner = '<span class="loading-spinner active"></span>';
 
-  let container = jQuery('#mapping-modal')
-  container.foundation('open')
+  let container = jQuery('#mapping-modal');
+  container.foundation('open');
 
-  let content = jQuery('#mapping-modal-contents')
+  let content = jQuery('#mapping-modal-contents');
   content.empty().append(`
            <div class="grid-x">
-            <div class="cell"><strong>${window.lodash.escape( label )}</strong></div>
+            <div class="cell"><strong>${window.lodash.escape(label)}</strong></div>
             <div class="cell">
                 <div id="map-wrapper">
                     <div id='map'>${spinner}</div>
                 </div>
             </div>
-           </div>`)
+           </div>`);
 
-  let zoom = 15
-  if ( 'admin0' === level ){
-    zoom = 3
-  } else if ( 'admin1' === level ) {
-    zoom = 6
-  } else if ( 'admin2' === level ) {
-    zoom = 10
+  let zoom = 15;
+  if ('admin0' === level) {
+    zoom = 3;
+  } else if ('admin1' === level) {
+    zoom = 6;
+  } else if ('admin2' === level) {
+    zoom = 10;
   }
 
-  jQuery('#map').empty()
+  jQuery('#map').empty();
   window.mapboxgl.accessToken = window.dtMapbox.map_key;
   var map = new window.mapboxgl.Map({
     container: 'map',
     style: 'mapbox://styles/mapbox/streets-v11',
     center: [lng, lat],
     minZoom: 1,
-    zoom: zoom
+    zoom: zoom,
   });
 
-  var marker = new window.mapboxgl.Marker()
-    .setLngLat([lng, lat])
-    .addTo(map);
+  var marker = new window.mapboxgl.Marker().setLngLat([lng, lat]).addTo(map);
 }
 
 // resets the tiles for new spacing
 function reset_tile_spacing() {
-  let masonGrid = jQuery('.grid')
-  if ( typeof masonGrid.masonry !== 'undefined' ){
+  let masonGrid = jQuery('.grid');
+  if (typeof masonGrid.masonry !== 'undefined') {
     masonGrid.masonry({
       itemSelector: '.grid-item',
-      percentPosition: true
+      percentPosition: true,
     });
   }
 }
 
 // writes the geocoding field at the top of the mapping area for adding a new location
 window.write_input_widget = function write_input_widget() {
-
-  if ( jQuery('#mapbox-autocomplete').length === 0 ) {
+  if (jQuery('#mapbox-autocomplete').length === 0) {
     jQuery('#mapbox-wrapper').prepend(`
     <div id="mapbox-autocomplete" class="mapbox-autocomplete input-group" data-autosubmit="true" data-add-address="true">
-        <input id="mapbox-search" type="text" name="mapbox_search" class="input-group-field" autocomplete="off" dir="auto" placeholder="${ window.dtMapbox.translations.search_location /*Search Location*/ }" />
+        <input id="mapbox-search" type="text" name="mapbox_search" class="input-group-field" autocomplete="off" dir="auto" placeholder="${window.dtMapbox.translations.search_location /*Search Location*/}" />
         <div class="input-group-button">
             <button id="mapbox-spinner-button" class="button hollow" style="display:none;border-color:lightgrey;">
                 <span class="" style="border-radius: 50%;width: 24px;height: 24px;border: 0.25rem solid lightgrey;border-top-color: black;animation: spin 1s infinite linear;display: inline-block;"></span>
             </button>
-            <button id="mapbox-clear-autocomplete" class="button alert input-height delete-button-style mapbox-delete-button" type="button" title="${ window.lodash.escape( window.dtMapbox.translations.clear ) /*Delete Location*/}" style="display:none;">&times;</button>
+            <button id="mapbox-clear-autocomplete" class="button alert input-height delete-button-style mapbox-delete-button" type="button" title="${window.lodash.escape(window.dtMapbox.translations.clear) /*Delete Location*/}" style="display:none;">&times;</button>
         </div>
         <div id="mapbox-autocomplete-list" class="mapbox-autocomplete-items"></div>
-    </div>`)
+    </div>`);
   }
 
-  let mapbox_search = jQuery('#mapbox-search')
+  let mapbox_search = jQuery('#mapbox-search');
 
-  window.currentfocus = -1
+  window.currentfocus = -1;
 
   //hide the geocoding options when the user clicks out of the input.
-  let hide_list_setup = false
-  let setup_hide_list = function (){
-    if ( !hide_list_setup ){
-      hide_list_setup = true
-      jQuery(document).mouseup(function(e){
-        let container = jQuery("#mapbox-autocomplete");
-        container.removeClass('active')
-        let list = jQuery('#mapbox-autocomplete-list')
+  let hide_list_setup = false;
+  let setup_hide_list = function () {
+    if (!hide_list_setup) {
+      hide_list_setup = true;
+      jQuery(document).mouseup(function (e) {
+        let container = jQuery('#mapbox-autocomplete');
+        container.removeClass('active');
+        let list = jQuery('#mapbox-autocomplete-list');
         let isEmpty = !jQuery.trim(list.html());
         // if the target of the click isn't the container nor a descendant of the container
-        if (!container.is(e.target) && container.has(e.target).length === 0 && !isEmpty )
-        {
-          list.empty()
+        if (
+          !container.is(e.target) &&
+          container.has(e.target).length === 0 &&
+          !isEmpty
+        ) {
+          list.empty();
         }
       });
     }
-  }
+  };
 
-  mapbox_search.on("keydown", function (e){
+  mapbox_search.on('keydown', function (e) {
     if (e.which === 13) {
       /*If the ENTER key is pressed, prevent the form from being submitted,*/
       e.preventDefault();
     }
-  })
-  mapbox_search.on("keyup", function(e){
-    setup_hide_list()
-    let x = document.getElementById("mapbox-autocomplete-list");
-    if (x) x = x.getElementsByTagName("div");
+  });
+  mapbox_search.on('keyup', function (e) {
+    setup_hide_list();
+    let x = document.getElementById('mapbox-autocomplete-list');
+    if (x) x = x.getElementsByTagName('div');
     if (e.which === 40) {
       /*If the arrow DOWN key is pressed,
       increase the currentFocus variable:*/
       window.currentfocus++;
       /*and and make the current item more visible:*/
       add_active(x);
-    } else if (e.which === 38) { //up
+    } else if (e.which === 38) {
+      //up
       /*If the arrow UP key is pressed,
       decrease the currentFocus variable:*/
       window.currentfocus--;
@@ -243,34 +254,38 @@ window.write_input_widget = function write_input_widget() {
       e.preventDefault();
       if (window.currentfocus > -1) {
         /*and simulate a click on the "active" item:*/
-        close_all_lists(jQuery(jQuery("#mapbox-autocomplete-list div")[window.currentfocus]).data("value"));
+        close_all_lists(
+          jQuery(
+            jQuery('#mapbox-autocomplete-list div')[window.currentfocus],
+          ).data('value'),
+        );
       }
     } else {
-      validate_timer()
+      validate_timer();
     }
-  })
+  });
 
-  let mapbox_clear = jQuery('#mapbox-clear-autocomplete')
-  mapbox_clear.hide().on('click', function(){
-    clear_autocomplete()
-  })
+  let mapbox_clear = jQuery('#mapbox-clear-autocomplete');
+  mapbox_clear.hide().on('click', function () {
+    clear_autocomplete();
+  });
 
-  reset_tile_spacing()
-}
+  reset_tile_spacing();
+};
 function add_active(x) {
   /*a function to classify an item as "active":*/
   if (!x) return false;
   /*start by removing the "active" class on all items:*/
   remove_active(x);
   if (window.currentfocus >= x.length) window.currentfocus = 0;
-  if (window.currentfocus < 0) window.currentfocus = (x.length - 1);
+  if (window.currentfocus < 0) window.currentfocus = x.length - 1;
   /*add class "autocomplete-active":*/
-  x[window.currentfocus].classList.add("mapbox-autocomplete-active");
+  x[window.currentfocus].classList.add('mapbox-autocomplete-active');
 }
 function remove_active(x) {
   /*a function to remove the "active" class from all autocomplete items:*/
   for (var i = 0; i < x.length; i++) {
-    x[i].classList.remove("mapbox-autocomplete-active");
+    x[i].classList.remove('mapbox-autocomplete-active');
   }
 }
 
@@ -278,31 +293,28 @@ function remove_active(x) {
 // essentially the timer is reset each time a new character is added, and waits 1 second after key strokes stop
 window.validate_timer_id = '';
 function validate_timer() {
-
-  clear_timer()
+  clear_timer();
 
   // toggle buttons
-  jQuery('#mapbox-spinner-button').show()
+  jQuery('#mapbox-spinner-button').show();
 
   // set timer
-  window.validate_timer_id = setTimeout(function(){
-
+  window.validate_timer_id = setTimeout(function () {
     //add space under the location input and reset tiles so options are not hidden off the page.
     jQuery('#mapbox-autocomplete').addClass('active');
-    reset_tile_spacing()
+    reset_tile_spacing();
 
     // call geocoder
-    if ( window.dtMapbox.google_map_key ) {
-      google_autocomplete( jQuery('#mapbox-search').val() )
+    if (window.dtMapbox.google_map_key) {
+      google_autocomplete(jQuery('#mapbox-search').val());
     } else {
-      mapbox_autocomplete( jQuery('#mapbox-search').val() )
+      mapbox_autocomplete(jQuery('#mapbox-search').val());
     }
 
     // toggle buttons back
-    jQuery('#mapbox-spinner-button').hide()
-    jQuery('#mapbox-clear-autocomplete').show()
+    jQuery('#mapbox-spinner-button').hide();
+    jQuery('#mapbox-clear-autocomplete').show();
   }, 700);
-
 }
 function clear_timer() {
   clearTimeout(window.validate_timer_id);
@@ -311,49 +323,56 @@ function clear_timer() {
 
 // main processor and router for selection of autocomplete results
 function close_all_lists(selection_id) {
-  if ( typeof selection_id === 'undefined' || selection_id === null) {
-    return
+  if (typeof selection_id === 'undefined' || selection_id === null) {
+    return;
   }
   /* if Geocoding overridden, and plain text address selected */
-  if( 'address' === selection_id ) {
-    jQuery('#mapbox-autocomplete-list').empty()
-    let address = jQuery('#mapbox-search').val()
-    let update = { value: address }
-    post_contact_address( update )
-  }
-
-  /* if Google Geocoding enabled*/
-  else if ( window.dtMapbox.google_map_key ) {
-    jQuery('#mapbox-search').val(window.mapbox_result_features[selection_id].description)
-    jQuery('#mapbox-autocomplete-list').empty()
+  if ('address' === selection_id) {
+    jQuery('#mapbox-autocomplete-list').empty();
+    let address = jQuery('#mapbox-search').val();
+    let update = { value: address };
+    post_contact_address(update);
+  } else if (window.dtMapbox.google_map_key) {
+    /* if Google Geocoding enabled*/
+    jQuery('#mapbox-search').val(
+      window.mapbox_result_features[selection_id].description,
+    );
+    jQuery('#mapbox-autocomplete-list').empty();
 
     const geocoder = new window.google.maps.Geocoder();
-    geocoder.geocode({ placeId: window.mapbox_result_features[selection_id].place_id }, (results, status) => {
-      if (status !== "OK") {
-        console.log("Geocoder failed due to: " + status);
-        return;
-      }
-
-      window.location_data = {
-        location_grid_meta: {
-          values: [
-            {
-              lng: results[0].geometry.location.lng(),
-              lat: results[0].geometry.location.lat(),
-              level: convert_level( results[0].types[0] ),
-              label: window.mapbox_result_features[selection_id].description || results[0].formatted_address,
-              source: 'user'
-            }
-          ]
+    geocoder.geocode(
+      { placeId: window.mapbox_result_features[selection_id].place_id },
+      (results, status) => {
+        if (status !== 'OK') {
+          console.log('Geocoder failed due to: ' + status);
+          return;
         }
-      }
-      post_geocoded_location()
-    });
+
+        window.location_data = {
+          location_grid_meta: {
+            values: [
+              {
+                lng: results[0].geometry.location.lng(),
+                lat: results[0].geometry.location.lat(),
+                level: convert_level(results[0].types[0]),
+                label:
+                  window.mapbox_result_features[selection_id].description ||
+                  results[0].formatted_address,
+                source: 'user',
+              },
+            ],
+          },
+        };
+        post_geocoded_location();
+      },
+    );
 
     /* if Mapbox enabled */
   } else {
-    jQuery('#mapbox-search').val(window.mapbox_result_features[selection_id].place_name)
-    jQuery('#mapbox-autocomplete-list').empty()
+    jQuery('#mapbox-search').val(
+      window.mapbox_result_features[selection_id].place_name,
+    );
+    jQuery('#mapbox-autocomplete-list').empty();
 
     window.location_data = {
       location_grid_meta: {
@@ -363,144 +382,164 @@ function close_all_lists(selection_id) {
             lat: window.mapbox_result_features[selection_id].center[1],
             level: window.mapbox_result_features[selection_id].place_type[0],
             label: window.mapbox_result_features[selection_id].place_name,
-            source: 'user'
-          }
-        ]
-      }
-    }
-    post_geocoded_location()
+            source: 'user',
+          },
+        ],
+      },
+    };
+    post_geocoded_location();
   }
 }
 
 // builds the mapbox autocomplete list for selection
-function mapbox_autocomplete(address){
-  if ( address.length < 1 ) {
-    jQuery('#mapbox-clear-autocomplete').hide()
+function mapbox_autocomplete(address) {
+  if (address.length < 1) {
+    jQuery('#mapbox-clear-autocomplete').hide();
     return;
   }
 
-  let root = 'https://api.mapbox.com/geocoding/v5/mapbox.places/'
-  let settings = '.json?types=country,region,postcode,district,place,locality,neighborhood,address&limit=6&access_token='
-  let key = window.dtMapbox.map_key
-  let url = root + encodeURI( address ) + settings + key
+  let root = 'https://api.mapbox.com/geocoding/v5/mapbox.places/';
+  let settings =
+    '.json?types=country,region,postcode,district,place,locality,neighborhood,address&limit=6&access_token=';
+  let key = window.dtMapbox.map_key;
+  let url = root + encodeURI(address) + settings + key;
 
-  fetch( url, {
-    referrerPolicy: "strict-origin-when-cross-origin"
-  }).then(response => response.json())
-  .then( data => {
-    if( data.features.length < 1 ) {
-      // destroy lists
-      console.log('no results')
-      return
-    }
-
-    let list = jQuery('#mapbox-autocomplete-list')
-    list.empty()
-
-    jQuery.each( data.features, function( index, value ) {
-      if ( 4 > index ){
-        list.append(`<div data-value="${window.lodash.escape( index )}">${window.lodash.escape( value.place_name )}</div>`)
+  fetch(url, {
+    referrerPolicy: 'strict-origin-when-cross-origin',
+  })
+    .then((response) => response.json())
+    .then((data) => {
+      if (data.features.length < 1) {
+        // destroy lists
+        console.log('no results');
+        return;
       }
-    })
 
-    let add_address = jQuery('#mapbox-autocomplete').data('add-address')
-    if ( typeof add_address === 'undefined' || add_address === true ) {
-      list.append(`<div data-value="address" style="font-weight:bold;">${window.lodash.escape( window.dtMapbox.translations.use )}: <span dir="auto">"${window.lodash.escape( address )}"</span></div>`)
-    }
+      let list = jQuery('#mapbox-autocomplete-list');
+      list.empty();
 
-    jQuery('#mapbox-autocomplete-list div').on("click", function (e) {
-      close_all_lists(e.target.attributes['data-value'].value);
-    });
-
-    // Set globals
-    window.mapbox_result_features = data.features
-
-
-  }); // end get request
-} // end validate
-
-// builds the autocomplete list from Google (if Google key is installed)
-function google_autocomplete(address){
-  if ( address.length < 1 ) {
-    jQuery('#mapbox-clear-autocomplete').hide()
-    return;
-  }
-
-  let service = new window.google.maps.places.AutocompleteService();
-  service.getPlacePredictions({ 'input': address }, function(predictions, status ) {
-    let list = jQuery('#mapbox-autocomplete-list')
-    list.empty()
-
-    if ( status === 'OK' ) {
-      jQuery.each( predictions, function( index, value ) {
-        if ( 4 > index ) {
-          list.append(`<div data-value="${index}">${window.lodash.escape(value.description)}</div>`)
+      jQuery.each(data.features, function (index, value) {
+        if (4 > index) {
+          list.append(
+            `<div data-value="${window.lodash.escape(index)}">${window.lodash.escape(value.place_name)}</div>`,
+          );
         }
-      })
+      });
 
-      let add_address = jQuery('#mapbox-autocomplete').data('add-address')
-      if ( typeof add_address === 'undefined' || add_address === true ) {
-        list.append(`<div data-value="address" style="font-weight:bold;">${window.lodash.escape( window.dtMapbox.translations.use )}: <span dir="auto">"${window.lodash.escape( address )}"</span></div>`)
+      let add_address = jQuery('#mapbox-autocomplete').data('add-address');
+      if (typeof add_address === 'undefined' || add_address === true) {
+        list.append(
+          `<div data-value="address" style="font-weight:bold;">${window.lodash.escape(window.dtMapbox.translations.use)}: <span dir="auto">"${window.lodash.escape(address)}"</span></div>`,
+        );
       }
 
-      jQuery('#mapbox-autocomplete-list div').on("click", function (e) {
+      jQuery('#mapbox-autocomplete-list div').on('click', function (e) {
         close_all_lists(e.target.attributes['data-value'].value);
       });
 
       // Set globals
-      window.mapbox_result_features = predictions
-    }
-    else if ( status === 'ZERO_RESULTS' ) {
-      list.append(`<div>No Results Found</div>`)
-      list.append(`<div data-value="address" style="font-weight:bold;">${window.lodash.escape( window.dtMapbox.translations.use )}: <span dir="auto">"${window.lodash.escape( address )}"</span></div>`)
+      window.mapbox_result_features = data.features;
+    }); // end get request
+} // end validate
 
-      jQuery('#mapbox-autocomplete-list div').on("click", function (e) {
-        close_all_lists(e.target.attributes['data-value'].value);
-      });
-    }
-    else {
-      console.log('Predictions was not successful for the following reason: ' + status)
-    }
-  })
+// builds the autocomplete list from Google (if Google key is installed)
+function google_autocomplete(address) {
+  if (address.length < 1) {
+    jQuery('#mapbox-clear-autocomplete').hide();
+    return;
+  }
+
+  let service = new window.google.maps.places.AutocompleteService();
+  service.getPlacePredictions(
+    { input: address },
+    function (predictions, status) {
+      let list = jQuery('#mapbox-autocomplete-list');
+      list.empty();
+
+      if (status === 'OK') {
+        jQuery.each(predictions, function (index, value) {
+          if (4 > index) {
+            list.append(
+              `<div data-value="${index}">${window.lodash.escape(value.description)}</div>`,
+            );
+          }
+        });
+
+        let add_address = jQuery('#mapbox-autocomplete').data('add-address');
+        if (typeof add_address === 'undefined' || add_address === true) {
+          list.append(
+            `<div data-value="address" style="font-weight:bold;">${window.lodash.escape(window.dtMapbox.translations.use)}: <span dir="auto">"${window.lodash.escape(address)}"</span></div>`,
+          );
+        }
+
+        jQuery('#mapbox-autocomplete-list div').on('click', function (e) {
+          close_all_lists(e.target.attributes['data-value'].value);
+        });
+
+        // Set globals
+        window.mapbox_result_features = predictions;
+      } else if (status === 'ZERO_RESULTS') {
+        list.append(`<div>No Results Found</div>`);
+        list.append(
+          `<div data-value="address" style="font-weight:bold;">${window.lodash.escape(window.dtMapbox.translations.use)}: <span dir="auto">"${window.lodash.escape(address)}"</span></div>`,
+        );
+
+        jQuery('#mapbox-autocomplete-list div').on('click', function (e) {
+          close_all_lists(e.target.attributes['data-value'].value);
+        });
+      } else {
+        console.log(
+          'Predictions was not successful for the following reason: ' + status,
+        );
+      }
+    },
+  );
 }
 
 // submits geocoded results and resets list
 function post_geocoded_location() {
-  if ( jQuery('#mapbox-autocomplete').data('autosubmit') ) {
+  if (jQuery('#mapbox-autocomplete').data('autosubmit')) {
     /* if post_type = user, else all other post types */
-    jQuery('#mapbox-spinner-button').show()
+    jQuery('#mapbox-spinner-button').show();
 
-    window.API.update_post( window.dtMapbox.post_type, window.dtMapbox.post_id, window.location_data ).then(function (response) {
-      window.dtMapbox.post = response
-      jQuery('#mapbox-wrapper').empty()
-      window.write_results_box()
-
-    }).catch(err => { console.error(err) })
-
+    window.API.update_post(
+      window.dtMapbox.post_type,
+      window.dtMapbox.post_id,
+      window.location_data,
+    )
+      .then(function (response) {
+        window.dtMapbox.post = response;
+        jQuery('#mapbox-wrapper').empty();
+        window.write_results_box();
+      })
+      .catch((err) => {
+        console.error(err);
+      });
   } else {
-    window.selected_location_grid_meta = window.location_data
-    jQuery('#mapbox-spinner-button').hide()
-    jQuery('#mapbox-clear-autocomplete').show()
+    window.selected_location_grid_meta = window.location_data;
+    jQuery('#mapbox-spinner-button').hide();
+    jQuery('#mapbox-clear-autocomplete').show();
   }
 }
 
 // submits address override and resets list
-function post_contact_address( update ) {
-
-  let mapbox_autocomplete = jQuery('#mapbox-autocomplete')
+function post_contact_address(update) {
+  let mapbox_autocomplete = jQuery('#mapbox-autocomplete');
 
   // if autosubmit true (normal behavior on details pages)
-  if ( mapbox_autocomplete.data('autosubmit') ) {
-    jQuery('#mapbox-spinner-button').show()
+  if (mapbox_autocomplete.data('autosubmit')) {
+    jQuery('#mapbox-spinner-button').show();
 
-    window.API.update_post(window.dtMapbox.post_type, window.dtMapbox.post_id, {["contact_address"]: [update]}).then((updatedContact) => {
-      window.dtMapbox.post = updatedContact
-      jQuery('#mapbox-wrapper').empty()
-      window.write_results_box()
-    }).catch(window.handleAjaxError)
-
+    window.API.update_post(window.dtMapbox.post_type, window.dtMapbox.post_id, {
+      ['contact_address']: [update],
+    })
+      .then((updatedContact) => {
+        window.dtMapbox.post = updatedContact;
+        jQuery('#mapbox-wrapper').empty();
+        window.write_results_box();
+      })
+      .catch(window.handleAjaxError);
   } else {
-
     // if autosubmit false (primarily used on new post template)
     jQuery(`<div class="input-group" id="new_contact_address_container">
                 <input type="text"
@@ -512,42 +551,42 @@ function post_contact_address( update ) {
                 <div class="input-group-button">
                   <button class="button alert input-height delete-button-style channel-delete-button delete-button new-contact_address" data-field="contact_address" data-key="contact_address">&times;</button>
                 </div>
-           </div>`).insertAfter(mapbox_autocomplete)
-    jQuery('button.delete-button.new-contact_address').on('click', function(){
-      jQuery('#new_contact_address_container').remove()
-    })
-    clear_autocomplete()
+           </div>`).insertAfter(mapbox_autocomplete);
+    jQuery('button.delete-button.new-contact_address').on('click', function () {
+      jQuery('#new_contact_address_container').remove();
+    });
+    clear_autocomplete();
   }
 }
 
-function clear_autocomplete(){
-  jQuery('#mapbox-search').val('')
-  jQuery('#mapbox-autocomplete-list').empty()
-  jQuery('#mapbox-spinner-button').hide()
-  jQuery('#mapbox-clear-autocomplete').hide()
+function clear_autocomplete() {
+  jQuery('#mapbox-search').val('');
+  jQuery('#mapbox-autocomplete-list').empty();
+  jQuery('#mapbox-spinner-button').hide();
+  jQuery('#mapbox-clear-autocomplete').hide();
 }
 
 // converts the long admin level response to a location grid version
-function convert_level( level ) {
-  switch(level){
+function convert_level(level) {
+  switch (level) {
     case 'administrative_area_level_0':
-      level = 'admin0'
-      break
+      level = 'admin0';
+      break;
     case 'administrative_area_level_1':
-      level = 'admin1'
-      break
+      level = 'admin1';
+      break;
     case 'administrative_area_level_2':
-      level = 'admin2'
-      break
+      level = 'admin2';
+      break;
     case 'administrative_area_level_3':
-      level = 'admin3'
-      break
+      level = 'admin3';
+      break;
     case 'administrative_area_level_4':
-      level = 'admin4'
-      break
+      level = 'admin4';
+      break;
     case 'administrative_area_level_5':
-      level = 'admin5'
-      break
+      level = 'admin5';
+      break;
   }
-  return level
+  return level;
 }

--- a/dt-mapping/geocode-api/mapbox-users-search-widget.js
+++ b/dt-mapping/geocode-api/mapbox-users-search-widget.js
@@ -1,120 +1,131 @@
 /** Mapbox search box widget for users */
-jQuery(document).ready(function(){
-
+jQuery(document).ready(function () {
   // load widget
-  if ( window.dtMapbox.user_location.length !== 0 ) {
-    window.write_results_box()
+  if (window.dtMapbox.user_location.length !== 0) {
+    window.write_results_box();
   }
-  jQuery( '#new-mapbox-search' ).on( "click", function() {
-    window.write_input_widget()
+  jQuery('#new-mapbox-search').on('click', function () {
+    window.write_input_widget();
   });
-
-})
+});
 
 function write_results_box() {
-  jQuery('#mapbox-wrapper').empty().append(`<div id="location-grid-meta-results"></div>`)
+  jQuery('#mapbox-wrapper')
+    .empty()
+    .append(`<div id="location-grid-meta-results"></div>`);
 
-  if ( window.dtMapbox.user_location.location_grid_meta !== undefined && window.dtMapbox.user_location.location_grid_meta.length !== 0 ) {
-    let lgm_results = jQuery('#location-grid-meta-results')
-    jQuery.each( window.dtMapbox.user_location.location_grid_meta, function(i,v) {
-      lgm_results.append(`<div class="input-group">
-                              <input type="text" class="active-location input-group-field " id="location-${window.lodash.escape( v.grid_meta_id )}" value="${window.lodash.escape( v.label )}" readonly />
+  if (
+    window.dtMapbox.user_location.location_grid_meta !== undefined &&
+    window.dtMapbox.user_location.location_grid_meta.length !== 0
+  ) {
+    let lgm_results = jQuery('#location-grid-meta-results');
+    jQuery.each(
+      window.dtMapbox.user_location.location_grid_meta,
+      function (i, v) {
+        lgm_results.append(`<div class="input-group">
+                              <input type="text" class="active-location input-group-field " id="location-${window.lodash.escape(v.grid_meta_id)}" value="${window.lodash.escape(v.label)}" readonly />
                               <div class="input-group-button">
-                                <button type="button" class="button alert clear-date-button delete-button mapbox-delete-button" title="${ window.lodash.escape( window.dtMapbox.translations.delete_location ) /*Delete Location*/}" data-id="${window.lodash.escape( v.grid_meta_id )}">&times;</button>
+                                <button type="button" class="button alert clear-date-button delete-button mapbox-delete-button" title="${window.lodash.escape(window.dtMapbox.translations.delete_location) /*Delete Location*/}" data-id="${window.lodash.escape(v.grid_meta_id)}">&times;</button>
                               </div>
-                            </div>`)
-    })
-    delete_location_listener()
-    reset_tile_spacing()
+                            </div>`);
+      },
+    );
+    delete_location_listener();
+    reset_tile_spacing();
   } /*end valid check*/
 }
 
 function delete_location_listener() {
-  jQuery( '.mapbox-delete-button' ).on( "click", function(e) {
-
+  jQuery('.mapbox-delete-button').on('click', function (e) {
     let data = {
       user_id: window.dtMapbox.user_id,
       user_location: {
         location_grid_meta: [
           {
-            grid_meta_id: jQuery(this).data("id"),
-          }
-        ]
-      }
-    }
+            grid_meta_id: jQuery(this).data('id'),
+          },
+        ],
+      },
+    };
 
-    window.makeRequest( "DELETE", `users/user_location`, data )
-    .then(function (response) {
-      window.dtMapbox.user_location = response.user_location
-      window.dtMapbox.user_id = response.user_id
-      window.write_results_box()
-    }).catch(err => { console.error(err) })
-
+    window
+      .makeRequest('DELETE', `users/user_location`, data)
+      .then(function (response) {
+        window.dtMapbox.user_location = response.user_location;
+        window.dtMapbox.user_id = response.user_id;
+        window.write_results_box();
+      })
+      .catch((err) => {
+        console.error(err);
+      });
   });
 }
 
 function reset_tile_spacing() {
-  let masonGrid = jQuery('.grid')
+  let masonGrid = jQuery('.grid');
   masonGrid.masonry({
     itemSelector: '.grid-item',
-    percentPosition: true
+    percentPosition: true,
   });
 }
 
 function write_input_widget() {
-
-  if ( jQuery('#mapbox-autocomplete').length === 0 ) {
+  if (jQuery('#mapbox-autocomplete').length === 0) {
     jQuery('#mapbox-wrapper').prepend(`
     <div id="mapbox-autocomplete" class="mapbox-autocomplete input-group" data-autosubmit="true">
         <input id="mapbox-search" type="text" name="mapbox_search" placeholder="Search Location" autocomplete="off" dir="auto" />
         <div class="input-group-button">
             <button id="mapbox-spinner-button" class="button hollow" style="display:none;"><span class="loading-spinner active"></span></button>
-            <button id="mapbox-clear-autocomplete" class="button alert input-height delete-button-style mapbox-delete-button" type="button" title="${ window.lodash.escape( window.dtMapbox.translations.clear ) /*Delete Location*/}" >&times;</button>
+            <button id="mapbox-clear-autocomplete" class="button alert input-height delete-button-style mapbox-delete-button" type="button" title="${window.lodash.escape(window.dtMapbox.translations.clear) /*Delete Location*/}" >&times;</button>
         </div>
         <div id="mapbox-autocomplete-list" class="mapbox-autocomplete-items"></div>
     </div>
-  `)
+  `);
   }
 
-  window.currentfocus = -1
+  window.currentfocus = -1;
 
   //hide the geocoding options when the user clicks out of the input.
-  let hide_list_setup = false
-  let setup_hide_list = function (){
-    if ( !hide_list_setup ){
-      hide_list_setup = true
-      jQuery(document).mouseup(function(e){
-        let container = jQuery("#mapbox-autocomplete");
-        let list = jQuery('#mapbox-autocomplete-list')
+  let hide_list_setup = false;
+  let setup_hide_list = function () {
+    if (!hide_list_setup) {
+      hide_list_setup = true;
+      jQuery(document).mouseup(function (e) {
+        let container = jQuery('#mapbox-autocomplete');
+        let list = jQuery('#mapbox-autocomplete-list');
         let isEmpty = !jQuery.trim(list.html());
         // if the target of the click isn't the container nor a descendant of the container
-        if (!container.is(e.target) && container.has(e.target).length === 0 && !isEmpty )
-        {
-          list.empty()
+        if (
+          !container.is(e.target) &&
+          container.has(e.target).length === 0 &&
+          !isEmpty
+        ) {
+          list.empty();
         }
       });
     }
-  }
+  };
 
-  let mapbox_search = jQuery('#mapbox-search')
-  mapbox_search.on("keydown", function (e){
+  let mapbox_search = jQuery('#mapbox-search');
+  mapbox_search.on('keydown', function (e) {
     if (e.which === 13) {
       /*If the ENTER key is pressed, prevent the form from being submitted,*/
       e.preventDefault();
     }
-  })
+  });
 
-  mapbox_search.on("keyup", function(e){
-    setup_hide_list()
-    var x = document.getElementById("mapbox-autocomplete-list");
-    if (x) x = x.getElementsByTagName("div");
+  mapbox_search.on('keyup', function (e) {
+    setup_hide_list();
+    var x = document.getElementById('mapbox-autocomplete-list');
+    if (x) x = x.getElementsByTagName('div');
     if (e.which === 40) {
       /*If the arrow DOWN key is pressed,
       increase the currentFocus variable:*/
       window.currentfocus++;
       /*and and make the current item more visible:*/
       add_active(x);
-    } else if (e.which === 38) { //up
+    } else if (e.which === 38) {
+      //up
       /*If the arrow UP key is pressed,
       decrease the currentFocus variable:*/
       window.currentfocus--;
@@ -128,120 +139,120 @@ function write_input_widget() {
         close_all_lists(window.currentfocus);
       }
     } else {
-      validate_timer()
+      validate_timer();
     }
+  });
 
-  })
+  let mapbox_clear = jQuery('#mapbox-clear-autocomplete');
+  mapbox_clear.hide().on('click', function () {
+    clear_autocomplete();
+  });
 
-  let mapbox_clear = jQuery('#mapbox-clear-autocomplete')
-  mapbox_clear.hide().on('click', function(){
-    clear_autocomplete()
-  })
-
-  reset_tile_spacing()
-
+  reset_tile_spacing();
 }
 
 // delay location lookup
 window.validate_timer_id = '';
 function validate_timer() {
-
-  clear_timer()
+  clear_timer();
 
   // toggle buttons
-  jQuery('#mapbox-spinner-button').show()
+  jQuery('#mapbox-spinner-button').show();
 
   // set timer
-  window.validate_timer_id = setTimeout(function(){
+  window.validate_timer_id = setTimeout(function () {
     // call geocoder
-    if ( window.dtMapbox.google_map_key ) {
-      google_autocomplete( jQuery('#mapbox-search').val() )
+    if (window.dtMapbox.google_map_key) {
+      google_autocomplete(jQuery('#mapbox-search').val());
     } else {
-      mapbox_autocomplete( jQuery('#mapbox-search').val() )
+      mapbox_autocomplete(jQuery('#mapbox-search').val());
     }
 
     // toggle buttons back
-    jQuery('#mapbox-spinner-button').hide()
-    jQuery('#mapbox-clear-autocomplete').show()
+    jQuery('#mapbox-spinner-button').hide();
+    jQuery('#mapbox-clear-autocomplete').show();
   }, 700);
-
 }
 function clear_timer() {
   clearTimeout(window.validate_timer_id);
 }
 // end delay location lookup
 
-function mapbox_autocomplete(address){
-  if ( address.length < 1 ) {
-    jQuery('#mapbox-clear-autocomplete').hide()
+function mapbox_autocomplete(address) {
+  if (address.length < 1) {
+    jQuery('#mapbox-clear-autocomplete').hide();
     return;
   }
 
-  let root = 'https://api.mapbox.com/geocoding/v5/mapbox.places/'
-  let settings = '.json?types=country,region,postcode,district,place,locality,neighborhood,address&limit=6&access_token='
-  let key = window.dtMapbox.map_key
+  let root = 'https://api.mapbox.com/geocoding/v5/mapbox.places/';
+  let settings =
+    '.json?types=country,region,postcode,district,place,locality,neighborhood,address&limit=6&access_token=';
+  let key = window.dtMapbox.map_key;
 
-  let url = root + encodeURI( address ) + settings + key
+  let url = root + encodeURI(address) + settings + key;
 
-  fetch( url, {
-    referrerPolicy: "strict-origin-when-cross-origin"
-  }).then(response => response.json())
-  .then( data => {
-    if( data.features.length < 1 ) {
-      // destroy lists
-      return
-    }
+  fetch(url, {
+    referrerPolicy: 'strict-origin-when-cross-origin',
+  })
+    .then((response) => response.json())
+    .then((data) => {
+      if (data.features.length < 1) {
+        // destroy lists
+        return;
+      }
 
-    let list = jQuery('#mapbox-autocomplete-list')
-    list.empty()
+      let list = jQuery('#mapbox-autocomplete-list');
+      list.empty();
 
-    jQuery.each( data.features, function( index, value ) {
-      list.append(`<div data-value="${window.lodash.escape(index)}">${window.lodash.escape(value.place_name)}</div>`)
-    })
+      jQuery.each(data.features, function (index, value) {
+        list.append(
+          `<div data-value="${window.lodash.escape(index)}">${window.lodash.escape(value.place_name)}</div>`,
+        );
+      });
 
-    jQuery('#mapbox-autocomplete-list div').on("click", function (e) {
-      close_all_lists(e.target.attributes['data-value'].value);
-    });
-
-    // Set globals
-    window.mapbox_result_features = data.features
-
-
-  }); // end get request
-} // end validate
-
-function google_autocomplete(address){
-  if ( address.length < 1 ) {
-    jQuery('#mapbox-clear-autocomplete').hide()
-    return;
-  }
-
-  let service = new window.google.maps.places.AutocompleteService();
-  service.getPlacePredictions({ 'input': address }, function(predictions, status ) {
-    let list = jQuery('#mapbox-autocomplete-list')
-    list.empty()
-    if (status === 'OK') {
-
-      jQuery.each( predictions, function( index, value ) {
-        list.append(`<div data-value="${window.lodash.escape(index)}">${window.lodash.escape(value.description)}</div>`)
-      })
-
-      jQuery('#mapbox-autocomplete-list div').on("click", function (e) {
+      jQuery('#mapbox-autocomplete-list div').on('click', function (e) {
         close_all_lists(e.target.attributes['data-value'].value);
       });
 
       // Set globals
-      window.mapbox_result_features = predictions
+      window.mapbox_result_features = data.features;
+    }); // end get request
+} // end validate
 
-    }
-    else if ( status === 'ZERO_RESULTS' ) {
-      list.append(`<div>No Results Found</div>`)
-    }
-    else {
-      console.log('Predictions was not successful for the following reason: ' + status)
-    }
-  } )
+function google_autocomplete(address) {
+  if (address.length < 1) {
+    jQuery('#mapbox-clear-autocomplete').hide();
+    return;
+  }
 
+  let service = new window.google.maps.places.AutocompleteService();
+  service.getPlacePredictions(
+    { input: address },
+    function (predictions, status) {
+      let list = jQuery('#mapbox-autocomplete-list');
+      list.empty();
+      if (status === 'OK') {
+        jQuery.each(predictions, function (index, value) {
+          list.append(
+            `<div data-value="${window.lodash.escape(index)}">${window.lodash.escape(value.description)}</div>`,
+          );
+        });
+
+        jQuery('#mapbox-autocomplete-list div').on('click', function (e) {
+          close_all_lists(e.target.attributes['data-value'].value);
+        });
+
+        // Set globals
+        window.mapbox_result_features = predictions;
+      } else if (status === 'ZERO_RESULTS') {
+        list.append(`<div>No Results Found</div>`);
+      } else {
+        console.log(
+          'Predictions was not successful for the following reason: ' + status,
+        );
+      }
+    },
+  );
 } // end validate
 
 function add_active(x) {
@@ -250,48 +261,54 @@ function add_active(x) {
   /*start by removing the "active" class on all items:*/
   remove_active(x);
   if (window.currentfocus >= x.length) window.currentfocus = 0;
-  if (window.currentfocus < 0) window.currentfocus = (x.length - 1);
+  if (window.currentfocus < 0) window.currentfocus = x.length - 1;
   /*add class "autocomplete-active":*/
-  x[window.currentfocus].classList.add("mapbox-autocomplete-active");
+  x[window.currentfocus].classList.add('mapbox-autocomplete-active');
 }
 function remove_active(x) {
   /*a function to remove the "active" class from all autocomplete items:*/
   for (var i = 0; i < x.length; i++) {
-    x[i].classList.remove("mapbox-autocomplete-active");
+    x[i].classList.remove('mapbox-autocomplete-active');
   }
 }
 function close_all_lists(selection_id) {
-
-  if ( window.dtMapbox.google_map_key ) {
-    jQuery('#mapbox-search').val(window.mapbox_result_features[selection_id].description)
-    jQuery('#mapbox-autocomplete-list').empty()
+  if (window.dtMapbox.google_map_key) {
+    jQuery('#mapbox-search').val(
+      window.mapbox_result_features[selection_id].description,
+    );
+    jQuery('#mapbox-autocomplete-list').empty();
 
     const geocoder = new window.google.maps.Geocoder();
-    geocoder.geocode({ placeId: window.mapbox_result_features[selection_id].place_id }, (results, status) => {
-      if (status !== "OK") {
-        console.log("Geocoder failed due to: " + status);
-        return;
-      }
-
-      window.location_data = {
-        user_id: window.dtMapbox.user_id,
-        user_location: {
-          location_grid_meta: [
-            {
-              lng: results[0].geometry.location.lng(),
-              lat: results[0].geometry.location.lat(),
-              level: convert_level( results[0].types[0] ),
-              label: results[0].formatted_address,
-              source: 'user'
-            }
-          ]
+    geocoder.geocode(
+      { placeId: window.mapbox_result_features[selection_id].place_id },
+      (results, status) => {
+        if (status !== 'OK') {
+          console.log('Geocoder failed due to: ' + status);
+          return;
         }
-      }
-      post_geocoded_location()
-    });
+
+        window.location_data = {
+          user_id: window.dtMapbox.user_id,
+          user_location: {
+            location_grid_meta: [
+              {
+                lng: results[0].geometry.location.lng(),
+                lat: results[0].geometry.location.lat(),
+                level: convert_level(results[0].types[0]),
+                label: results[0].formatted_address,
+                source: 'user',
+              },
+            ],
+          },
+        };
+        post_geocoded_location();
+      },
+    );
   } else {
-    jQuery('#mapbox-search').val(window.mapbox_result_features[selection_id].place_name)
-    jQuery('#mapbox-autocomplete-list').empty()
+    jQuery('#mapbox-search').val(
+      window.mapbox_result_features[selection_id].place_name,
+    );
+    jQuery('#mapbox-autocomplete-list').empty();
 
     window.location_data = {
       user_id: window.dtMapbox.user_id,
@@ -302,59 +319,62 @@ function close_all_lists(selection_id) {
             lat: window.mapbox_result_features[selection_id].center[1],
             level: window.mapbox_result_features[selection_id].place_type[0],
             label: window.mapbox_result_features[selection_id].place_name,
-            source: 'user'
-          }
-        ]
-      }
-    }
-    post_geocoded_location()
+            source: 'user',
+          },
+        ],
+      },
+    };
+    post_geocoded_location();
   }
 }
 
-function post_geocoded_location(){
-  if ( jQuery('#mapbox-autocomplete').data('autosubmit') ) {
-    jQuery('#mapbox-spinner-button').show()
-    window.makeRequest( "POST", `users/user_location`, window.location_data )
-    .done(response => {
-      window.dtMapbox.user_location = response.user_location
-      window.dtMapbox.user_id = response.user_id
-      window.write_results_box()
-    })
-    .catch(err => { console.error(err) })
+function post_geocoded_location() {
+  if (jQuery('#mapbox-autocomplete').data('autosubmit')) {
+    jQuery('#mapbox-spinner-button').show();
+    window
+      .makeRequest('POST', `users/user_location`, window.location_data)
+      .done((response) => {
+        window.dtMapbox.user_location = response.user_location;
+        window.dtMapbox.user_id = response.user_id;
+        window.write_results_box();
+      })
+      .catch((err) => {
+        console.error(err);
+      });
   } else {
-    window.selected_location_grid_meta = window.location_data
-    jQuery('#mapbox-spinner-button').hide()
-    jQuery('#mapbox-clear-autocomplete').show()
+    window.selected_location_grid_meta = window.location_data;
+    jQuery('#mapbox-spinner-button').hide();
+    jQuery('#mapbox-clear-autocomplete').show();
   }
 }
 
-function clear_autocomplete(){
-  jQuery('#mapbox-search').val('')
-  jQuery('#mapbox-autocomplete-list').empty()
-  jQuery('#mapbox-spinner-button').hide()
-  jQuery('#mapbox-clear-autocomplete').hide()
+function clear_autocomplete() {
+  jQuery('#mapbox-search').val('');
+  jQuery('#mapbox-autocomplete-list').empty();
+  jQuery('#mapbox-spinner-button').hide();
+  jQuery('#mapbox-clear-autocomplete').hide();
 }
 
-function convert_level( level ) {
-  switch(level){
+function convert_level(level) {
+  switch (level) {
     case 'administrative_area_level_0':
-      level = 'admin0'
-      break
+      level = 'admin0';
+      break;
     case 'administrative_area_level_1':
-      level = 'admin1'
-      break
+      level = 'admin1';
+      break;
     case 'administrative_area_level_2':
-      level = 'admin2'
-      break
+      level = 'admin2';
+      break;
     case 'administrative_area_level_3':
-      level = 'admin3'
-      break
+      level = 'admin3';
+      break;
     case 'administrative_area_level_4':
-      level = 'admin4'
-      break
+      level = 'admin4';
+      break;
     case 'administrative_area_level_5':
-      level = 'admin5'
-      break
+      level = 'admin5';
+      break;
   }
-  return level
+  return level;
 }

--- a/dt-mapping/mapping.js
+++ b/dt-mapping/mapping.js
@@ -1,20 +1,19 @@
 /*global amcharts:false, am4maps:false */
-"use strict";
-let translations = window.mappingModule.mapping_module.translations
+'use strict';
+let translations = window.mappingModule.mapping_module.translations;
 
-let MAPPINGDATA = window.mappingModule.mapping_module
+let MAPPINGDATA = window.mappingModule.mapping_module;
 
-let openChart = null
+let openChart = null;
 
-let mapFillColor = "rgb(217, 217, 217)"
+let mapFillColor = 'rgb(217, 217, 217)';
 
 //called when a drilldown option is selected or when the map clicked
-window.DRILLDOWN.map_chart_drilldown = function( grid_id ) {
-  MAPPINGDATA.settings.current_map = grid_id || 'world'
-  location_grid_map( 'map_chart', grid_id )
-  data_type_list( 'data_type_list' )
-}
-
+window.DRILLDOWN.map_chart_drilldown = function (grid_id) {
+  MAPPINGDATA.settings.current_map = grid_id || 'world';
+  location_grid_map('map_chart', grid_id);
+  data_type_list('data_type_list');
+};
 
 /**********************************************************************************************************************
  *
@@ -23,9 +22,9 @@ window.DRILLDOWN.map_chart_drilldown = function( grid_id ) {
  * This displays a vision map and allows for drill down through clicking on map sections.
  *
  **********************************************************************************************************************/
-function page_mapping_view( rest_endpoints_base = null ) {
-  MAPPINGDATA.rest_endpoints_base = rest_endpoints_base
-  let chartDiv = jQuery('#mapping_chart')
+function page_mapping_view(rest_endpoints_base = null) {
+  MAPPINGDATA.rest_endpoints_base = rest_endpoints_base;
+  let chartDiv = jQuery('#mapping_chart');
   chartDiv.empty().html(`
     <style>#chart { height: ${window.innerHeight - 100}px !important; }
     #map_chart { height: ${window.innerHeight - 300}px !important; }
@@ -57,29 +56,35 @@ function page_mapping_view( rest_endpoints_base = null ) {
       <hr id="map_hr_2" class="map_hr">
     </div>
 
-    <span id="refresh_data" class="refresh_data"><a onclick="get_data(true)">${window.lodash.escape( translations.refresh_data )}</a></span>
+    <span id="refresh_data" class="refresh_data"><a onclick="get_data(true)">${window.lodash.escape(translations.refresh_data)}</a></span>
   `);
 
-  if ( MAPPINGDATA.data ){
-    window.DRILLDOWN.get_drill_down('map_chart_drilldown', MAPPINGDATA.settings.current_map)
+  if (MAPPINGDATA.data) {
+    window.DRILLDOWN.get_drill_down(
+      'map_chart_drilldown',
+      MAPPINGDATA.settings.current_map,
+    );
   } else {
-    return get_data(false).then(response=>{
-      MAPPINGDATA.data = response
-      // set the depth of the drill down
-      MAPPINGDATA.settings.hide_final_drill_down = false
-      // load drill down
-      window.DRILLDOWN.get_drill_down('map_chart_drilldown', MAPPINGDATA.settings.current_map)
-    }).fail(err=>{
-      console.log(err)
-    })
+    return get_data(false)
+      .then((response) => {
+        MAPPINGDATA.data = response;
+        // set the depth of the drill down
+        MAPPINGDATA.settings.hide_final_drill_down = false;
+        // load drill down
+        window.DRILLDOWN.get_drill_down(
+          'map_chart_drilldown',
+          MAPPINGDATA.settings.current_map,
+        );
+      })
+      .fail((err) => {
+        console.log(err);
+      });
   }
-
 }
 
-
-function setCommonMapSettings( chart ) {
+function setCommonMapSettings(chart) {
   let polygonSeries = chart.series.push(new window.am4maps.MapPolygonSeries());
-  polygonSeries.exclude = ["AQ","GL"];
+  polygonSeries.exclude = ['AQ', 'GL'];
   polygonSeries.useGeodata = true;
   let template = polygonSeries.mapPolygons.template;
 
@@ -88,358 +93,422 @@ function setCommonMapSettings( chart ) {
                             ---------<br>
                             ${window.lodash.escape(translations.population)}: {population}<br>
                             `;
-  jQuery.each( MAPPINGDATA.data.custom_column_labels, function(labelIndex, vc) {
-    toolTipContent += `${window.lodash.escape(vc.label)}: {${window.lodash.escape( vc.key )}}<br>`
-  })
+  jQuery.each(MAPPINGDATA.data.custom_column_labels, function (labelIndex, vc) {
+    toolTipContent += `${window.lodash.escape(vc.label)}: {${window.lodash.escape(vc.key)}}<br>`;
+  });
 
-  template.tooltipHTML = toolTipContent
+  template.tooltipHTML = toolTipContent;
 
   // Create hover state and set alternative fill color
-  let hs = template.states.create("hover");
-  hs.properties.fill = window.am4core.color("#000");
+  let hs = template.states.create('hover');
+  hs.properties.fill = window.am4core.color('#000');
 
-  template.propertyFields.fill = "fill";
+  template.propertyFields.fill = 'fill';
   polygonSeries.tooltip.label.interactionsEnabled = true;
-  polygonSeries.tooltip.pointerOrientation = "vertical";
-  template.fill = window.am4core.color("#FFFFFF");
+  polygonSeries.tooltip.pointerOrientation = 'vertical';
+  template.fill = window.am4core.color('#FFFFFF');
   // template.stroke = window.am4core.color("rgba(89,89,89,0.51)");
 
   polygonSeries.heatRules.push({
-    property: "fill",
+    property: 'fill',
     target: template,
     min: chart.colors.getIndex(1).brighten(1.5),
-    max: chart.colors.getIndex(1).brighten(-0.3)
+    max: chart.colors.getIndex(1).brighten(-0.3),
   });
   // Zoom control
   chart.zoomControl = new window.am4maps.ZoomControl();
 
   let homeButton = new window.am4core.Button();
-  homeButton.events.on("hit", function(){
+  homeButton.events.on('hit', function () {
     chart.goHome();
   });
 
   homeButton.icon = new window.am4core.Sprite();
   homeButton.padding(7, 5, 7, 5);
   homeButton.width = 30;
-  homeButton.icon.path = "M16,8 L14,8 L14,16 L10,16 L10,10 L6,10 L6,16 L2,16 L2,8 L0,8 L8,0 L16,8 Z M16,8";
+  homeButton.icon.path =
+    'M16,8 L14,8 L14,16 L10,16 L10,10 L6,10 L6,16 L2,16 L2,8 L0,8 L8,0 L16,8 Z M16,8';
   homeButton.marginBottom = 10;
   homeButton.parent = chart.zoomControl;
   homeButton.insertBefore(chart.zoomControl.plusButton);
 
-
   /* Click navigation */
-  template.events.on("hit", function(ev) {
-    // if (MAPPINGDATA.data[ev.target.dataItem.dataContext.grid_id]) {
-    return window.DRILLDOWN.get_drill_down('map_chart_drilldown', ev.target.dataItem.dataContext.grid_id)
-    // }
-  }, this);
+  template.events.on(
+    'hit',
+    function (ev) {
+      // if (MAPPINGDATA.data[ev.target.dataItem.dataContext.grid_id]) {
+      return window.DRILLDOWN.get_drill_down(
+        'map_chart_drilldown',
+        ev.target.dataItem.dataContext.grid_id,
+      );
+      // }
+    },
+    this,
+  );
 
-
-  let default_map_settings = MAPPINGDATA.settings.default_map_settings
-  if ( default_map_settings.children.length > 1 && default_map_settings.type !== "world" && MAPPINGDATA.settings.current_map == default_map_settings.parent ){
+  let default_map_settings = MAPPINGDATA.settings.default_map_settings;
+  if (
+    default_map_settings.children.length > 1 &&
+    default_map_settings.type !== 'world' &&
+    MAPPINGDATA.settings.current_map == default_map_settings.parent
+  ) {
     // Pre-zoom to a list of countries
     let zoomTo = MAPPINGDATA.settings.default_map_settings.children;
-    chart.events.on("appeared", function(ev) {
+    chart.events.on('appeared', function (ev) {
       // Init extrems
       let north, south, west, east;
 
       // Find extreme coordinates for all pre-zoom countries
-      for(let i = 0; i < zoomTo.length; i++) {
+      for (let i = 0; i < zoomTo.length; i++) {
         let country = polygonSeries.getPolygonById(zoomTo[i]);
-        if (north === undefined || (country.north > north)) {
+        if (north === undefined || country.north > north) {
           north = country.north;
         }
-        if (south === undefined || (country.south < south)) {
+        if (south === undefined || country.south < south) {
           south = country.south;
         }
-        if (west === undefined || (country.west < west)) {
+        if (west === undefined || country.west < west) {
           west = country.west;
         }
-        if (east === undefined || (country.east > east)) {
+        if (east === undefined || country.east > east) {
           east = country.east;
         }
 
         country.isActive = true;
       }
       chart.zoomToRectangle(north, east, south, west, 1, true);
-    })
+    });
   }
 }
 
-function setUpData( features, map_data ){
-  jQuery.each( features, function(featureIndex, mapFeature ) {
-    let grid_id =  mapFeature.properties.grid_id
-    let locationData =  window.lodash.get( map_data, `children[${grid_id}]` ) || window.lodash.get(map_data, `children[${mapFeature.id}]`)  || window.lodash.get( map_data, `${grid_id}.self` );
-    if ( locationData ) {
-      mapFeature.properties.grid_id = locationData.grid_id
-      mapFeature.properties.population = locationData.population
-      mapFeature.properties.name = locationData.name
+function setUpData(features, map_data) {
+  jQuery.each(features, function (featureIndex, mapFeature) {
+    let grid_id = mapFeature.properties.grid_id;
+    let locationData =
+      window.lodash.get(map_data, `children[${grid_id}]`) ||
+      window.lodash.get(map_data, `children[${mapFeature.id}]`) ||
+      window.lodash.get(map_data, `${grid_id}.self`);
+    if (locationData) {
+      mapFeature.properties.grid_id = locationData.grid_id;
+      mapFeature.properties.population = locationData.population;
+      mapFeature.properties.name = locationData.name;
 
       /* custom columns */
-      if ( MAPPINGDATA.data.custom_column_data[grid_id] ) {
+      if (MAPPINGDATA.data.custom_column_data[grid_id]) {
         /* Note: Amcharts calculates heatmap off last variable. So this section moves selected
-        * heatmap variable to the end of the array */
-        let focus = MAPPINGDATA.settings.heatmap_focus
-        jQuery.each( MAPPINGDATA.data.custom_column_labels, function(labelIndex, label) {
-          mapFeature.properties.fill = null;
-          if ( labelIndex !== focus ) {
-            mapFeature.properties[label.key] = MAPPINGDATA.data.custom_column_data[grid_id][labelIndex]
-            mapFeature.properties.value = mapFeature.properties[label.key]
-          }
-        })
-        jQuery.each( MAPPINGDATA.data.custom_column_labels, function(labelIndex, label) {
-          if ( labelIndex === focus ) {
-            mapFeature.properties[label.key] = MAPPINGDATA.data.custom_column_data[grid_id][labelIndex]
-            mapFeature.properties.value = mapFeature.properties[label.key]
-            if ( mapFeature.properties.value === 0 ){
-              mapFeature.properties.fill = window.am4core.color(mapFillColor);
+         * heatmap variable to the end of the array */
+        let focus = MAPPINGDATA.settings.heatmap_focus;
+        jQuery.each(
+          MAPPINGDATA.data.custom_column_labels,
+          function (labelIndex, label) {
+            mapFeature.properties.fill = null;
+            if (labelIndex !== focus) {
+              mapFeature.properties[label.key] =
+                MAPPINGDATA.data.custom_column_data[grid_id][labelIndex];
+              mapFeature.properties.value = mapFeature.properties[label.key];
             }
-          }
-        })
+          },
+        );
+        jQuery.each(
+          MAPPINGDATA.data.custom_column_labels,
+          function (labelIndex, label) {
+            if (labelIndex === focus) {
+              mapFeature.properties[label.key] =
+                MAPPINGDATA.data.custom_column_data[grid_id][labelIndex];
+              mapFeature.properties.value = mapFeature.properties[label.key];
+              if (mapFeature.properties.value === 0) {
+                mapFeature.properties.fill = window.am4core.color(mapFillColor);
+              }
+            }
+          },
+        );
       } else {
-        jQuery.each( MAPPINGDATA.data.custom_column_labels, function(labelIndex, label) {
-          mapFeature.properties[label.key] = 0
-          mapFeature.properties.value = 0
-          mapFeature.properties.fill = window.am4core.color(mapFillColor);
-        })
+        jQuery.each(
+          MAPPINGDATA.data.custom_column_labels,
+          function (labelIndex, label) {
+            mapFeature.properties[label.key] = 0;
+            mapFeature.properties.value = 0;
+            mapFeature.properties.fill = window.am4core.color(mapFillColor);
+          },
+        );
       }
       /* end custom column */
     }
-  })
-  return features
+  });
+  return features;
 }
 
-
-function location_grid_map( div, grid_id = 'world' ) {
+function location_grid_map(div, grid_id = 'world') {
   window.am4core.useTheme(window.am4themes_animated);
 
-  let chart = null
-  if ( openChart ){
-    openChart.dispose()
+  let chart = null;
+  if (openChart) {
+    openChart.dispose();
   }
-  chart = window.am4core.create( div, window.am4maps.MapChart);
-  setCommonMapSettings( chart );
+  chart = window.am4core.create(div, window.am4maps.MapChart);
+  setCommonMapSettings(chart);
   chart.projection = new window.am4maps.projections.Miller(); // Set projection
-  chart.reverseGeodata = true
-  openChart = chart
-  let title = jQuery('#section_title')
-  let rest = MAPPINGDATA.settings.endpoints.get_map_by_grid_id_endpoint
+  chart.reverseGeodata = true;
+  openChart = chart;
+  let title = jQuery('#section_title');
+  let rest = MAPPINGDATA.settings.endpoints.get_map_by_grid_id_endpoint;
 
+  title.empty();
 
-  title.empty()
-
-
-  if ( MAPPINGDATA.data[grid_id] ) {
-    build_map( MAPPINGDATA.data[grid_id] )
+  if (MAPPINGDATA.data[grid_id]) {
+    build_map(MAPPINGDATA.data[grid_id]);
   } else {
-    jQuery.ajax({
-      type: rest.method,
-      contentType: "application/json; charset=utf-8",
-      data: JSON.stringify( { 'grid_id': grid_id, 'cached': MAPPINGDATA.settings.cached, 'cached_length': MAPPINGDATA.settings.cached_length } ),
-      dataType: "json",
-      url: MAPPINGDATA.settings.root + rest.namespace + rest.route,
-      beforeSend: function(xhr) {
-        xhr.setRequestHeader('X-WP-Nonce', rest.nonce);
-      },
-    })
-    .done( function( response ) {
-      MAPPINGDATA.data[grid_id] = response
-      build_map(response)
-
-    }) // end success statement
-    .fail(function (err) {
-      console.log("error")
-      console.log(err)
-    })
+    jQuery
+      .ajax({
+        type: rest.method,
+        contentType: 'application/json; charset=utf-8',
+        data: JSON.stringify({
+          grid_id: grid_id,
+          cached: MAPPINGDATA.settings.cached,
+          cached_length: MAPPINGDATA.settings.cached_length,
+        }),
+        dataType: 'json',
+        url: MAPPINGDATA.settings.root + rest.namespace + rest.route,
+        beforeSend: function (xhr) {
+          xhr.setRequestHeader('X-WP-Nonce', rest.nonce);
+        },
+      })
+      .done(function (response) {
+        MAPPINGDATA.data[grid_id] = response;
+        build_map(response);
+      }) // end success statement
+      .fail(function (err) {
+        console.log('error');
+        console.log(err);
+      });
   }
 
-  function build_map( response ) {
-    title.html(response.self.name)
+  function build_map(response) {
+    title.html(response.self.name);
 
-    jQuery.getJSON( MAPPINGDATA.settings.mapping_source_url + 'collection/' + grid_id+'.geojson', function( data ) { // get geojson data
+    jQuery
+      .getJSON(
+        MAPPINGDATA.settings.mapping_source_url +
+          'collection/' +
+          grid_id +
+          '.geojson',
+        function (data) {
+          // get geojson data
 
-      // load geojson with additional parameters
-      let mapData = data
-      mapData.features = setUpData( mapData.features, response )
-      chart.geodata = mapData
+          // load geojson with additional parameters
+          let mapData = data;
+          mapData.features = setUpData(mapData.features, response);
+          chart.geodata = mapData;
 
-      //minimap
-      let coordinates = []
-      coordinates.push({
-        "latitude": response.self.latitude || 0,
-        "longitude": response.self.longitude || 0,
-        "title": response.self.name || 'World'
-      })
-      mini_map( 'minimap', coordinates )
+          //minimap
+          let coordinates = [];
+          coordinates.push({
+            latitude: response.self.latitude || 0,
+            longitude: response.self.longitude || 0,
+            title: response.self.name || 'World',
+          });
+          mini_map('minimap', coordinates);
 
-      //add totals section under the minimap
-      let totals = MAPPINGDATA.data.custom_column_data[grid_id] || []
-      if ( grid_id === "world" ){
-        totals = new Array(MAPPINGDATA.data.custom_column_labels.length).fill(0)
-        Object.keys(MAPPINGDATA.data.world.children).forEach(id=>{
-          if ( MAPPINGDATA.data.custom_column_data[id] ){
-            totals = totals.map((num, idx)=>{
-              return num + MAPPINGDATA.data.custom_column_data[id][idx]
-            })
+          //add totals section under the minimap
+          let totals = MAPPINGDATA.data.custom_column_data[grid_id] || [];
+          if (grid_id === 'world') {
+            totals = new Array(
+              MAPPINGDATA.data.custom_column_labels.length,
+            ).fill(0);
+            Object.keys(MAPPINGDATA.data.world.children).forEach((id) => {
+              if (MAPPINGDATA.data.custom_column_data[id]) {
+                totals = totals.map((num, idx) => {
+                  return num + MAPPINGDATA.data.custom_column_data[id][idx];
+                });
+              }
+            });
           }
-        })
-      }
-      let self_info = jQuery('#self_info')
-      self_info.empty()
-      let self_html = `<ul class="ul-no-bullets">`
-      jQuery.each( MAPPINGDATA.data.custom_column_labels, function(labelIndex, label) {
-        let value = totals[labelIndex] || 0
-        self_html += `<li><strong>${label.label}</strong>: ${value}</li>`
+          let self_info = jQuery('#self_info');
+          self_info.empty();
+          let self_html = `<ul class="ul-no-bullets">`;
+          jQuery.each(
+            MAPPINGDATA.data.custom_column_labels,
+            function (labelIndex, label) {
+              let value = totals[labelIndex] || 0;
+              self_html += `<li><strong>${label.label}</strong>: ${value}</li>`;
+            },
+          );
+          self_info.html(self_html + `</ul`);
+        },
+      ) // end get geojson
 
-      })
-      self_info.html(self_html + `</ul`)
+      .fail(function () {
+        // if failed to get multi polygon map, then get boundary map and fill with placemarks
 
-    }) // end get geojson
+        jQuery
+          .getJSON(
+            MAPPINGDATA.settings.mapping_source_url +
+              'low/' +
+              grid_id +
+              '.geojson',
+          )
+          .then(function (data) {
+            // Create map polygon series
+            chart.geodata = data;
 
+            chart.projection = new window.am4maps.projections.Miller();
+            chart.reverseGeodata = true;
+            let polygonSeries = chart.series.push(
+              new window.am4maps.MapPolygonSeries(),
+            );
+            polygonSeries.useGeodata = true;
 
-    .fail(function() {
-      // if failed to get multi polygon map, then get boundary map and fill with placemarks
+            let imageSeries = chart.series.push(
+              new window.am4maps.MapImageSeries(),
+            );
 
-      jQuery.getJSON( MAPPINGDATA.settings.mapping_source_url + 'low/' + grid_id+'.geojson' ).then(function( data ) {
-        // Create map polygon series
-        chart.geodata = data
+            let locations = [];
+            jQuery.each(MAPPINGDATA.data[grid_id].children, function (i, v) {
+              /* custom columns */
+              let focus = MAPPINGDATA.settings.heatmap_focus;
+              jQuery.each(
+                MAPPINGDATA.data.custom_column_labels,
+                function (labelIndex, label) {
+                  v[label.key] = window.lodash.get(
+                    MAPPINGDATA.data.custom_column_data,
+                    `[${v.grid_id}][${labelIndex}]`,
+                    0,
+                  );
+                },
+              );
 
-        chart.projection = new window.am4maps.projections.Miller();
-        chart.reverseGeodata = true
-        let polygonSeries = chart.series.push(new window.am4maps.MapPolygonSeries());
-        polygonSeries.useGeodata = true;
+              locations.push(v);
+            });
+            imageSeries.data = locations;
 
-        let imageSeries = chart.series.push(new window.am4maps.MapImageSeries());
+            let imageSeriesTemplate = imageSeries.mapImages.template;
+            let circle = imageSeriesTemplate.createChild(window.am4core.Circle);
+            circle.radius = 6;
+            circle.fill = window.am4core.color('#3c5bdc');
+            circle.stroke = window.am4core.color('#3c5bdc');
+            circle.strokeWidth = 2;
+            circle.nonScaling = true;
 
-        let locations = []
-        jQuery.each( MAPPINGDATA.data[grid_id].children, function(i, v) {
-          /* custom columns */
-          let focus = MAPPINGDATA.settings.heatmap_focus
-          jQuery.each( MAPPINGDATA.data.custom_column_labels, function(labelIndex, label) {
-            v[label.key] = window.lodash.get( MAPPINGDATA.data.custom_column_data, `[${v.grid_id}][${labelIndex}]`, 0 )
-          })
+            // Click navigation
+            circle.events.on(
+              'hit',
+              function (ev) {
+                return window.DRILLDOWN.get_drill_down(
+                  'map_chart_drilldown',
+                  ev.target.dataItem.dataContext.grid_id,
+                  MAPPINGDATA.settings.cached,
+                );
+              },
+              this,
+            );
 
-          locations.push( v )
-        } )
-        imageSeries.data = locations;
-
-
-        let imageSeriesTemplate = imageSeries.mapImages.template;
-        let circle = imageSeriesTemplate.createChild(window.am4core.Circle);
-        circle.radius = 6;
-        circle.fill = window.am4core.color("#3c5bdc");
-        circle.stroke = window.am4core.color("#3c5bdc");
-        circle.strokeWidth = 2;
-        circle.nonScaling = true;
-
-        // Click navigation
-        circle.events.on("hit", function (ev) {
-
-          return window.DRILLDOWN.get_drill_down( 'map_chart_drilldown', ev.target.dataItem.dataContext.grid_id, MAPPINGDATA.settings.cached )
-
-        }, this);
-
-        let circleTipContent = `<strong>{name}</strong><br>
+            let circleTipContent = `<strong>{name}</strong><br>
                             ---------<br>
                             ${window.lodash.escape(translations.population)}: {population}<br>
                             `;
-        jQuery.each( MAPPINGDATA.data.custom_column_labels, function(labelIndex, vc) {
-          circleTipContent += `${window.lodash.escape(vc.label)}: {${window.lodash.escape( vc.key )}}<br>`
-        })
-        circle.tooltipHTML = circleTipContent
+            jQuery.each(
+              MAPPINGDATA.data.custom_column_labels,
+              function (labelIndex, vc) {
+                circleTipContent += `${window.lodash.escape(vc.label)}: {${window.lodash.escape(vc.key)}}<br>`;
+              },
+            );
+            circle.tooltipHTML = circleTipContent;
 
-        imageSeries.heatRules.push({
-          property: "fill",
-          target: circle,
-          min: chart.colors.getIndex(1).brighten(1.5),
-          max: chart.colors.getIndex(1).brighten(-0.3)
-        });
+            imageSeries.heatRules.push({
+              property: 'fill',
+              target: circle,
+              min: chart.colors.getIndex(1).brighten(1.5),
+              max: chart.colors.getIndex(1).brighten(-0.3),
+            });
 
-        imageSeriesTemplate.propertyFields.latitude = "latitude";
-        imageSeriesTemplate.propertyFields.longitude = "longitude";
-        imageSeriesTemplate.nonScaling = true;
-
-      })
-    })
+            imageSeriesTemplate.propertyFields.latitude = 'latitude';
+            imageSeriesTemplate.propertyFields.longitude = 'longitude';
+            imageSeriesTemplate.nonScaling = true;
+          });
+      });
   }
 }
 
-function data_type_list( div ) {
-  let list = jQuery('#'+div )
-  list.empty()
-  let focus = MAPPINGDATA.settings.heatmap_focus
+function data_type_list(div) {
+  let list = jQuery('#' + div);
+  list.empty();
+  let focus = MAPPINGDATA.settings.heatmap_focus;
 
-  jQuery.each( MAPPINGDATA.data.custom_column_labels, function(i,v) {
-    let hollow = 'hollow'
-    if ( i === focus ) {
-      hollow = ''
+  jQuery.each(MAPPINGDATA.data.custom_column_labels, function (i, v) {
+    let hollow = 'hollow';
+    if (i === focus) {
+      hollow = '';
     }
     list.append(`
-      <a onclick="heatmap_focus_change( ${window.lodash.escape( i )}, '${MAPPINGDATA.settings.current_map}' )"
+      <a onclick="heatmap_focus_change( ${window.lodash.escape(i)}, '${MAPPINGDATA.settings.current_map}' )"
         class="button ${hollow}"
-        id="${window.lodash.escape( v.key )}">
-        ${window.lodash.escape( v.label )}
+        id="${window.lodash.escape(v.key)}">
+        ${window.lodash.escape(v.label)}
       </a>
-    `)
-  })
+    `);
+  });
 }
 
-function heatmap_focus_change( focus_id, current_map ) {
+function heatmap_focus_change(focus_id, current_map) {
+  MAPPINGDATA.settings.heatmap_focus = focus_id;
+  let geodata = openChart.geodata;
+  geodata.features = setUpData(
+    geodata.features,
+    MAPPINGDATA.data[MAPPINGDATA.settings.current_map],
+  );
 
-  MAPPINGDATA.settings.heatmap_focus = focus_id
-  let geodata = openChart.geodata
-  geodata.features = setUpData( geodata.features, MAPPINGDATA.data[MAPPINGDATA.settings.current_map])
+  openChart.reverseGeodata = false;
+  openChart.geodata = [];
+  openChart.geodata = geodata;
+  openChart.reverseGeodata = true;
 
-  openChart.reverseGeodata = false
-  openChart.geodata = []
-  openChart.geodata = geodata
-  openChart.reverseGeodata = true
-
-  data_type_list( 'data_type_list' )
+  data_type_list('data_type_list');
 }
 
-
-let minimapChart = null
-function mini_map( div, marker_data ) {
+let minimapChart = null;
+function mini_map(div, marker_data) {
   //if the minimap is not set
-  if ( !jQuery('#' + div ).length ){
-    return
+  if (!jQuery('#' + div).length) {
+    return;
   }
 
-  if ( window.am4geodata_worldLow === undefined ) {
-    let mapUrl = MAPPINGDATA.settings.mapping_source_url + 'collection/world.geojson'
-    jQuery.getJSON( mapUrl, function( data ) {
-      window.am4geodata_worldLow = data
-      build_minimap()
-    })
+  if (window.am4geodata_worldLow === undefined) {
+    let mapUrl =
+      MAPPINGDATA.settings.mapping_source_url + 'collection/world.geojson';
+    jQuery.getJSON(mapUrl, function (data) {
+      window.am4geodata_worldLow = data;
+      build_minimap();
+    });
   } else {
-    build_minimap()
+    build_minimap();
   }
 
-  function build_minimap(){
-    if (minimapChart){
-      minimapChart.dispose()
+  function build_minimap() {
+    if (minimapChart) {
+      minimapChart.dispose();
     }
 
     window.am4core.useTheme(window.am4themes_animated);
 
-    minimapChart = window.am4core.create( div, window.am4maps.MapChart);
-    let chart = minimapChart
+    minimapChart = window.am4core.create(div, window.am4maps.MapChart);
+    let chart = minimapChart;
 
     chart.projection = new window.am4maps.projections.Orthographic(); // Set projection
-    chart.reverseGeodata = true
+    chart.reverseGeodata = true;
 
     chart.seriesContainer.draggable = false;
     chart.seriesContainer.resizable = false;
 
-    if ( parseInt(marker_data[0].longitude) < 0 ) {
+    if (parseInt(marker_data[0].longitude) < 0) {
       chart.deltaLongitude = parseInt(Math.abs(marker_data[0].longitude));
     } else {
       chart.deltaLongitude = parseInt(-Math.abs(marker_data[0].longitude));
     }
 
     chart.geodata = window.am4geodata_worldLow;
-    let polygonSeries = chart.series.push(new window.am4maps.MapPolygonSeries());
+    let polygonSeries = chart.series.push(
+      new window.am4maps.MapPolygonSeries(),
+    );
 
     polygonSeries.useGeodata = true;
 
@@ -450,38 +519,36 @@ function mini_map( div, marker_data ) {
     let imageSeriesTemplate = imageSeries.mapImages.template;
     let circle = imageSeriesTemplate.createChild(window.am4core.Circle);
     circle.radius = 4;
-    circle.fill = window.am4core.color("#B27799");
-    circle.stroke = window.am4core.color("#FFFFFF");
+    circle.fill = window.am4core.color('#B27799');
+    circle.stroke = window.am4core.color('#FFFFFF');
     circle.strokeWidth = 2;
     circle.nonScaling = true;
-    circle.tooltipText = "{title}";
-    imageSeriesTemplate.propertyFields.latitude = "latitude";
-    imageSeriesTemplate.propertyFields.longitude = "longitude";
+    circle.tooltipText = '{title}';
+    imageSeriesTemplate.propertyFields.latitude = 'latitude';
+    imageSeriesTemplate.propertyFields.longitude = 'longitude';
   }
 }
 
-function get_data( force_refresh = false ) {
-  let spinner = jQuery('.loading-spinner')
-  spinner.addClass('active')
-  return jQuery.ajax({
-    type: "GET",
-    contentType: "application/json; charset=utf-8",
-    dataType: "json",
-    url: `${MAPPINGDATA.rest_endpoints_base}/data?refresh=${force_refresh}`,
-    beforeSend: function(xhr) {
-      xhr.setRequestHeader('X-WP-Nonce', window.mappingModule.nonce );
-    },
-  })
-  .then( function( response ) {
-    spinner.removeClass('active')
-    return response
-  })
-  .fail(function (err) {
-    spinner.removeClass('active')
-    console.log("error")
-    console.log(err)
-  })
+function get_data(force_refresh = false) {
+  let spinner = jQuery('.loading-spinner');
+  spinner.addClass('active');
+  return jQuery
+    .ajax({
+      type: 'GET',
+      contentType: 'application/json; charset=utf-8',
+      dataType: 'json',
+      url: `${MAPPINGDATA.rest_endpoints_base}/data?refresh=${force_refresh}`,
+      beforeSend: function (xhr) {
+        xhr.setRequestHeader('X-WP-Nonce', window.mappingModule.nonce);
+      },
+    })
+    .then(function (response) {
+      spinner.removeClass('active');
+      return response;
+    })
+    .fail(function (err) {
+      spinner.removeClass('active');
+      console.log('error');
+      console.log(err);
+    });
 }
-
-
-

--- a/dt-metrics/combined/combined.js
+++ b/dt-metrics/combined/combined.js
@@ -1,62 +1,96 @@
-window.mapbox_library_api.current_map_type = "points"
-jQuery(document).ready(function($) {
-
-
-  let recursive_load = async function (body, data = [], offset = 0, limit = 50000) {
-    body.offset = offset
-    body.limit = limit
+window.mapbox_library_api.current_map_type = 'points';
+jQuery(document).ready(function ($) {
+  let recursive_load = async function (
+    body,
+    data = [],
+    offset = 0,
+    limit = 50000,
+  ) {
+    body.offset = offset;
+    body.limit = limit;
     let geojson = await window.makeRequest(
-      "POST",
+      'POST',
       window.mapbox_library_api.obj.settings.points_rest_url,
       body,
-      window.mapbox_library_api.obj.settings.rest_base_url)
+      window.mapbox_library_api.obj.settings.rest_base_url,
+    );
 
-
-    data = data.concat(geojson.features)
-    jQuery('#loading-legend').html(`<span>(${data.length.toLocaleString()})</span>`)
+    data = data.concat(geojson.features);
+    jQuery('#loading-legend').html(
+      `<span>(${data.length.toLocaleString()})</span>`,
+    );
 
     // return data;
-    if (geojson.features.length > 0 && geojson.features.length === limit ) {
-      return recursive_load(body, data, offset + limit, limit)
+    if (geojson.features.length > 0 && geojson.features.length === limit) {
+      return recursive_load(body, data, offset + limit, limit);
     }
     jQuery('#loading-legend').html('');
-    return data
-  }
+    return data;
+  };
 
   //over-ride points setup so we can load 2 layers.
-  window.mapbox_library_api.points_map.setup = async function (){
-    let contact_points_data = await recursive_load({post_type: "contacts", query: []})
-    let contact_points = {features:contact_points_data, type:'FeatureCollection'}
-    let group_points_data = await recursive_load({post_type: "groups", query: []})
-    let group_points = {features:group_points_data, type:'FeatureCollection'}
+  window.mapbox_library_api.points_map.setup = async function () {
+    let contact_points_data = await recursive_load({
+      post_type: 'contacts',
+      query: [],
+    });
+    let contact_points = {
+      features: contact_points_data,
+      type: 'FeatureCollection',
+    };
+    let group_points_data = await recursive_load({
+      post_type: 'groups',
+      query: [],
+    });
+    let group_points = {
+      features: group_points_data,
+      type: 'FeatureCollection',
+    };
 
-
-    window.mapbox_library_api.area_map.setup = async function (){
-      let area_map = window.mapbox_library_api.area_map
-      area_map.grid_data = await window.makeRequest( "POST", window.mapbox_library_api.obj.settings.totals_rest_url, { post_type: window.mapbox_library_api.obj.settings.post_type, query: window.mapbox_library_api.query_args || {}} , window.mapbox_library_api.obj.settings.rest_base_url )
-      await area_map.load_layer()
+    window.mapbox_library_api.area_map.setup = async function () {
+      let area_map = window.mapbox_library_api.area_map;
+      area_map.grid_data = await window.makeRequest(
+        'POST',
+        window.mapbox_library_api.obj.settings.totals_rest_url,
+        {
+          post_type: window.mapbox_library_api.obj.settings.post_type,
+          query: window.mapbox_library_api.query_args || {},
+        },
+        window.mapbox_library_api.obj.settings.rest_base_url,
+      );
+      await area_map.load_layer();
       // load new layer on event
-      window.mapbox_library_api.map.on('zoomend', function() {
-        area_map.load_layer()
-      })
-      window.mapbox_library_api.map.on('dragend', function() {
-        area_map.load_layer()
-      })
-      window.mapbox_library_api.map.on('click', function( e ) {
+      window.mapbox_library_api.map.on('zoomend', function () {
+        area_map.load_layer();
+      });
+      window.mapbox_library_api.map.on('dragend', function () {
+        area_map.load_layer();
+      });
+      window.mapbox_library_api.map.on('click', function (e) {
         // this section increments up the result on level because
         // it corresponds better to the viewable user intent for details
-        let level = window.mapbox_library_api.get_level()
-        area_map.load_detail_panel( e.lngLat.lng, e.lngLat.lat, level )
-      })
-    }
-    window.mapbox_library_api.area_map.load_detail_panel = function (){};
-    window.mapbox_library_api.area_map.behind_layer = 'dt-maps-groups_points_layer'
-    window.mapbox_library_api.points_map.load_layer( group_points, "groups_points_layer",'#cc4b37', 10 )
-    window.mapbox_library_api.points_map.load_layer( contact_points, "contacts_points_layer", '#11b4da' )
-    await window.mapbox_library_api.area_map.setup()
-    await window.mapbox_library_api.area_map.load_layer()
+        let level = window.mapbox_library_api.get_level();
+        area_map.load_detail_panel(e.lngLat.lng, e.lngLat.lat, level);
+      });
+    };
+    window.mapbox_library_api.area_map.load_detail_panel = function () {};
+    window.mapbox_library_api.area_map.behind_layer =
+      'dt-maps-groups_points_layer';
+    window.mapbox_library_api.points_map.load_layer(
+      group_points,
+      'groups_points_layer',
+      '#cc4b37',
+      10,
+    );
+    window.mapbox_library_api.points_map.load_layer(
+      contact_points,
+      'contacts_points_layer',
+      '#11b4da',
+    );
+    await window.mapbox_library_api.area_map.setup();
+    await window.mapbox_library_api.area_map.load_layer();
     jQuery('#loading-spinner').hide();
-  }
+  };
 
   let split_by_html = `
     <div id="legend-icons" class="border-left">
@@ -78,8 +112,7 @@ jQuery(document).ready(function($) {
         ${window.SHAREDFUNCTIONS.escapeHTML(window.dt_metrics_mapbox_caller_js.translations.active_users)}
        </span>
     </div>
-  `
-  $('#legend-bar').append(split_by_html)
-  $('#map-type').hide()
-
-})
+  `;
+  $('#legend-bar').append(split_by_html);
+  $('#map-type').hide();
+});

--- a/dt-metrics/combined/critical-path.js
+++ b/dt-metrics/combined/critical-path.js
@@ -1,33 +1,31 @@
-const chart_label_width = 230
-const chart_row_height = 25
-const chart_min_height = 84
+const chart_label_width = 230;
+const chart_row_height = 25;
+const chart_min_height = 84;
 
-jQuery(document).ready(function() {
-  if ( window.wpApiShare.url_path.startsWith( 'metrics/combined/critical_path' ) ) {
-    project_critical_path()
+jQuery(document).ready(function () {
+  if (window.wpApiShare.url_path.startsWith('metrics/combined/critical_path')) {
+    project_critical_path();
   }
-})
-
+});
 
 function numberWithCommas(x) {
   x = (x || 0).toString();
   let pattern = /(-?\d+)(\d{3})/;
-  while (pattern.test(x))
-    x = x.replace(pattern, "$1,$2");
+  while (pattern.test(x)) x = x.replace(pattern, '$1,$2');
   return x;
 }
 
 function project_critical_path() {
-  let chartDiv = jQuery('#chart')
-  let translations = window.dtMetricsProject.translations
+  let chartDiv = jQuery('#chart');
+  let translations = window.dtMetricsProject.translations;
 
   jQuery('#metrics-sidemenu').foundation('down', jQuery('#combined-menu'));
 
   chartDiv.empty().html(`
-    <div class="section-header">${ window.SHAREDFUNCTIONS.escapeHTML( translations.title_critical_path ) }</div>
+    <div class="section-header">${window.SHAREDFUNCTIONS.escapeHTML(translations.title_critical_path)}</div>
     <div class="date_range_picker">
         <i class="fi-calendar"></i>&nbsp;
-        <span>${window.moment().format("YYYY")}</span>
+        <span>${window.moment().format('YYYY')}</span>
         <i class="dt_caret down"></i>
     </div>
     <div style="display: inline-block" class="loading-spinner"></div>
@@ -37,54 +35,54 @@ function project_critical_path() {
     <div id="ongoingChart" style="width:90%;"></div>
     <!--<div id="chartdiv" style="height: 800px; width:100%;"></div>-->
     <br>
-    <h4>${ window.SHAREDFUNCTIONS.escapeHTML( translations.filter_critical_path ) }</h4>
+    <h4>${window.SHAREDFUNCTIONS.escapeHTML(translations.filter_critical_path)}</h4>
     <div id="field_selector" style="display: flex; flex-wrap: wrap"> </div>
-  `)
+  `);
 
-  fieldSelector( window.dtMetricsProject.data.cp )
+  fieldSelector(window.dtMetricsProject.data.cp);
 
   window.METRICS.setupDatePicker(
     `${window.dtMetricsProject.root}dt/v1/metrics/critical_path_activity`,
     function (data, label) {
       if (data) {
         jQuery('.date_range_picker span').html(label);
-        window.dtMetricsProject.data.cp = data
-        fieldSelector( window.dtMetricsProject.data.cp )
-        mediaChart(data)
-        activityChart(data)
-        ongoingChart(data)
+        window.dtMetricsProject.data.cp = data;
+        fieldSelector(window.dtMetricsProject.data.cp);
+        mediaChart(data);
+        activityChart(data);
+        ongoingChart(data);
         // main_chart(data)
       }
     },
-    window.moment().startOf('year')
-  )
-  buildCharts( window.dtMetricsProject.data.cp )
+    window.moment().startOf('year'),
+  );
+  buildCharts(window.dtMetricsProject.data.cp);
 }
 
-let buildCharts = function( data ){
-  mediaChart(data)
-  activityChart(data)
-  ongoingChart(data)
+let buildCharts = function (data) {
+  mediaChart(data);
+  activityChart(data);
+  ongoingChart(data);
   // main_chart(data)
-}
+};
 
-let main_chart = function(data){
-
-
-  data = data.filter(a=>a.outreach === undefined).reverse()
+let main_chart = function (data) {
+  data = data.filter((a) => a.outreach === undefined).reverse();
 
   // Create chart instance
-  jQuery('#chartdiv').empty().height(50 + chart_row_height * data.length)
-  let chart = window.am4core.create("chartdiv", window.am4charts.XYChart);
+  jQuery('#chartdiv')
+    .empty()
+    .height(50 + chart_row_height * data.length);
+  let chart = window.am4core.create('chartdiv', window.am4charts.XYChart);
 
-  chart.data = data
+  chart.data = data;
 
   chart.legend = new window.am4charts.Legend();
   chart.legend.useDefaultMarker = true;
 
   // Create axes
   let categoryAxis = chart.yAxes.push(new window.am4charts.CategoryAxis());
-  categoryAxis.dataFields.category = "label";
+  categoryAxis.dataFields.category = 'label';
   categoryAxis.renderer.grid.template.location = 0;
   categoryAxis.renderer.minGridDistance = 30;
   categoryAxis.renderer.maxGridDistance = 30;
@@ -97,16 +95,15 @@ let main_chart = function(data){
   // valueAxis.max = max.value * 1.1
   // console.log(valueAxis.max);
 
-
   // valueAxis.logarithmic = true;
 
   // Create series
   let series = chart.series.push(new window.am4charts.ColumnSeries());
-  series.name = "Current System counts"
-  series.dataFields.valueX = "total";
-  series.dataFields.categoryY = "label";
+  series.name = 'Current System counts';
+  series.dataFields.valueX = 'total';
+  series.dataFields.categoryY = 'label';
   series.clustered = false;
-  series.tooltipText = "Total: [bold]{valueX}[/]";
+  series.tooltipText = 'Total: [bold]{valueX}[/]';
 
   // var valueLabel = series.bullets.push(new window.am4charts.LabelBullet());
   // valueLabel.label.text = "{valueX}";
@@ -116,75 +113,71 @@ let main_chart = function(data){
   // valueLabel.label.truncate = false;
 
   let series2 = chart.series.push(new window.am4charts.ColumnSeries());
-  series2.name = "Activity"
-  series2.dataFields.valueX = "value";
-  series2.dataFields.test = "value";
-  series2.dataFields.categoryY = "label";
+  series2.name = 'Activity';
+  series2.dataFields.valueX = 'value';
+  series2.dataFields.test = 'value';
+  series2.dataFields.categoryY = 'label';
   series2.clustered = false;
   series2.columns.template.height = window.am4core.percent(50);
-  series2.tooltipText = "[bold]{test}[/]";
+  series2.tooltipText = '[bold]{test}[/]';
 
   let valueLabel = series2.bullets.push(new window.am4charts.LabelBullet());
-  valueLabel.label.text = "{valueX}";
-  valueLabel.label.horizontalCenter = "left";
+  valueLabel.label.text = '{valueX}';
+  valueLabel.label.horizontalCenter = 'left';
   valueLabel.label.dx = 10;
   valueLabel.label.hideOversized = false;
   valueLabel.label.truncate = false;
-
 
   chart.cursor = new window.am4charts.XYCursor();
   chart.cursor.lineX.disabled = true;
   chart.cursor.lineY.disabled = true;
 
-
   let label = categoryAxis.renderer.labels.template;
   // label.wrap = true;
-  label.truncate = true
+  label.truncate = true;
   label.maxWidth = chart_label_width;
   label.minWidth = chart_label_width;
-  label.tooltipText = "{category}";
-}
+  label.tooltipText = '{category}';
+};
 
-
-let setupChart = function ( chart, valueX, titleText){
-
+let setupChart = function (chart, valueX, titleText) {
   let title = chart.titles.create();
   title.text = `[bold]${titleText}[/]`;
-  title.textAlign = "middle";
-  title.dy = -5
+  title.textAlign = 'middle';
+  title.dy = -5;
 
   let categoryAxis = chart.yAxes.push(new window.am4charts.CategoryAxis());
-  categoryAxis.dataFields.category = "label";
+  categoryAxis.dataFields.category = 'label';
   categoryAxis.renderer.grid.template.location = 0;
   categoryAxis.renderer.minGridDistance = 10;
 
   let label = categoryAxis.renderer.labels.template;
-  label.truncate = true
+  label.truncate = true;
   label.maxWidth = chart_label_width;
   label.minWidth = chart_label_width;
-  label.tooltipText = "{description}";
-  label.textAlign = "end"
-  label.dx = -5
+  label.tooltipText = '{description}';
+  label.textAlign = 'end';
+  label.dx = -5;
 
   let valueAxis = chart.xAxes.push(new window.am4charts.ValueAxis());
   valueAxis.title.fontWeight = 800;
-  valueAxis.renderer.grid.template.disabled = true
+  valueAxis.renderer.grid.template.disabled = true;
   valueAxis.extraMax = 0.1;
-  valueAxis.min = 0
+  valueAxis.min = 0;
   valueAxis.paddingRight = 20;
 
   let series = chart.series.push(new window.am4charts.ColumnSeries());
-  series.name = "Activity"
+  series.name = 'Activity';
   series.dataFields.valueX = valueX;
-  series.dataFields.categoryY = "label";
+  series.dataFields.categoryY = 'label';
   series.clustered = false;
-  series.tooltipText = "[bold]{valueX}[/]";
-  series.columns.template.height = 20
+  series.tooltipText = '[bold]{valueX}[/]';
+  series.columns.template.height = 20;
 
   //field value label
   let valueLabel = series.bullets.push(new window.am4charts.LabelBullet());
-  valueLabel.label.text = "{valueX}";
-  valueLabel.label.horizontalCenter = "left";
+  valueLabel.label.text = '{valueX}';
+  valueLabel.label.horizontalCenter = 'left';
   valueLabel.label.dx = 10;
   valueLabel.label.hideOversized = false;
   valueLabel.label.truncate = false;
@@ -192,58 +185,80 @@ let setupChart = function ( chart, valueX, titleText){
   chart.cursor = new window.am4charts.XYCursor();
   chart.cursor.lineX.disabled = true;
   chart.cursor.lineY.disabled = true;
-}
+};
 
-let mediaChart = function ( data ) {
-  data = data.filter(a=>a.outreach).reverse()
-  jQuery('#mediachart').empty().height(chart_min_height + chart_row_height * data.length)
-  if ( data.length ) {
-    let chart = window.am4core.create("mediachart", window.am4charts.XYChart);
-    chart.data = data
-    setupChart( chart, "outreach", window.dtMetricsProject.translations.title_outreach )
+let mediaChart = function (data) {
+  data = data.filter((a) => a.outreach).reverse();
+  jQuery('#mediachart')
+    .empty()
+    .height(chart_min_height + chart_row_height * data.length);
+  if (data.length) {
+    let chart = window.am4core.create('mediachart', window.am4charts.XYChart);
+    chart.data = data;
+    setupChart(
+      chart,
+      'outreach',
+      window.dtMetricsProject.translations.title_outreach,
+    );
   }
-}
+};
 
-let activityChart = function ( data ) {
-  data = data.filter(a=>a.type==="activity").reverse()
-  jQuery('#activityChart').empty().height(chart_min_height+chart_row_height * data.length)
-  if ( data.length ) {
-    let chart = window.am4core.create("activityChart", window.am4charts.XYChart);
-    chart.data = data
-    setupChart( chart, "value", window.dtMetricsProject.translations.title_follow_up )
+let activityChart = function (data) {
+  data = data.filter((a) => a.type === 'activity').reverse();
+  jQuery('#activityChart')
+    .empty()
+    .height(chart_min_height + chart_row_height * data.length);
+  if (data.length) {
+    let chart = window.am4core.create(
+      'activityChart',
+      window.am4charts.XYChart,
+    );
+    chart.data = data;
+    setupChart(
+      chart,
+      'value',
+      window.dtMetricsProject.translations.title_follow_up,
+    );
   }
-}
-let ongoingChart = function ( data ) {
-  data = data.filter(a=>a.type==="ongoing").reverse()
-  jQuery('#ongoingChart').empty().height(chart_min_height+chart_row_height * data.length)
-  if ( data.length ) {
-    let chart = window.am4core.create("ongoingChart", window.am4charts.XYChart);
-    chart.data = data
-    setupChart( chart, "total", window.dtMetricsProject.translations.movement_training )
+};
+let ongoingChart = function (data) {
+  data = data.filter((a) => a.type === 'ongoing').reverse();
+  jQuery('#ongoingChart')
+    .empty()
+    .height(chart_min_height + chart_row_height * data.length);
+  if (data.length) {
+    let chart = window.am4core.create('ongoingChart', window.am4charts.XYChart);
+    chart.data = data;
+    setupChart(
+      chart,
+      'total',
+      window.dtMetricsProject.translations.movement_training,
+    );
   }
-}
+};
 
-let filtered = []
-let fieldSelector = function( data ){
-  let html = ``
-  data.forEach(field=>{
-    let checked = !filtered.includes(field.key) ? "checked" : ""
+let filtered = [];
+let fieldSelector = function (data) {
+  let html = ``;
+  data.forEach((field) => {
+    let checked = !filtered.includes(field.key) ? 'checked' : '';
     html += `<label style="flex-grow: 0;flex-basis:20%">
       <input type="checkbox" class="field-button" data-key="${field.key}" ${checked}>
       ${field.label}
     </label>
-    `
-  })
-  jQuery('#field_selector').html(html)
+    `;
+  });
+  jQuery('#field_selector').html(html);
 
-  jQuery('.field-button').on("click", function () {
-    let key = jQuery(this).data("key")
-    if ( jQuery(this).is(":checked") ){
-      filtered = filtered.filter(a=>a!==key)
+  jQuery('.field-button').on('click', function () {
+    let key = jQuery(this).data('key');
+    if (jQuery(this).is(':checked')) {
+      filtered = filtered.filter((a) => a !== key);
     } else {
-      filtered.push(key)
+      filtered.push(key);
     }
-    buildCharts( window.dtMetricsProject.data.cp.filter(a=>!filtered.includes(a.key)) )
-  })
-
-}
+    buildCharts(
+      window.dtMetricsProject.data.cp.filter((a) => !filtered.includes(a.key)),
+    );
+  });
+};

--- a/dt-metrics/combined/daily-activity.js
+++ b/dt-metrics/combined/daily-activity.js
@@ -1,7 +1,8 @@
 jQuery(document).ready(function ($) {
-
-  if (window.wpApiShare.url_path.startsWith('metrics/combined/daily-activity')) {
-    display_daily_activity()
+  if (
+    window.wpApiShare.url_path.startsWith('metrics/combined/daily-activity')
+  ) {
+    display_daily_activity();
   }
 
   function display_daily_activity() {
@@ -43,33 +44,35 @@ jQuery(document).ready(function ($) {
 
     // Ensure to hide daily sub-charts.
     $('#chart_day_title').html('');
-    $('#chart_day_counts_div').fadeOut('fast', function () {
-    });
-    $('#chart_day_health_counts_div').fadeOut('fast', function () {
-    });
+    $('#chart_day_counts_div').fadeOut('fast', function () {});
+    $('#chart_day_health_counts_div').fadeOut('fast', function () {});
 
     // Proceed with chart creation.
     $('#chartdiv').fadeOut('fast', function () {
       window.am4core.ready(function () {
-
         window.am4core.useTheme(window.am4themes_animated);
         window.am4core.ready(function () {
-          let chart = window.am4core.create("chartdiv", window.am4plugins_timeline.CurveChart);
+          let chart = window.am4core.create(
+            'chartdiv',
+            window.am4plugins_timeline.CurveChart,
+          );
 
           chart.curveContainer.padding(0, 300, 0, 0);
           chart.maskBullets = false;
 
           let colorSet = new window.am4core.ColorSet();
 
-          chart.dateFormatter.inputDateFormat = "yyyy-MM-dd";
-          chart.dateFormatter.dateFormat = "yyyy-MM-dd";
+          chart.dateFormatter.inputDateFormat = 'yyyy-MM-dd';
+          chart.dateFormatter.dateFormat = 'yyyy-MM-dd';
           chart.fontSize = 10;
           chart.tooltipContainer.fontSize = 10;
           chart.data = build_days_data_array(days, colorSet);
           chart.clickable = true;
 
-          let categoryAxis = chart.yAxes.push(new window.am4charts.CategoryAxis());
-          categoryAxis.dataFields.category = "category";
+          let categoryAxis = chart.yAxes.push(
+            new window.am4charts.CategoryAxis(),
+          );
+          categoryAxis.dataFields.category = 'category';
           categoryAxis.renderer.grid.template.disabled = true;
           categoryAxis.renderer.labels.template.paddingRight = 25;
           categoryAxis.renderer.minGridDistance = 10;
@@ -83,13 +86,16 @@ jQuery(document).ready(function ($) {
           dateAxis.renderer.autoScale = false;
           dateAxis.renderer.autoCenter = false;
           dateAxis.renderer.minGridDistance = 70;
-          dateAxis.baseInterval = {count: 1, timeUnit: "day"};
+          dateAxis.baseInterval = { count: 1, timeUnit: 'day' };
           dateAxis.renderer.tooltipLocation = 0;
-          dateAxis.renderer.line.strokeDasharray = "1,4";
+          dateAxis.renderer.line.strokeDasharray = '1,4';
           dateAxis.renderer.line.strokeOpacity = 0.5;
           dateAxis.tooltip.background.fillOpacity = 0.2;
           dateAxis.tooltip.background.cornerRadius = 5;
-          dateAxis.tooltip.label.fill = new window.am4core.InterfaceColorSet().getFor("alternativeBackground");
+          dateAxis.tooltip.label.fill =
+            new window.am4core.InterfaceColorSet().getFor(
+              'alternativeBackground',
+            );
           dateAxis.tooltip.label.paddingTop = 7;
           dateAxis.endLocation = 0;
           dateAxis.startLocation = -0.5;
@@ -97,30 +103,37 @@ jQuery(document).ready(function ($) {
           dateAxis.max = Date.parse(end_date);
 
           let labelTemplate = dateAxis.renderer.labels.template;
-          labelTemplate.verticalCenter = "middle";
+          labelTemplate.verticalCenter = 'middle';
           labelTemplate.fillOpacity = 0.6;
-          labelTemplate.background.fill = new window.am4core.InterfaceColorSet().getFor("background");
+          labelTemplate.background.fill =
+            new window.am4core.InterfaceColorSet().getFor('background');
           labelTemplate.background.fillOpacity = 1;
-          labelTemplate.fill = new window.am4core.InterfaceColorSet().getFor("text");
+          labelTemplate.fill = new window.am4core.InterfaceColorSet().getFor(
+            'text',
+          );
           labelTemplate.padding(7, 7, 7, 7);
 
-          let series = chart.series.push(new window.am4plugins_timeline.CurveColumnSeries());
+          let series = chart.series.push(
+            new window.am4plugins_timeline.CurveColumnSeries(),
+          );
           series.columns.template.height = window.am4core.percent(30);
 
-          series.dataFields.openDateX = "start";
-          series.dataFields.dateX = "end";
-          series.dataFields.categoryY = "category";
+          series.dataFields.openDateX = 'start';
+          series.dataFields.dateX = 'end';
+          series.dataFields.categoryY = 'category';
           series.baseAxis = categoryAxis;
-          series.columns.template.propertyFields.fill = "color"; // get color from data
-          series.columns.template.propertyFields.stroke = "color";
+          series.columns.template.propertyFields.fill = 'color'; // get color from data
+          series.columns.template.propertyFields.stroke = 'color';
           series.columns.template.strokeOpacity = 0;
           series.columns.template.fillOpacity = 0.6;
 
-          let imageBullet1 = series.bullets.push(new window.am4plugins_bullets.PinBullet());
+          let imageBullet1 = series.bullets.push(
+            new window.am4plugins_bullets.PinBullet(),
+          );
           imageBullet1.background.radius = 0;
           imageBullet1.locationX = 1;
-          imageBullet1.propertyFields.stroke = "color";
-          imageBullet1.background.propertyFields.fill = "color";
+          imageBullet1.propertyFields.stroke = 'color';
+          imageBullet1.background.propertyFields.fill = 'color';
           //..imageBullet1.image = new window.am4core.Image();
           //..imageBullet1.image.propertyFields.href = "icon";
           //..imageBullet1.image.scale = 0.7;
@@ -129,50 +142,59 @@ jQuery(document).ready(function ($) {
           imageBullet1.background.strokeOpacity = 0;
           imageBullet1.dy = -2;
           imageBullet1.background.pointerBaseWidth = 10;
-          imageBullet1.background.pointerLength = 10
+          imageBullet1.background.pointerLength = 10;
           imageBullet1.background.hide();
           imageBullet1.background.disabled = true;
           //..imageBullet1.tooltipHTML = "{tooltip}";
           imageBullet1.label = new window.am4core.Label();
-          imageBullet1.label.html = "{tooltip}";
+          imageBullet1.label.html = '{tooltip}';
 
           // Capture bullet clicks and display count breakdowns accordingly!
-          imageBullet1.cursorOverStyle = window.am4core.MouseCursorStyle.pointer;
-          imageBullet1.cursorDownStyle = window.am4core.MouseCursorStyle.grabbing;
+          imageBullet1.cursorOverStyle =
+            window.am4core.MouseCursorStyle.pointer;
+          imageBullet1.cursorDownStyle =
+            window.am4core.MouseCursorStyle.grabbing;
           imageBullet1.clickable = true;
-          imageBullet1.events.on("hit", function (ev) {
+          imageBullet1.events.on('hit', function (ev) {
             display_daily_counts(ev.target.dataItem.dataContext);
           });
 
-          series.tooltip.pointerOrientation = "up";
+          series.tooltip.pointerOrientation = 'up';
 
-          imageBullet1.background.adapter.add("pointerAngle", (value, target) => {
-            if (target.dataItem) {
-              var position = dateAxis.valueToPosition(target.dataItem.openDateX.getTime());
-              return dateAxis.renderer.positionToAngle(position);
-            }
-            return value;
-          });
+          imageBullet1.background.adapter.add(
+            'pointerAngle',
+            (value, target) => {
+              if (target.dataItem) {
+                var position = dateAxis.valueToPosition(
+                  target.dataItem.openDateX.getTime(),
+                );
+                return dateAxis.renderer.positionToAngle(position);
+              }
+              return value;
+            },
+          );
 
-          let hs = imageBullet1.states.create("hover");
+          let hs = imageBullet1.states.create('hover');
           hs.properties.scale = 1.3;
           hs.properties.opacity = 1;
 
-          let textBullet = series.bullets.push(new window.am4charts.LabelBullet());
-          textBullet.label.propertyFields.text = "text";
+          let textBullet = series.bullets.push(
+            new window.am4charts.LabelBullet(),
+          );
+          textBullet.label.propertyFields.text = 'text';
           textBullet.disabled = true;
-          textBullet.propertyFields.disabled = "textDisabled";
+          textBullet.propertyFields.disabled = 'textDisabled';
           textBullet.label.strokeOpacity = 0;
           textBullet.locationX = 1;
           textBullet.dy = -100;
-          textBullet.label.textAlign = "middle";
+          textBullet.label.textAlign = 'middle';
 
           chart.scrollbarX = new window.am4core.Scrollbar();
-          chart.scrollbarX.align = "center"
+          chart.scrollbarX.align = 'center';
           chart.scrollbarX.width = window.am4core.percent(75);
           chart.scrollbarX.parent = chart.curveContainer;
           chart.scrollbarX.height = 300;
-          chart.scrollbarX.orientation = "vertical";
+          chart.scrollbarX.orientation = 'vertical';
           chart.scrollbarX.x = 128;
           chart.scrollbarX.y = -140;
           chart.scrollbarX.isMeasured = false;
@@ -192,11 +214,11 @@ jQuery(document).ready(function ($) {
 
           let previousBullet;
 
-          chart.events.on("inited", function () {
+          chart.events.on('inited', function () {
             setTimeout(function () {
               // DISABLE ROLLOVER FUNCTION // hoverItem(series.dataItems.getIndex(0));
-            }, 2000)
-          })
+            }, 2000);
+          });
 
           function hoverItem(dataItem) {
             let bullet = dataItem.bullets.getKey(imageBullet1.uid);
@@ -207,7 +229,6 @@ jQuery(document).ready(function ($) {
             }
 
             if (bullet) {
-
               if (previousBullet) {
                 previousBullet.isHover = false;
               }
@@ -216,26 +237,30 @@ jQuery(document).ready(function ($) {
 
               previousBullet = bullet;
             }
-            setTimeout(
-              function () {
-                hoverItem(series.dataItems.getIndex(index + 1))
-              }, 1000);
+            setTimeout(function () {
+              hoverItem(series.dataItems.getIndex(index + 1));
+            }, 1000);
           }
 
           // Respond to filter date range changes
-          $(document).off('change').on('change', '#activity_date_range_filter', function () {
-            refresh_daily_activity_chart(chart, $('#activity_date_range_filter').val());
-          });
+          $(document)
+            .off('change')
+            .on('change', '#activity_date_range_filter', function () {
+              refresh_daily_activity_chart(
+                chart,
+                $('#activity_date_range_filter').val(),
+              );
+            });
 
           // Display Updated Chart
-          $('#chartdiv').fadeIn('slow', function () {
-          });
-
+          $('#chartdiv').fadeIn('slow', function () {});
         });
 
         function getPoints() {
-
-          let points = [{x: -1300, y: 200}, {x: 0, y: 200}];
+          let points = [
+            { x: -1300, y: 200 },
+            { x: 0, y: 200 },
+          ];
 
           let w = 400;
           let h = 400;
@@ -245,56 +270,77 @@ jQuery(document).ready(function ($) {
           let startX = radius;
 
           for (let i = 0; i < 25; i++) {
-            let angle = 0 + i / 25 * 90;
-            let centerPoint = {y: 200 - radius, x: 0}
+            let angle = 0 + (i / 25) * 90;
+            let centerPoint = { y: 200 - radius, x: 0 };
             points.push({
               y: centerPoint.y + radius * window.am4core.math.cos(angle),
-              x: centerPoint.x + radius * window.am4core.math.sin(angle)
+              x: centerPoint.x + radius * window.am4core.math.sin(angle),
             });
           }
 
-
           for (let i = 0; i < levelCount; i++) {
-
             if (i % 2 != 0) {
-              points.push({y: -h / 2 + radius, x: startX + w / (levelCount - 1) * i})
-              points.push({y: h / 2 - radius, x: startX + w / (levelCount - 1) * i})
+              points.push({
+                y: -h / 2 + radius,
+                x: startX + (w / (levelCount - 1)) * i,
+              });
+              points.push({
+                y: h / 2 - radius,
+                x: startX + (w / (levelCount - 1)) * i,
+              });
 
-              let centerPoint = {y: h / 2 - radius, x: startX + w / (levelCount - 1) * (i + 0.5)}
+              let centerPoint = {
+                y: h / 2 - radius,
+                x: startX + (w / (levelCount - 1)) * (i + 0.5),
+              };
               if (i < levelCount - 1) {
                 for (let k = 0; k < 50; k++) {
-                  let angle = -90 + k / 50 * 180;
+                  let angle = -90 + (k / 50) * 180;
                   points.push({
                     y: centerPoint.y + radius * window.am4core.math.cos(angle),
-                    x: centerPoint.x + radius * window.am4core.math.sin(angle)
+                    x: centerPoint.x + radius * window.am4core.math.sin(angle),
                   });
                 }
               }
 
               if (i == levelCount - 1) {
                 points.pop();
-                points.push({y: -radius, x: startX + w / (levelCount - 1) * i})
-                let centerPoint = {y: -radius, x: startX + w / (levelCount - 1) * (i + 0.5)}
+                points.push({
+                  y: -radius,
+                  x: startX + (w / (levelCount - 1)) * i,
+                });
+                let centerPoint = {
+                  y: -radius,
+                  x: startX + (w / (levelCount - 1)) * (i + 0.5),
+                };
                 for (let k = 0; k < 25; k++) {
-                  let angle = -90 + k / 25 * 90;
+                  let angle = -90 + (k / 25) * 90;
                   points.push({
                     y: centerPoint.y + radius * window.am4core.math.cos(angle),
-                    x: centerPoint.x + radius * window.am4core.math.sin(angle)
+                    x: centerPoint.x + radius * window.am4core.math.sin(angle),
                   });
                 }
-                points.push({y: 0, x: 1300});
+                points.push({ y: 0, x: 1300 });
               }
-
             } else {
-              points.push({y: h / 2 - radius, x: startX + w / (levelCount - 1) * i})
-              points.push({y: -h / 2 + radius, x: startX + w / (levelCount - 1) * i})
-              let centerPoint = {y: -h / 2 + radius, x: startX + w / (levelCount - 1) * (i + 0.5)}
+              points.push({
+                y: h / 2 - radius,
+                x: startX + (w / (levelCount - 1)) * i,
+              });
+              points.push({
+                y: -h / 2 + radius,
+                x: startX + (w / (levelCount - 1)) * i,
+              });
+              let centerPoint = {
+                y: -h / 2 + radius,
+                x: startX + (w / (levelCount - 1)) * (i + 0.5),
+              };
               if (i < levelCount - 1) {
                 for (let k = 0; k < 50; k++) {
-                  let angle = -90 - k / 50 * 180;
+                  let angle = -90 - (k / 50) * 180;
                   points.push({
                     y: centerPoint.y + radius * window.am4core.math.cos(angle),
-                    x: centerPoint.x + radius * window.am4core.math.sin(angle)
+                    x: centerPoint.x + radius * window.am4core.math.sin(angle),
                   });
                 }
               }
@@ -303,7 +349,6 @@ jQuery(document).ready(function ($) {
 
           return points;
         }
-
       });
     });
   }
@@ -317,28 +362,45 @@ jQuery(document).ready(function ($) {
     //console.log(day_counts);
     let chart_day_counts_div = $('#chart_day_counts_div');
     chart_day_counts_div.fadeOut('fast', function () {
-
       let metrics_html = '';
 
       // Default Metrics
       if (parseInt(day_counts['new_contacts']) > 0) {
         metrics_html += '<tr>';
-        metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.chart.new_contacts) + '</td>';
+        metrics_html +=
+          '<td>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            window.wp_js_object.translations.chart.new_contacts,
+          ) +
+          '</td>';
         metrics_html += '<td>' + day_counts['new_contacts'] + '</td>';
         metrics_html += '</tr>';
       }
 
       if (parseInt(day_counts['new_groups']) > 0) {
         metrics_html += '<tr>';
-        metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.chart.new_groups) + '</td>';
+        metrics_html +=
+          '<td>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            window.wp_js_object.translations.chart.new_groups,
+          ) +
+          '</td>';
         metrics_html += '<td>' + day_counts['new_groups'] + '</td>';
         metrics_html += '</tr>';
       }
 
       if (parseInt(day_counts['baptisms']) > 0) {
         metrics_html += '<tr>';
-        metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.chart.baptisms) + '</td>';
-        metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(day_counts['baptisms']) + '</td>';
+        metrics_html +=
+          '<td>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            window.wp_js_object.translations.chart.baptisms,
+          ) +
+          '</td>';
+        metrics_html +=
+          '<td>' +
+          window.SHAREDFUNCTIONS.escapeHTML(day_counts['baptisms']) +
+          '</td>';
         metrics_html += '</tr>';
       }
 
@@ -347,50 +409,120 @@ jQuery(document).ready(function ($) {
 
       if (parseInt(seeker_path_updates['attempted']['value']) > 0) {
         metrics_html += '<tr>';
-        metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(seeker_path_updates['attempted']['label']) + '</td>';
-        metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(seeker_path_updates['attempted']['value']) + '</td>';
+        metrics_html +=
+          '<td>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            seeker_path_updates['attempted']['label'],
+          ) +
+          '</td>';
+        metrics_html +=
+          '<td>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            seeker_path_updates['attempted']['value'],
+          ) +
+          '</td>';
         metrics_html += '</tr>';
       }
 
       if (parseInt(seeker_path_updates['coaching']['value']) > 0) {
         metrics_html += '<tr>';
-        metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(seeker_path_updates['coaching']['label']) + '</td>';
-        metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(seeker_path_updates['coaching']['value']) + '</td>';
+        metrics_html +=
+          '<td>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            seeker_path_updates['coaching']['label'],
+          ) +
+          '</td>';
+        metrics_html +=
+          '<td>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            seeker_path_updates['coaching']['value'],
+          ) +
+          '</td>';
         metrics_html += '</tr>';
       }
 
       if (parseInt(seeker_path_updates['established']['value']) > 0) {
         metrics_html += '<tr>';
-        metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(seeker_path_updates['established']['label']) + '</td>';
-        metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(seeker_path_updates['established']['value']) + '</td>';
+        metrics_html +=
+          '<td>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            seeker_path_updates['established']['label'],
+          ) +
+          '</td>';
+        metrics_html +=
+          '<td>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            seeker_path_updates['established']['value'],
+          ) +
+          '</td>';
         metrics_html += '</tr>';
       }
 
       if (parseInt(seeker_path_updates['met']['value']) > 0) {
         metrics_html += '<tr>';
-        metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(seeker_path_updates['met']['label']) + '</td>';
-        metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(seeker_path_updates['met']['value']) + '</td>';
+        metrics_html +=
+          '<td>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            seeker_path_updates['met']['label'],
+          ) +
+          '</td>';
+        metrics_html +=
+          '<td>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            seeker_path_updates['met']['value'],
+          ) +
+          '</td>';
         metrics_html += '</tr>';
       }
 
       if (parseInt(seeker_path_updates['none']['value']) > 0) {
         metrics_html += '<tr>';
-        metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(seeker_path_updates['none']['label'] )+ '</td>';
-        metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(seeker_path_updates['none']['value']) + '</td>';
+        metrics_html +=
+          '<td>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            seeker_path_updates['none']['label'],
+          ) +
+          '</td>';
+        metrics_html +=
+          '<td>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            seeker_path_updates['none']['value'],
+          ) +
+          '</td>';
         metrics_html += '</tr>';
       }
 
       if (parseInt(seeker_path_updates['ongoing']['value']) > 0) {
         metrics_html += '<tr>';
-        metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(seeker_path_updates['ongoing']['label']) + '</td>';
-        metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(seeker_path_updates['ongoing']['value']) + '</td>';
+        metrics_html +=
+          '<td>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            seeker_path_updates['ongoing']['label'],
+          ) +
+          '</td>';
+        metrics_html +=
+          '<td>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            seeker_path_updates['ongoing']['value'],
+          ) +
+          '</td>';
         metrics_html += '</tr>';
       }
 
       if (parseInt(seeker_path_updates['scheduled']['value']) > 0) {
         metrics_html += '<tr>';
-        metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(seeker_path_updates['scheduled']['label']) + '</td>';
-        metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(seeker_path_updates['scheduled']['value']) + '</td>';
+        metrics_html +=
+          '<td>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            seeker_path_updates['scheduled']['label'],
+          ) +
+          '</td>';
+        metrics_html +=
+          '<td>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            seeker_path_updates['scheduled']['value'],
+          ) +
+          '</td>';
         metrics_html += '</tr>';
       }
 
@@ -399,15 +531,24 @@ jQuery(document).ready(function ($) {
 
       if (health['metrics'] && health['metrics'].length > 0) {
         metrics_html += '<tr>';
-        metrics_html += '<td colspan="2" style="background-color:#E8E8E8FF;">' + window.SHAREDFUNCTIONS.escapeHTML(health['name']) + '</td>';
+        metrics_html +=
+          '<td colspan="2" style="background-color:#E8E8E8FF;">' +
+          window.SHAREDFUNCTIONS.escapeHTML(health['name']) +
+          '</td>';
         metrics_html += '</tr>';
 
         // Iterate over each field option
         health['metrics'].forEach(function (metric) {
           if (parseInt(metric['practicing']) > 0) {
             metrics_html += '<tr>';
-            metrics_html += '<td style="padding-left: 50px;"><li>' + window.SHAREDFUNCTIONS.escapeHTML(metric['label']) + '</li></td>';
-            metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(metric['practicing']) + '</td>';
+            metrics_html +=
+              '<td style="padding-left: 50px;"><li>' +
+              window.SHAREDFUNCTIONS.escapeHTML(metric['label']) +
+              '</li></td>';
+            metrics_html +=
+              '<td>' +
+              window.SHAREDFUNCTIONS.escapeHTML(metric['practicing']) +
+              '</td>';
             metrics_html += '</tr>';
           }
         });
@@ -417,15 +558,24 @@ jQuery(document).ready(function ($) {
       let multiselect_fields = day_counts['multiselect_fields'];
       for (let [field_key, field_value] of Object.entries(multiselect_fields)) {
         metrics_html += '<tr>';
-        metrics_html += '<td colspan="2" style="background-color:#E8E8E8FF;">' + field_key + '</td>';
+        metrics_html +=
+          '<td colspan="2" style="background-color:#E8E8E8FF;">' +
+          field_key +
+          '</td>';
         metrics_html += '</tr>';
 
         // Iterate over each field option
         field_value.forEach(function (metric) {
           if (parseInt(metric['value']) > 0) {
             metrics_html += '<tr>';
-            metrics_html += '<td style="padding-left: 50px;"><li>' + metric['label'] + '</li></td>';
-            metrics_html += '<td>' + window.SHAREDFUNCTIONS.escapeHTML(metric['value']) + '</td>';
+            metrics_html +=
+              '<td style="padding-left: 50px;"><li>' +
+              metric['label'] +
+              '</li></td>';
+            metrics_html +=
+              '<td>' +
+              window.SHAREDFUNCTIONS.escapeHTML(metric['value']) +
+              '</td>';
             metrics_html += '</tr>';
           }
         });
@@ -438,8 +588,18 @@ jQuery(document).ready(function ($) {
 
         html += '<thead>';
         html += '<tr>';
-        html += '<th>' + window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.chart.metrics) + '</th>';
-        html += '<th>' + window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.chart.count) + '</th>';
+        html +=
+          '<th>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            window.wp_js_object.translations.chart.metrics,
+          ) +
+          '</th>';
+        html +=
+          '<th>' +
+          window.SHAREDFUNCTIONS.escapeHTML(
+            window.wp_js_object.translations.chart.count,
+          ) +
+          '</th>';
         html += '</tr>';
         html += '</thead>';
 
@@ -447,43 +607,43 @@ jQuery(document).ready(function ($) {
         html += metrics_html;
         html += '</tbody>';
         html += '</table>';
-
       } else {
-        html += window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.chart.no_activity);
+        html += window.SHAREDFUNCTIONS.escapeHTML(
+          window.wp_js_object.translations.chart.no_activity,
+        );
       }
 
       chart_day_counts_div.html(html);
 
       // Display Counts Chart
-      chart_day_counts_div.fadeIn('slow', function () {
-      });
+      chart_day_counts_div.fadeIn('slow', function () {});
     });
   }
 
   function refresh_daily_activity_chart(chart, date_range_filter) {
     // Start loading spinner
-    $(".loading-spinner").addClass("active");
+    $('.loading-spinner').addClass('active');
 
     jQuery
       .ajax({
-        type: "GET",
-        contentType: "application/json; charset=utf-8",
-        dataType: "json",
+        type: 'GET',
+        contentType: 'application/json; charset=utf-8',
+        dataType: 'json',
         url: `${window.wp_js_object.rest_endpoints_base}/daily-activity/?date_range=${date_range_filter}`,
         beforeSend: function (xhr) {
-          xhr.setRequestHeader("X-WP-Nonce", window.wpApiShare.nonce);
+          xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce);
         },
       })
       .done(function (data) {
         // Disable loading spinner
-        $(".loading-spinner").removeClass("active");
+        $('.loading-spinner').removeClass('active');
 
         console.log(data);
         chart.dispose(); // Force chart disposal
         display_daily_activity_chart(data.start, data.end, data.days);
       })
       .fail(function (err) {
-        console.log("error");
+        console.log('error');
         console.log(err);
       });
   }
@@ -495,13 +655,13 @@ jQuery(document).ready(function ($) {
       //console.log(day);
 
       data.push({
-        "category": "",
-        "start": key + " 00:00",
-        "end": key + " 23:59",
-        "color": colorSet.next(),
-        "tooltip": fetch_tooltip(key, day),
-        "text": key,
-        "counts": day
+        category: '',
+        start: key + ' 00:00',
+        end: key + ' 23:59',
+        color: colorSet.next(),
+        tooltip: fetch_tooltip(key, day),
+        text: key,
+        counts: day,
       });
     }
 
@@ -511,8 +671,22 @@ jQuery(document).ready(function ($) {
   function fetch_tooltip(date, counts) {
     let html = '<h3>' + date + '</h3>';
     html += '<ul>';
-    html += '<li>' + window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.chart.new_contacts) + ': ' + window.SHAREDFUNCTIONS.escapeHTML(counts['new_contacts']) + '</li>'
-    html += '<li>' + window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.chart.new_groups) + ': ' + window.SHAREDFUNCTIONS.escapeHTML(counts['new_groups']) + '</li>'
+    html +=
+      '<li>' +
+      window.SHAREDFUNCTIONS.escapeHTML(
+        window.wp_js_object.translations.chart.new_contacts,
+      ) +
+      ': ' +
+      window.SHAREDFUNCTIONS.escapeHTML(counts['new_contacts']) +
+      '</li>';
+    html +=
+      '<li>' +
+      window.SHAREDFUNCTIONS.escapeHTML(
+        window.wp_js_object.translations.chart.new_groups,
+      ) +
+      ': ' +
+      window.SHAREDFUNCTIONS.escapeHTML(counts['new_groups']) +
+      '</li>';
     html += '</ul>';
 
     return html;

--- a/dt-metrics/combined/hover-map.js
+++ b/dt-metrics/combined/hover-map.js
@@ -1,13 +1,16 @@
-"use strict";
+'use strict';
 
-jQuery(document).ready(function() {
-  jQuery('#metrics-sidemenu').foundation('down', jQuery(`#${window.wp_js_object.base_slug}-menu`));
+jQuery(document).ready(function () {
+  jQuery('#metrics-sidemenu').foundation(
+    'down',
+    jQuery(`#${window.wp_js_object.base_slug}-menu`),
+  );
 
-  let chartDiv = jQuery('#chart')
+  let chartDiv = jQuery('#chart');
   chartDiv.empty().html(`
     <span class="section-header" title="Showing all contacts from all time with any status">${window.wp_js_object.translations.title}</span>
     <div id="mapping_chart"></div>
-  `)
+  `);
 
-  window.page_mapping_view(window.wp_js_object.rest_endpoints_base)
-})
+  window.page_mapping_view(window.wp_js_object.rest_endpoints_base);
+});

--- a/dt-metrics/combined/locations-list.js
+++ b/dt-metrics/combined/locations-list.js
@@ -1,21 +1,22 @@
-"use strict";
-let LISTDATA = null
+'use strict';
+let LISTDATA = null;
 
-jQuery(document).ready(function() {
-  jQuery('#metrics-sidemenu').foundation('down', jQuery(`#${window.wp_js_object.base_slug}-menu`));
+jQuery(document).ready(function () {
+  jQuery('#metrics-sidemenu').foundation(
+    'down',
+    jQuery(`#${window.wp_js_object.base_slug}-menu`),
+  );
 
-  let chartDiv = jQuery('#chart')
+  let chartDiv = jQuery('#chart');
   chartDiv.empty().html(`
     <div id="mapping_chart"></div>
-  `)
+  `);
 
-
-  if( window.wpApiShare.url_path.startsWith( window.wp_js_object.load_url )) {
-    LISTDATA = window.wp_js_object.mapping_module
-    page_mapping_list()
+  if (window.wpApiShare.url_path.startsWith(window.wp_js_object.load_url)) {
+    LISTDATA = window.wp_js_object.mapping_module;
+    page_mapping_list();
   }
-
-})
+});
 
 /**********************************************************************************************************************
  *
@@ -26,8 +27,8 @@ jQuery(document).ready(function() {
  **********************************************************************************************************************/
 
 function page_mapping_list() {
-  "use strict";
-  let chartDiv = jQuery('#chart')
+  'use strict';
+  let chartDiv = jQuery('#chart');
   chartDiv.empty().html(`
     <style>
       .map_wrapper {}
@@ -74,192 +75,213 @@ function page_mapping_list() {
     </div> <!-- end widget -->
   `);
 
-  get_data(false).then(response=>{
-    LISTDATA.data = response
-    // set the depth of the drill down
-    LISTDATA.settings.hide_final_drill_down = false
-    // load drill down
-    window.DRILLDOWN.get_drill_down('location_list_drilldown', LISTDATA.settings.current_map, LISTDATA.settings.cached)
-  }).fail(err=>{
-    console.log(err)
-  })
+  get_data(false)
+    .then((response) => {
+      LISTDATA.data = response;
+      // set the depth of the drill down
+      LISTDATA.settings.hide_final_drill_down = false;
+      // load drill down
+      window.DRILLDOWN.get_drill_down(
+        'location_list_drilldown',
+        LISTDATA.settings.current_map,
+        LISTDATA.settings.cached,
+      );
+    })
+    .fail((err) => {
+      console.log(err);
+    });
 }
 
-window.DRILLDOWN.location_list_drilldown = function( grid_id ) {
-  location_grid_list( 'location_list', grid_id )
-}
-function get_data( force_refresh = false ) {
-  let spinner = jQuery('.loading-spinner')
-  spinner.addClass('active')
-  return jQuery.ajax({
-    type: "GET",
-    contentType: "application/json; charset=utf-8",
-    dataType: "json",
-    url: `${window.wp_js_object.rest_endpoint}?refresh=${force_refresh}`,
-    beforeSend: function(xhr) {
-      xhr.setRequestHeader('X-WP-Nonce', window.wp_js_object.nonce );
-    },
-  })
-    .then( function( response ) {
-      spinner.removeClass('active')
-      return response
+window.DRILLDOWN.location_list_drilldown = function (grid_id) {
+  location_grid_list('location_list', grid_id);
+};
+function get_data(force_refresh = false) {
+  let spinner = jQuery('.loading-spinner');
+  spinner.addClass('active');
+  return jQuery
+    .ajax({
+      type: 'GET',
+      contentType: 'application/json; charset=utf-8',
+      dataType: 'json',
+      url: `${window.wp_js_object.rest_endpoint}?refresh=${force_refresh}`,
+      beforeSend: function (xhr) {
+        xhr.setRequestHeader('X-WP-Nonce', window.wp_js_object.nonce);
+      },
+    })
+    .then(function (response) {
+      spinner.removeClass('active');
+      return response;
     })
     .fail(function (err) {
-      spinner.removeClass('active')
-      console.log("error")
-      console.log(err)
-    })
+      spinner.removeClass('active');
+      console.log('error');
+      console.log(err);
+    });
 }
 
-function location_grid_list( div, grid_id ) {
-  window.DRILLDOWN.show_spinner()
+function location_grid_list(div, grid_id) {
+  window.DRILLDOWN.show_spinner();
 
   // Find data source before build
-  if ( grid_id === 'top_map_level' ) {
-    let map_data = null
-    let default_map_settings = LISTDATA.settings.default_map_settings
+  if (grid_id === 'top_map_level') {
+    let map_data = null;
+    let default_map_settings = LISTDATA.settings.default_map_settings;
 
-    if (window.DRILLDOWN.isEmpty( default_map_settings.children ) ) {
-      map_data = LISTDATA.data[default_map_settings.parent]
-    }
-    else {
-      if ( default_map_settings.children.length < 2 ) {
+    if (window.DRILLDOWN.isEmpty(default_map_settings.children)) {
+      map_data = LISTDATA.data[default_map_settings.parent];
+    } else {
+      if (default_map_settings.children.length < 2) {
         // single child
-        map_data = LISTDATA.data[default_map_settings.children[0]]
+        map_data = LISTDATA.data[default_map_settings.children[0]];
       } else {
         // multiple child
-        jQuery('#section_title').empty()
-        jQuery('#current_level').empty()
-        jQuery('#location_list').empty().append('Select Location')
-        window.DRILLDOWN.hide_spinner()
+        jQuery('#section_title').empty();
+        jQuery('#current_level').empty();
+        jQuery('#location_list').empty().append('Select Location');
+        window.DRILLDOWN.hide_spinner();
         return;
       }
     }
 
     // Initialize Location Data
-    if ( map_data === undefined ) {
-      console.log('error getting map_data')
+    if (map_data === undefined) {
+      console.log('error getting map_data');
       return;
     }
 
-    build_location_grid_list( div, map_data )
-  }
-  else if ( LISTDATA.data[grid_id] === undefined ) {
-    let rest = LISTDATA.settings.endpoints.get_map_by_grid_id_endpoint
+    build_location_grid_list(div, map_data);
+  } else if (LISTDATA.data[grid_id] === undefined) {
+    let rest = LISTDATA.settings.endpoints.get_map_by_grid_id_endpoint;
 
-    jQuery.ajax({
-      type: rest.method,
-      contentType: "application/json; charset=utf-8",
-      data: JSON.stringify( { 'grid_id': grid_id, 'cached': LISTDATA.settings.cached, 'cached_length': LISTDATA.settings.cached_length } ),
-      dataType: "json",
-      url: LISTDATA.settings.root + rest.namespace + rest.route,
-      beforeSend: function(xhr) {
-        xhr.setRequestHeader('X-WP-Nonce', rest.nonce );
-      },
-    })
-      .done( function( response ) {
-        LISTDATA.data[grid_id] = response
-        build_location_grid_list( div, LISTDATA.data[grid_id] )
+    jQuery
+      .ajax({
+        type: rest.method,
+        contentType: 'application/json; charset=utf-8',
+        data: JSON.stringify({
+          grid_id: grid_id,
+          cached: LISTDATA.settings.cached,
+          cached_length: LISTDATA.settings.cached_length,
+        }),
+        dataType: 'json',
+        url: LISTDATA.settings.root + rest.namespace + rest.route,
+        beforeSend: function (xhr) {
+          xhr.setRequestHeader('X-WP-Nonce', rest.nonce);
+        },
+      })
+      .done(function (response) {
+        LISTDATA.data[grid_id] = response;
+        build_location_grid_list(div, LISTDATA.data[grid_id]);
       })
       .fail(function (err) {
-        console.log("error")
-        console.log(err)
-        window.DRILLDOWN.hide_spinner()
-      })
-
+        console.log('error');
+        console.log(err);
+        window.DRILLDOWN.hide_spinner();
+      });
   } else {
-    build_location_grid_list( div, LISTDATA.data[grid_id] )
+    build_location_grid_list(div, LISTDATA.data[grid_id]);
   }
 
   // build list
-  function build_location_grid_list( div, map_data ) {
-    let translations = window.wp_js_object.translations
+  function build_location_grid_list(div, map_data) {
+    let translations = window.wp_js_object.translations;
 
     // Place Title
-    let title = jQuery('#section_title')
-    title.empty().html(map_data.self.name)
+    let title = jQuery('#section_title');
+    title.empty().html(map_data.self.name);
 
     // Population Division and Check for Custom Division
-    let pd_settings = LISTDATA.settings.population_division
-    let population_division = pd_settings.base
-    if ( !window.DRILLDOWN.isEmpty( pd_settings.custom ) ) {
-      jQuery.each( pd_settings.custom, function(i,v) {
-        if ( map_data.self.grid_id === i ) {
-          population_division = v
+    let pd_settings = LISTDATA.settings.population_division;
+    let population_division = pd_settings.base;
+    if (!window.DRILLDOWN.isEmpty(pd_settings.custom)) {
+      jQuery.each(pd_settings.custom, function (i, v) {
+        if (map_data.self.grid_id === i) {
+          population_division = v;
         }
-      })
+      });
     }
 
     // Self Data
-    let self_population = map_data.self.population_formatted
-    jQuery('#current_level').empty().html(`${window.SHAREDFUNCTIONS.escapeHTML(translations.population)} ${window.SHAREDFUNCTIONS.escapeHTML( self_population )}`)
+    let self_population = map_data.self.population_formatted;
+    jQuery('#current_level')
+      .empty()
+      .html(
+        `${window.SHAREDFUNCTIONS.escapeHTML(translations.population)} ${window.SHAREDFUNCTIONS.escapeHTML(self_population)}`,
+      );
 
     // Build List
-    let locations = jQuery('#location_list')
-    locations.empty()
+    let locations = jQuery('#location_list');
+    locations.empty();
 
-    let html = `<table id="country-list-table" class="display">`
+    let html = `<table id="country-list-table" class="display">`;
 
     // Header Section
-    html += `<thead><tr><th>${window.SHAREDFUNCTIONS.escapeHTML(translations.name)}</th><th>${window.SHAREDFUNCTIONS.escapeHTML(translations.population)}</th>`
+    html += `<thead><tr><th>${window.SHAREDFUNCTIONS.escapeHTML(translations.name)}</th><th>${window.SHAREDFUNCTIONS.escapeHTML(translations.population)}</th>`;
 
     /* Additional Columns */
-    if ( LISTDATA.data.custom_column_labels ) {
-      jQuery.each( LISTDATA.data.custom_column_labels, function(i,v) {
-        html += `<th>${window.SHAREDFUNCTIONS.escapeHTML( v.label )}</th>`
-      })
+    if (LISTDATA.data.custom_column_labels) {
+      jQuery.each(LISTDATA.data.custom_column_labels, function (i, v) {
+        html += `<th>${window.SHAREDFUNCTIONS.escapeHTML(v.label)}</th>`;
+      });
     }
     /* End Additional Columns */
 
-    html += `</tr></thead>`
+    html += `</tr></thead>`;
     // End Header Section
 
     // Children List Section
-    let sorted_children =  window.lodash.sortBy(map_data.children, [function(o) { return o.name; }]);
+    let sorted_children = window.lodash.sortBy(map_data.children, [
+      function (o) {
+        return o.name;
+      },
+    ]);
 
-    html += `<tbody>`
+    html += `<tbody>`;
 
-    jQuery.each( sorted_children, function(i, v) {
-      let population = v.population_formatted
+    jQuery.each(sorted_children, function (i, v) {
+      let population = v.population_formatted;
 
       html += `<tr>
-                    <td><strong><a onclick="DRILLDOWN.get_drill_down('location_list_drilldown', ${window.SHAREDFUNCTIONS.escapeHTML( v.grid_id )} )">${window.SHAREDFUNCTIONS.escapeHTML( v.name )}</a></strong></td>
-                    <td>${window.SHAREDFUNCTIONS.escapeHTML( population )}</td>`
+                    <td><strong><a onclick="DRILLDOWN.get_drill_down('location_list_drilldown', ${window.SHAREDFUNCTIONS.escapeHTML(v.grid_id)} )">${window.SHAREDFUNCTIONS.escapeHTML(v.name)}</a></strong></td>
+                    <td>${window.SHAREDFUNCTIONS.escapeHTML(population)}</td>`;
 
       /* Additional Columns */
-      if ( LISTDATA.data.custom_column_data[v.grid_id] ) {
-        jQuery.each( LISTDATA.data.custom_column_data[v.grid_id], function(ii,vv) {
-          html += `<td><strong>${window.SHAREDFUNCTIONS.escapeHTML( vv )}</strong></td>`
-        })
+      if (LISTDATA.data.custom_column_data[v.grid_id]) {
+        jQuery.each(
+          LISTDATA.data.custom_column_data[v.grid_id],
+          function (ii, vv) {
+            html += `<td><strong>${window.SHAREDFUNCTIONS.escapeHTML(vv)}</strong></td>`;
+          },
+        );
       } else {
-        jQuery.each( LISTDATA.data.custom_column_labels, function(ii,vv) {
-          html += `<td class="grey">0</td>`
-        })
+        jQuery.each(LISTDATA.data.custom_column_labels, function (ii, vv) {
+          html += `<td class="grey">0</td>`;
+        });
       }
       /* End Additional Columns */
 
-      html += `</tr>`
-
-    })
-    html += `</tbody>`
+      html += `</tr>`;
+    });
+    html += `</tbody>`;
     // end Child section
 
-    html += `</table>`
-    locations.append(html)
+    html += `</table>`;
+    locations.append(html);
 
-    let isMobile = window.matchMedia("only screen and (max-width: 760px)").matches;
+    let isMobile = window.matchMedia(
+      'only screen and (max-width: 760px)',
+    ).matches;
 
     if (isMobile) {
       jQuery('#country-list-table').DataTable({
-        "paging":   false,
-        "scrollX": true
+        paging: false,
+        scrollX: true,
       });
     } else {
       jQuery('#country-list-table').DataTable({
-        "paging":   false
+        paging: false,
       });
     }
 
-    window.DRILLDOWN.hide_spinner()
+    window.DRILLDOWN.hide_spinner();
   }
 }

--- a/dt-metrics/combined/site-links.js
+++ b/dt-metrics/combined/site-links.js
@@ -1,7 +1,6 @@
 jQuery(document).ready(function ($) {
-
   if (window.wpApiShare.url_path.startsWith('metrics/combined/site-links')) {
-    display_site_link_metrics()
+    display_site_link_metrics();
   }
 
   function display_site_link_metrics() {
@@ -10,7 +9,8 @@ jQuery(document).ready(function ($) {
     let chartDiv = jQuery('#chart');
 
     // Display chart controls
-    chartDiv.empty().html(`
+    chartDiv.empty().html(
+      `
     <div class="section-header">${window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.headings.header)}</div>
     <div class="section-subheader">${window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.headings.sub_header)}:</div>
     <br>
@@ -25,8 +25,12 @@ jQuery(document).ready(function ($) {
         </thead>
         <tbody>
             <tr>
-                <td>` + date_ranges_select_html() + `</td>
-                <td>` + site_links_select_html() + `</td>
+                <td>` +
+        date_ranges_select_html() +
+        `</td>
+                <td>` +
+        site_links_select_html() +
+        `</td>
             </tr>
         </tbody>
     </table>
@@ -133,7 +137,8 @@ jQuery(document).ready(function ($) {
                 </tr>
             </tbody>
         </table>
-    </div>`);
+    </div>`,
+    );
 
     // Activate date range picker
     window.METRICS.setupDatePickerWithoutEndpoint(
@@ -142,7 +147,7 @@ jQuery(document).ready(function ($) {
         refresh_charts();
       },
       window.moment().startOf('year'),
-      window.moment().endOf('year')
+      window.moment().endOf('year'),
     );
 
     // Trigger data refreshes, following a site link change
@@ -157,7 +162,7 @@ jQuery(document).ready(function ($) {
   function date_ranges_select_html() {
     return `<div class="date_range_picker" style="min-width: 150px;">
                 <i class="fi-calendar"></i>
-                <span>${window.moment().format("YYYY")}</span>
+                <span>${window.moment().format('YYYY')}</span>
                 <i class="dt_caret down"></i>
             </div>`;
   }
@@ -166,17 +171,22 @@ jQuery(document).ready(function ($) {
     let sites = window.wp_js_object.data.sites;
 
     if (sites && sites.length > 0) {
-
       let html = '<select id="site_links_filter" style="min-width: 150px;">';
       $.each(sites, function (idx, val) {
-        html += '<option value="' + window.SHAREDFUNCTIONS.escapeHTML(val['id']) + '">' + window.SHAREDFUNCTIONS.escapeHTML(val['name']) + '</option>';
+        html +=
+          '<option value="' +
+          window.SHAREDFUNCTIONS.escapeHTML(val['id']) +
+          '">' +
+          window.SHAREDFUNCTIONS.escapeHTML(val['name']) +
+          '</option>';
       });
 
       html += '</select>';
       return html;
-
     } else {
-      return window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.headings.site_links_none_header);
+      return window.SHAREDFUNCTIONS.escapeHTML(
+        window.wp_js_object.translations.headings.site_links_none_header,
+      );
     }
   }
 
@@ -195,7 +205,7 @@ jQuery(document).ready(function ($) {
     $('#metrics_msg').fadeOut('fast');
 
     // Indicate something is happening..!
-    $(".loading-spinner").addClass("active");
+    $('.loading-spinner').addClass('active');
 
     // Fetch current parameters
     let drp = $('.date_range_picker').data('daterangepicker');
@@ -206,33 +216,51 @@ jQuery(document).ready(function ($) {
     // Fetch metrics from specified endpoint
     jQuery
       .ajax({
-        type: "GET",
-        contentType: "application/json; charset=utf-8",
-        dataType: "json",
+        type: 'GET',
+        contentType: 'application/json; charset=utf-8',
+        dataType: 'json',
         url: `${window.wp_js_object.rest_endpoints_base}/site-links/?site_id=${site_id}&start=${start_date}&end=${end_date}`,
         beforeSend: function (xhr) {
-          xhr.setRequestHeader("X-WP-Nonce", window.wpApiShare.nonce);
+          xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce);
         },
       })
       .done(function (data) {
         // Disable loading spinner
-        $(".loading-spinner").removeClass("active");
+        $('.loading-spinner').removeClass('active');
 
         if (no_data_available(data)) {
           display_msg(window.wp_js_object.translations.general.no_data_msg);
         } else {
-          display_site_link_charts(data['total'], data['statuses_current'], data['statuses_changes'], data['seeker_paths_current'], data['seeker_paths_changes'], data['milestones_current'], data['milestones_changes']);
+          display_site_link_charts(
+            data['total'],
+            data['statuses_current'],
+            data['statuses_changes'],
+            data['seeker_paths_current'],
+            data['seeker_paths_changes'],
+            data['milestones_current'],
+            data['milestones_changes'],
+          );
         }
       })
       .fail(function (err) {
-        console.log("error");
+        console.log('error');
         console.log(err);
         display_msg(err);
       });
   }
 
   function no_data_available(data) {
-    return !data || data.length === 0 || (!data['total'] && data['statuses_current'].length === 0 && data['statuses_changes'].length === 0 && data['seeker_paths_current'].length === 0 && data['seeker_paths_changes'].length === 0 && data['milestones_current'].length === 0 && data['milestones_changes'].length === 0);
+    return (
+      !data ||
+      data.length === 0 ||
+      (!data['total'] &&
+        data['statuses_current'].length === 0 &&
+        data['statuses_changes'].length === 0 &&
+        data['seeker_paths_current'].length === 0 &&
+        data['seeker_paths_changes'].length === 0 &&
+        data['milestones_current'].length === 0 &&
+        data['milestones_changes'].length === 0)
+    );
   }
 
   function display_msg(msg) {
@@ -241,7 +269,15 @@ jQuery(document).ready(function ($) {
     });
   }
 
-  function display_site_link_charts(total, statuses_current, statuses_changes, seeker_paths_current, seeker_paths_changes, milestones_current, milestones_changes) {
+  function display_site_link_charts(
+    total,
+    statuses_current,
+    statuses_changes,
+    seeker_paths_current,
+    seeker_paths_changes,
+    milestones_current,
+    milestones_changes,
+  ) {
     // Ensure overwritten charts are automatically disposed.
     window.am4core.options.autoDispose = true;
     window.am4core.useTheme(window.am4themes_animated);
@@ -255,36 +291,60 @@ jQuery(document).ready(function ($) {
 
     // Display created based metrics
     $('#status_created_div').fadeOut('fast', function () {
-      display_site_link_charts_status(statuses_current, 'status_created_chart', function () {
-        $('#status_created_div').fadeIn('slow');
-      });
+      display_site_link_charts_status(
+        statuses_current,
+        'status_created_chart',
+        function () {
+          $('#status_created_div').fadeIn('slow');
+        },
+      );
     });
     $('#seeker_created_div').fadeOut('fast', function () {
-      display_site_link_charts_seeker(seeker_paths_current, 'seeker_created_chart', function () {
-        $('#seeker_created_div').fadeIn('slow');
-      });
+      display_site_link_charts_seeker(
+        seeker_paths_current,
+        'seeker_created_chart',
+        function () {
+          $('#seeker_created_div').fadeIn('slow');
+        },
+      );
     });
     $('#milestones_created_div').fadeOut('fast', function () {
-      display_site_link_charts_milestones(milestones_current, 'milestones_created_chart', function () {
-        $('#milestones_created_div').fadeIn('slow');
-      });
+      display_site_link_charts_milestones(
+        milestones_current,
+        'milestones_created_chart',
+        function () {
+          $('#milestones_created_div').fadeIn('slow');
+        },
+      );
     });
 
     // Display changes based metrics
     $('#status_changes_div').fadeOut('fast', function () {
-      display_site_link_charts_status(statuses_changes, 'status_changes_chart', function () {
-        $('#status_changes_div').fadeIn('slow');
-      });
+      display_site_link_charts_status(
+        statuses_changes,
+        'status_changes_chart',
+        function () {
+          $('#status_changes_div').fadeIn('slow');
+        },
+      );
     });
     $('#seeker_changes_div').fadeOut('fast', function () {
-      display_site_link_charts_seeker(seeker_paths_changes, 'seeker_changes_chart', function () {
-        $('#seeker_changes_div').fadeIn('slow');
-      });
+      display_site_link_charts_seeker(
+        seeker_paths_changes,
+        'seeker_changes_chart',
+        function () {
+          $('#seeker_changes_div').fadeIn('slow');
+        },
+      );
     });
     $('#milestones_changes_div').fadeOut('fast', function () {
-      display_site_link_charts_milestones(milestones_changes, 'milestones_changes_chart', function () {
-        $('#milestones_changes_div').fadeIn('slow');
-      });
+      display_site_link_charts_milestones(
+        milestones_changes,
+        'milestones_changes_chart',
+        function () {
+          $('#milestones_changes_div').fadeIn('slow');
+        },
+      );
     });
   }
 
@@ -297,7 +357,6 @@ jQuery(document).ready(function ($) {
 
   function display_site_link_charts_status(statuses, chart_div, callback) {
     window.am4core.ready(function () {
-
       // Create chart instance
       let chart = window.am4core.create(chart_div, window.am4charts.PieChart);
 
@@ -307,17 +366,17 @@ jQuery(document).ready(function ($) {
         $.each(statuses, function (idx, metric) {
           if (metric['status'] && metric['count']) {
             chart.data.push({
-              'status': metric['status'],
-              'count': metric['count']
+              status: metric['status'],
+              count: metric['count'],
             });
           }
         });
 
         // Add and configure Series
         let pieSeries = chart.series.push(new window.am4charts.PieSeries());
-        pieSeries.dataFields.value = "count";
-        pieSeries.dataFields.category = "status";
-        pieSeries.slices.template.stroke = window.am4core.color("#fff");
+        pieSeries.dataFields.value = 'count';
+        pieSeries.dataFields.category = 'status';
+        pieSeries.slices.template.stroke = window.am4core.color('#fff');
         pieSeries.slices.template.strokeWidth = 2;
         pieSeries.slices.template.strokeOpacity = 1;
 
@@ -334,7 +393,6 @@ jQuery(document).ready(function ($) {
 
   function display_site_link_charts_seeker(seeker_paths, chart_div, callback) {
     window.am4core.ready(function () {
-
       // Create chart instance
       let chart = window.am4core.create(chart_div, window.am4charts.XYChart);
 
@@ -344,16 +402,18 @@ jQuery(document).ready(function ($) {
         $.each(seeker_paths, function (idx, metric) {
           if (metric['seeker_path'] && metric['count']) {
             chart.data.push({
-              'seeker_path': metric['seeker_path'],
-              'count': metric['count']
+              seeker_path: metric['seeker_path'],
+              count: metric['count'],
             });
           }
         });
 
         // Create axes
-        let categoryAxis = chart.yAxes.push(new window.am4charts.CategoryAxis());
-        categoryAxis.dataFields.category = "seeker_path";
-        categoryAxis.numberFormatter.numberFormat = "#";
+        let categoryAxis = chart.yAxes.push(
+          new window.am4charts.CategoryAxis(),
+        );
+        categoryAxis.dataFields.category = 'seeker_path';
+        categoryAxis.numberFormatter.numberFormat = '#';
         categoryAxis.renderer.inversed = true;
         categoryAxis.renderer.grid.template.location = 0;
         categoryAxis.renderer.cellStartLocation = 0.1;
@@ -362,7 +422,7 @@ jQuery(document).ready(function ($) {
         let valueAxis = chart.xAxes.push(new window.am4charts.ValueAxis());
         valueAxis.renderer.opposite = true;
 
-        createSeries("count", "");
+        createSeries('count', '');
 
         // Execute callback() function
         callback();
@@ -372,33 +432,40 @@ jQuery(document).ready(function ($) {
       function createSeries(field, name) {
         let series = chart.series.push(new window.am4charts.ColumnSeries());
         series.dataFields.valueX = field;
-        series.dataFields.categoryY = "seeker_path";
+        series.dataFields.categoryY = 'seeker_path';
         series.name = name;
-        series.columns.template.tooltipText = "{categoryY}: [bold]{valueX}[/]";
+        series.columns.template.tooltipText = '{categoryY}: [bold]{valueX}[/]';
         series.columns.template.height = window.am4core.percent(100);
         series.sequencedInterpolation = true;
 
-        let valueLabel = series.bullets.push(new window.am4charts.LabelBullet());
-        valueLabel.label.text = "{valueX}";
-        valueLabel.label.horizontalCenter = "left";
+        let valueLabel = series.bullets.push(
+          new window.am4charts.LabelBullet(),
+        );
+        valueLabel.label.text = '{valueX}';
+        valueLabel.label.horizontalCenter = 'left';
         valueLabel.label.dx = 10;
         valueLabel.label.hideOversized = false;
         valueLabel.label.truncate = false;
 
-        let categoryLabel = series.bullets.push(new window.am4charts.LabelBullet());
-        categoryLabel.label.text = "{name}";
-        categoryLabel.label.horizontalCenter = "right";
+        let categoryLabel = series.bullets.push(
+          new window.am4charts.LabelBullet(),
+        );
+        categoryLabel.label.text = '{name}';
+        categoryLabel.label.horizontalCenter = 'right';
         categoryLabel.label.dx = -10;
-        categoryLabel.label.fill = window.am4core.color("#fff");
+        categoryLabel.label.fill = window.am4core.color('#fff');
         categoryLabel.label.hideOversized = false;
         categoryLabel.label.truncate = false;
       }
     }); // end window.am4core.ready()
   }
 
-  function display_site_link_charts_milestones(milestones, chart_div, callback) {
+  function display_site_link_charts_milestones(
+    milestones,
+    chart_div,
+    callback,
+  ) {
     window.am4core.ready(function () {
-
       // Create chart instance
       let chart = window.am4core.create(chart_div, window.am4charts.XYChart);
 
@@ -408,34 +475,39 @@ jQuery(document).ready(function ($) {
         $.each(milestones, function (idx, metric) {
           if (metric['milestone'] && metric['count']) {
             chart.data.push({
-              'milestone': metric['milestone'],
-              'count': metric['count']
+              milestone: metric['milestone'],
+              count: metric['count'],
             });
           }
         });
 
         // Create axes
-        let categoryAxis = chart.xAxes.push(new window.am4charts.CategoryAxis());
-        categoryAxis.dataFields.category = "milestone";
+        let categoryAxis = chart.xAxes.push(
+          new window.am4charts.CategoryAxis(),
+        );
+        categoryAxis.dataFields.category = 'milestone';
         categoryAxis.renderer.grid.template.location = 0;
         categoryAxis.renderer.minGridDistance = 30;
 
-        categoryAxis.renderer.labels.template.adapter.add("dy", function (dy, target) {
-          if (target.dataItem && target.dataItem.index & 2 == 2) {
-            return dy + 25;
-          }
-          return dy;
-        });
+        categoryAxis.renderer.labels.template.adapter.add(
+          'dy',
+          function (dy, target) {
+            if (target.dataItem && target.dataItem.index & (2 == 2)) {
+              return dy + 25;
+            }
+            return dy;
+          },
+        );
 
         let valueAxis = chart.yAxes.push(new window.am4charts.ValueAxis());
 
         // Create series
         let series = chart.series.push(new window.am4charts.ColumnSeries());
-        series.dataFields.valueY = "count";
-        series.dataFields.categoryX = "milestone";
-        series.name = "Milestones";
-        series.columns.template.tooltipText = "{categoryX}: [bold]{valueY}[/]";
-        series.columns.template.fillOpacity = .8;
+        series.dataFields.valueY = 'count';
+        series.dataFields.categoryX = 'milestone';
+        series.name = 'Milestones';
+        series.columns.template.tooltipText = '{categoryX}: [bold]{valueY}[/]';
+        series.columns.template.fillOpacity = 0.8;
 
         let columnTemplate = series.columns.template;
         columnTemplate.strokeWidth = 2;

--- a/dt-metrics/common/maps_library.js
+++ b/dt-metrics/common/maps_library.js
@@ -1,5 +1,5 @@
-let spinner_html = '<span class="loading-spinner users-spinner active"></span>'
-let saved_data = []
+let spinner_html = '<span class="loading-spinner users-spinner active"></span>';
+let saved_data = [];
 let mapbox_library_api = {
   container_set_up: false,
   current_map_type: 'cluster',
@@ -8,22 +8,32 @@ let mapbox_library_api = {
   title: window.dt_mapbox_metrics.settings.title,
   map: null,
   spinner: null,
-  setup_container: function (){
-    if ( this.container_set_up ){ return; }
-    if ( typeof window.dt_mapbox_metrics.settings === 'undefined' ) { return; }
+  setup_container: function () {
+    if (this.container_set_up) {
+      return;
+    }
+    if (typeof window.dt_mapbox_metrics.settings === 'undefined') {
+      return;
+    }
 
     let chart = jQuery('#chart');
 
     // Ensure a valid mapbox key has been specified.
     if (!window.dt_mapbox_metrics.settings.map_key) {
       chart.empty();
-      let mapping_settings_url = window.wpApiShare.site_url + '/wp-admin/admin.php?page=dt_mapping_module&tab=geocoding';
-      chart.empty().html(`<a href="${window.SHAREDFUNCTIONS.escapeHTML(mapping_settings_url)}">${window.SHAREDFUNCTIONS.escapeHTML(window.dt_mapbox_metrics.settings.no_map_key_msg)}</a>`);
+      let mapping_settings_url =
+        window.wpApiShare.site_url +
+        '/wp-admin/admin.php?page=dt_mapping_module&tab=geocoding';
+      chart
+        .empty()
+        .html(
+          `<a href="${window.SHAREDFUNCTIONS.escapeHTML(mapping_settings_url)}">${window.SHAREDFUNCTIONS.escapeHTML(window.dt_mapbox_metrics.settings.no_map_key_msg)}</a>`,
+        );
 
       return;
     }
 
-    chart.empty().html(spinner_html)
+    chart.empty().html(spinner_html);
 
     chart.empty().html(`
       <style>
@@ -46,20 +56,20 @@ let mapbox_library_api = {
         <div id='legend' class='legend'>
           <div id="legend-bar" class="grid-x grid-margin-x grid-padding-x">
             <div class="cell small-2 center info-bar-font">
-                ${window.SHAREDFUNCTIONS.escapeHTML( this.title )} 
+                ${window.SHAREDFUNCTIONS.escapeHTML(this.title)} 
                 <span id="loading-spinner" style="display: inline-block" class="loading-spinner active"></span>
                 <div id="loading-legend"></div>
             </div>
             <div id="map-type" class="border-left">
-              <button class="button small select-button ${mapbox_library_api.current_map_type === 'cluster' ? 'selected-select-button': ' empty-select-button' }"
+              <button class="button small select-button ${mapbox_library_api.current_map_type === 'cluster' ? 'selected-select-button' : ' empty-select-button'}"
                 id="cluster">
                 <img src="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.template_dir)}/dt-assets/images/dots.svg">
               </button>
-              <button class="button small select-button ${mapbox_library_api.current_map_type === 'points' ? 'selected-select-button': ' empty-select-button' }"
+              <button class="button small select-button ${mapbox_library_api.current_map_type === 'points' ? 'selected-select-button' : ' empty-select-button'}"
                 id="points">
                 <img src="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.template_dir)}/dt-assets/images/dot.svg">
               </button>
-              <button class="button small select-button ${mapbox_library_api.current_map_type === 'area' ? 'selected-select-button': ' empty-select-button' }"
+              <button class="button small select-button ${mapbox_library_api.current_map_type === 'area' ? 'selected-select-button' : ' empty-select-button'}"
                 id="area">
                 <img src="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.template_dir)}/dt-assets/images/location_shape.svg">
               </button>
@@ -68,91 +78,100 @@ let mapbox_library_api = {
         </div>
         <div id="spinner">${spinner_html}</div>
         <div id="geocode-details" class="geocode-details">
-          ${window.SHAREDFUNCTIONS.escapeHTML( this.title )}<span class="close-details" style="float:right;"><i class="fi-x"></i></span>
+          ${window.SHAREDFUNCTIONS.escapeHTML(this.title)}<span class="close-details" style="float:right;"><i class="fi-x"></i></span>
           <hr style="margin:10px 5px;">
           <div id="geocode-details-content"></div>
         </div>
       </div>
-    `)
-    this.spinner = jQuery("#spinner")
+    `);
+    this.spinner = jQuery('#spinner');
 
     //set_info_boxes
-    let map_wrapper = jQuery('#map-wrapper')
-    jQuery('.legend').css( 'width', map_wrapper.innerWidth() - 20 )
-    jQuery( window ).resize(function() {
-      jQuery('.legend').css( 'width', map_wrapper.innerWidth() - 20 )
+    let map_wrapper = jQuery('#map-wrapper');
+    jQuery('.legend').css('width', map_wrapper.innerWidth() - 20);
+    jQuery(window).resize(function () {
+      jQuery('.legend').css('width', map_wrapper.innerWidth() - 20);
     });
 
-    mapbox_library_api.setup_map_type()
+    mapbox_library_api.setup_map_type();
 
-
-    jQuery('#map-type button').on('click', function (e){
-      jQuery('#map-type button').removeClass("selected-select-button").addClass("empty-select-button")
-      jQuery(this).addClass("selected-select-button")
+    jQuery('#map-type button').on('click', function (e) {
+      jQuery('#map-type button')
+        .removeClass('selected-select-button')
+        .addClass('empty-select-button');
+      jQuery(this).addClass('selected-select-button');
       mapbox_library_api.current_map_type = jQuery(this).attr('id');
-      mapbox_library_api.setup_map_type()
-    })
+      mapbox_library_api.setup_map_type();
+    });
 
-
-    if ( mapbox_library_api.obj.settings.split_by ){
-      window.lodash.forOwn( mapbox_library_api.obj.settings.split_by, (field_values, field_key)=>{
-        let options_html = ``
-        window.lodash.forOwn(field_values.default, (option, option_key)=>{
-          options_html += `<button class="button small select-button selected-select-button" data-key="${window.SHAREDFUNCTIONS.escapeHTML(option_key)}" id=${window.SHAREDFUNCTIONS.escapeHTML(field_key)}_${window.SHAREDFUNCTIONS.escapeHTML(option_key)}>
+    if (mapbox_library_api.obj.settings.split_by) {
+      window.lodash.forOwn(
+        mapbox_library_api.obj.settings.split_by,
+        (field_values, field_key) => {
+          let options_html = ``;
+          window.lodash.forOwn(field_values.default, (option, option_key) => {
+            options_html += `<button class="button small select-button selected-select-button" data-key="${window.SHAREDFUNCTIONS.escapeHTML(option_key)}" id=${window.SHAREDFUNCTIONS.escapeHTML(field_key)}_${window.SHAREDFUNCTIONS.escapeHTML(option_key)}>
             ${window.SHAREDFUNCTIONS.escapeHTML(option.label)}
-          </button>`
-        })
-        let split_by_html = `
+          </button>`;
+          });
+          let split_by_html = `
           <div id="${field_key}" class="border-left map-option-buttons">
             ${window.SHAREDFUNCTIONS.escapeHTML(field_values.name)}:
             ${options_html}
           </div>
-        `
-        jQuery('#legend-bar').append(split_by_html)
-        jQuery(`#${field_key} button`).on('click', function (e){
-          saved_data = []
-          jQuery(this).toggleClass("selected-select-button")
-          jQuery(this).toggleClass("empty-select-button")
+        `;
+          jQuery('#legend-bar').append(split_by_html);
+          jQuery(`#${field_key} button`).on('click', function (e) {
+            saved_data = [];
+            jQuery(this).toggleClass('selected-select-button');
+            jQuery(this).toggleClass('empty-select-button');
 
-          let ar = [];
-          jQuery(`#${field_key} button`).each((index, button)=>{
-            if ( !jQuery(button).hasClass("empty-select-button")){
-              ar.push(jQuery(button).data('key'))
-            }
-          })
-          let query = { [field_key]: ar}
-          mapbox_library_api.query_args = query
-          mapbox_library_api.setup_map_type()
-        })
-      })
+            let ar = [];
+            jQuery(`#${field_key} button`).each((index, button) => {
+              if (!jQuery(button).hasClass('empty-select-button')) {
+                ar.push(jQuery(button).data('key'));
+              }
+            });
+            let query = { [field_key]: ar };
+            mapbox_library_api.query_args = query;
+            mapbox_library_api.setup_map_type();
+          });
+        },
+      );
     }
-
   },
-  setup_map_type: function (){
+  setup_map_type: function () {
     // init map
     window.mapboxgl.accessToken = this.obj.settings.map_key;
-    if ( mapbox_library_api.map ){
-      mapbox_library_api.map.remove()
+    if (mapbox_library_api.map) {
+      mapbox_library_api.map.remove();
     }
     mapbox_library_api.map = new window.mapboxgl.Map({
       container: 'map',
       style: 'mapbox://styles/mapbox/light-v10',
       center: [2, 46],
       minZoom: 1,
-      zoom: 1.8
+      zoom: 1.8,
     });
     // SET BOUNDS
-    let map_bounds_token = this.obj.settings.post_type + this.obj.settings.menu_slug
-    let map_start = window.get_map_start( map_bounds_token )
-    if ( map_start ) {
-      mapbox_library_api.map.fitBounds( map_start, {duration: 0});
+    let map_bounds_token =
+      this.obj.settings.post_type + this.obj.settings.menu_slug;
+    let map_start = window.get_map_start(map_bounds_token);
+    if (map_start) {
+      mapbox_library_api.map.fitBounds(map_start, { duration: 0 });
     }
-    mapbox_library_api.map.on('zoomend', function() {
-      window.set_map_start( map_bounds_token, mapbox_library_api.map.getBounds() )
-    })
-    mapbox_library_api.map.on('dragend', function() {
-      window.set_map_start( map_bounds_token, mapbox_library_api.map.getBounds() )
-    })
+    mapbox_library_api.map.on('zoomend', function () {
+      window.set_map_start(
+        map_bounds_token,
+        mapbox_library_api.map.getBounds(),
+      );
+    });
+    mapbox_library_api.map.on('dragend', function () {
+      window.set_map_start(
+        map_bounds_token,
+        mapbox_library_api.map.getBounds(),
+      );
+    });
     // end set bounds
     // disable map rotation using right click + drag
     mapbox_library_api.map.dragRotate.disable();
@@ -160,65 +179,76 @@ let mapbox_library_api = {
     // disable map rotation using touch rotation gesture
     mapbox_library_api.map.touchZoomRotate.disableRotation();
 
-    mapbox_library_api.map.on('load', function() {
-      mapbox_library_api.load_map()
-    })
+    mapbox_library_api.map.on('load', function () {
+      mapbox_library_api.load_map();
+    });
   },
-  load_map: function (map_type, query){
-
-    let style = mapbox_library_api.map.getStyle()
-    style.layers.forEach( layer=>{
-      if ( layer.id.startsWith("dt-maps-")){
-        mapbox_library_api.map.removeLayer( layer.id )
+  load_map: function (map_type, query) {
+    let style = mapbox_library_api.map.getStyle();
+    style.layers.forEach((layer) => {
+      if (layer.id.startsWith('dt-maps-')) {
+        mapbox_library_api.map.removeLayer(layer.id);
       }
-    } )
-    window.lodash.forOwn(style.sources, ( source, source_id)=>{
-      if ( source_id.startsWith("dt-maps-")){
-        mapbox_library_api.map.removeSource( source_id )
+    });
+    window.lodash.forOwn(style.sources, (source, source_id) => {
+      if (source_id.startsWith('dt-maps-')) {
+        mapbox_library_api.map.removeSource(source_id);
       }
-    } )
-    mapbox_library_api.spinner.show()
-    mapbox_library_api.area_map.previous_grid_list = []
+    });
+    mapbox_library_api.spinner.show();
+    mapbox_library_api.area_map.previous_grid_list = [];
 
-    if ( mapbox_library_api.current_map_type === "cluster" ){
-      mapbox_library_api.cluster_map.default_setup()
-    } else if ( mapbox_library_api.current_map_type === "area" ){
-      mapbox_library_api.area_map.setup()
+    if (mapbox_library_api.current_map_type === 'cluster') {
+      mapbox_library_api.cluster_map.default_setup();
+    } else if (mapbox_library_api.current_map_type === 'area') {
+      mapbox_library_api.area_map.setup();
     } else {
-      mapbox_library_api.points_map.setup()
+      mapbox_library_api.points_map.setup();
     }
   },
-  get_level: function (){
-    let level = 'world'
-    if ( mapbox_library_api.map.getZoom() >= 4 ) {
-      level = 'admin1'
-    } if ( mapbox_library_api.map.getZoom() >= 6 ){
-      level = 'admin2'
+  get_level: function () {
+    let level = 'world';
+    if (mapbox_library_api.map.getZoom() >= 4) {
+      level = 'admin1';
+    }
+    if (mapbox_library_api.map.getZoom() >= 6) {
+      level = 'admin2';
     }
     return level;
   },
 
   points_map: {
-    setup: async function (){
-      jQuery('#loading-spinner').show()
-      let data = await recursive_load()
-      this.load_layer({features:data, type:'FeatureCollection'})
-      jQuery('#loading-spinner').hide()
+    setup: async function () {
+      jQuery('#loading-spinner').show();
+      let data = await recursive_load();
+      this.load_layer({ features: data, type: 'FeatureCollection' });
+      jQuery('#loading-spinner').hide();
     },
-    load_layer: function ( points, layer_key = 'pointsLayer', color = '#11b4da', size = 6 ) {
-      layer_key = 'dt-maps-' + layer_key
+    load_layer: function (
+      points,
+      layer_key = 'pointsLayer',
+      color = '#11b4da',
+      size = 6,
+    ) {
+      layer_key = 'dt-maps-' + layer_key;
       let mapLayer = mapbox_library_api.map.getLayer(layer_key);
-      if (typeof mapLayer!=='undefined') {
-        mapbox_library_api.map.off('click', layer_key, mapbox_library_api.points_map.on_click);
-        mapbox_library_api.map.removeLayer(layer_key)
+      if (typeof mapLayer !== 'undefined') {
+        mapbox_library_api.map.off(
+          'click',
+          layer_key,
+          mapbox_library_api.points_map.on_click,
+        );
+        mapbox_library_api.map.removeLayer(layer_key);
       }
-      let mapSource = mapbox_library_api.map.getSource(`${layer_key}_pointsSource`);
-      if (typeof mapSource !=='undefined') {
-        mapbox_library_api.map.removeSource(`${layer_key}_pointsSource`)
+      let mapSource = mapbox_library_api.map.getSource(
+        `${layer_key}_pointsSource`,
+      );
+      if (typeof mapSource !== 'undefined') {
+        mapbox_library_api.map.removeSource(`${layer_key}_pointsSource`);
       }
       mapbox_library_api.map.addSource(`${layer_key}_pointsSource`, {
-        'type': 'geojson',
-        'data': points
+        type: 'geojson',
+        data: points,
       });
 
       mapbox_library_api.map.addLayer({
@@ -229,11 +259,15 @@ let mapbox_library_api = {
           'circle-color': color,
           'circle-radius': size,
           'circle-stroke-width': 0.5,
-          'circle-stroke-color': '#fff'
-        }
+          'circle-stroke-color': '#fff',
+        },
       });
 
-      mapbox_library_api.map.on('click', layer_key, mapbox_library_api.points_map.on_click);
+      mapbox_library_api.map.on(
+        'click',
+        layer_key,
+        mapbox_library_api.points_map.on_click,
+      );
 
       mapbox_library_api.map.on('mouseenter', layer_key, function () {
         mapbox_library_api.map.getCanvas().style.cursor = 'pointer';
@@ -242,114 +276,130 @@ let mapbox_library_api = {
         mapbox_library_api.map.getCanvas().style.cursor = '';
       });
 
-      mapbox_library_api.spinner.hide()
+      mapbox_library_api.spinner.hide();
     },
     on_click: function (e) {
-      let list = []
-      jQuery('#geocode-details').show()
+      let list = [];
+      jQuery('#geocode-details').show();
 
-      let content = jQuery('#geocode-details-content')
-      content.empty().html( mapbox_library_api.spinner )
+      let content = jQuery('#geocode-details-content');
+      content.empty().html(mapbox_library_api.spinner);
 
-      jQuery.each(e.features, function(i,v) {
-        if ( i > 20 ){ return }
+      jQuery.each(e.features, function (i, v) {
+        if (i > 20) {
+          return;
+        }
         let post_id = e.features[i].properties.post_id;
-        let post_type = e.features[i].properties.post_type
-        content.append(`<div class="grid-x" id="list-${window.SHAREDFUNCTIONS.escapeHTML( i )}"></div>`)
-        window.makeRequest('GET', window.SHAREDFUNCTIONS.escapeHTML( post_type ) +'/'+window.SHAREDFUNCTIONS.escapeHTML( post_id )+'/', null, 'dt-posts/v2/' )
-        .done(details=>{
-          list[i] = jQuery('#list-'+i)
+        let post_type = e.features[i].properties.post_type;
+        content.append(
+          `<div class="grid-x" id="list-${window.SHAREDFUNCTIONS.escapeHTML(i)}"></div>`,
+        );
+        window
+          .makeRequest(
+            'GET',
+            window.SHAREDFUNCTIONS.escapeHTML(post_type) +
+              '/' +
+              window.SHAREDFUNCTIONS.escapeHTML(post_id) +
+              '/',
+            null,
+            'dt-posts/v2/',
+          )
+          .done((details) => {
+            list[i] = jQuery('#list-' + i);
 
-          list[i].append(`
-            <div class="cell"><a  target="_blank" href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/${window.SHAREDFUNCTIONS.escapeHTML( post_type )}/${window.SHAREDFUNCTIONS.escapeHTML( details.ID )}">${window.SHAREDFUNCTIONS.escapeHTML( details.title )/*View Record*/}</a></div>
-          `)
+            list[i].append(`
+            <div class="cell"><a  target="_blank" href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/${window.SHAREDFUNCTIONS.escapeHTML(post_type)}/${window.SHAREDFUNCTIONS.escapeHTML(details.ID)}">${window.SHAREDFUNCTIONS.escapeHTML(details.title) /*View Record*/}</a></div>
+          `);
 
-          jQuery('.loading-spinner').hide()
-        })
-      })
-    }
+            jQuery('.loading-spinner').hide();
+          });
+      });
+    },
   },
-  standardize_longitude: function (lng){
+  standardize_longitude: function (lng) {
     if (lng > 180) {
-      lng = lng - 180
-      lng = -Math.abs(lng)
+      lng = lng - 180;
+      lng = -Math.abs(lng);
     } else if (lng < -180) {
-      lng = lng + 180
-      lng = Math.abs(lng)
+      lng = lng + 180;
+      lng = Math.abs(lng);
     }
     return lng;
-  }
+  },
+};
 
-}
-
-jQuery('.close-details').on('click', function() {
-  jQuery('#geocode-details').hide()
-})
-
-
+jQuery('.close-details').on('click', function () {
+  jQuery('#geocode-details').hide();
+});
 
 let recursive_load = async function (data = [], offset = 0, limit = 50000) {
-  if ( saved_data && saved_data.length > 0 ){
+  if (saved_data && saved_data.length > 0) {
     return saved_data;
   }
-  let geojson = await window.makeRequest("POST", mapbox_library_api.obj.settings.rest_url, {
-    post_type: mapbox_library_api.post_type,
-    query: mapbox_library_api.query_args || {},
-    offset,
-    limit
-  }, mapbox_library_api.obj.settings.rest_base_url)
+  let geojson = await window.makeRequest(
+    'POST',
+    mapbox_library_api.obj.settings.rest_url,
+    {
+      post_type: mapbox_library_api.post_type,
+      query: mapbox_library_api.query_args || {},
+      offset,
+      limit,
+    },
+    mapbox_library_api.obj.settings.rest_base_url,
+  );
 
-
-  data = data.concat(geojson.features)
-  jQuery('#loading-legend').html(`<span>(${data.length.toLocaleString()})</span>`)
+  data = data.concat(geojson.features);
+  jQuery('#loading-legend').html(
+    `<span>(${data.length.toLocaleString()})</span>`,
+  );
 
   // return data;
-  if (geojson.features.length > 0 && geojson.features.length === limit ) {
-    return recursive_load(data, offset + limit, limit)
+  if (geojson.features.length > 0 && geojson.features.length === limit) {
+    return recursive_load(data, offset + limit, limit);
   }
   jQuery('#loading-legend').html('');
   saved_data = data;
-  return data
-
-}
-
+  return data;
+};
 
 let cluster_map = {
-  default_setup: async function (){
-    jQuery('#loading-spinner').show()
-    let data = await recursive_load()
-    cluster_map.load_layer({features:data, type:'FeatureCollection'})
-    jQuery('#loading-spinner').hide()
+  default_setup: async function () {
+    jQuery('#loading-spinner').show();
+    let data = await recursive_load();
+    cluster_map.load_layer({ features: data, type: 'FeatureCollection' });
+    jQuery('#loading-spinner').hide();
   },
-  load_layer: function ( geojson ) {
-
-    mapbox_library_api.map.on('click', 'dt-maps-clusters', function(e) {
-      let features =mapbox_library_api.map.queryRenderedFeatures(e.point, {
-        layers: ['dt-maps-clusters']
+  load_layer: function (geojson) {
+    mapbox_library_api.map.on('click', 'dt-maps-clusters', function (e) {
+      let features = mapbox_library_api.map.queryRenderedFeatures(e.point, {
+        layers: ['dt-maps-clusters'],
       });
 
       let clusterId = features[0].properties.cluster_id;
-      mapbox_library_api.map.getSource('dt-maps-clusterSource').getClusterExpansionZoom(
-        clusterId,
-        function(err, zoom) {
+      mapbox_library_api.map
+        .getSource('dt-maps-clusterSource')
+        .getClusterExpansionZoom(clusterId, function (err, zoom) {
           if (err) return;
 
           mapbox_library_api.map.easeTo({
             center: features[0].geometry.coordinates,
-            zoom: zoom
+            zoom: zoom,
           });
-        }
-      );
-    })
-    mapbox_library_api.map.on('click', 'dt-maps-unclustered-point', cluster_map.on_click );
-    mapbox_library_api.map.on('mouseenter', 'dt-maps-clusters', function() {
+        });
+    });
+    mapbox_library_api.map.on(
+      'click',
+      'dt-maps-unclustered-point',
+      cluster_map.on_click,
+    );
+    mapbox_library_api.map.on('mouseenter', 'dt-maps-clusters', function () {
       mapbox_library_api.map.getCanvas().style.cursor = 'pointer';
     });
-    mapbox_library_api.map.on('mouseleave', 'dt-maps-clusters', function() {
+    mapbox_library_api.map.on('mouseleave', 'dt-maps-clusters', function () {
       mapbox_library_api.map.getCanvas().style.cursor = '';
     });
     let mapSource = mapbox_library_api.map.getSource(`dt-maps-clusterSource`);
-    if (typeof mapSource!=='undefined') {
+    if (typeof mapSource !== 'undefined') {
       mapbox_library_api.map.removeSource(`dt-maps-clusterSource`);
     }
     mapbox_library_api.map.addSource('dt-maps-clusterSource', {
@@ -357,7 +407,7 @@ let cluster_map = {
       data: geojson,
       cluster: true,
       clusterMaxZoom: 14,
-      clusterRadius: 50
+      clusterRadius: 50,
     });
 
     mapbox_library_api.map.addLayer({
@@ -373,18 +423,10 @@ let cluster_map = {
           100,
           '#f1f075',
           750,
-          '#f28cb1'
+          '#f28cb1',
         ],
-        'circle-radius': [
-          'step',
-          ['get', 'point_count'],
-          20,
-          100,
-          30,
-          750,
-          40
-        ]
-      }
+        'circle-radius': ['step', ['get', 'point_count'], 20, 100, 30, 750, 40],
+      },
     });
     mapbox_library_api.map.addLayer({
       id: 'dt-maps-cluster-count',
@@ -394,8 +436,8 @@ let cluster_map = {
       layout: {
         'text-field': '{point_count_abbreviated}',
         'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
-        'text-size': 12
-      }
+        'text-size': 12,
+      },
     });
     mapbox_library_api.map.addLayer({
       id: 'dt-maps-unclustered-point',
@@ -404,285 +446,404 @@ let cluster_map = {
       filter: ['!', ['has', 'point_count']],
       paint: {
         'circle-color': '#11b4da',
-        'circle-radius':12,
+        'circle-radius': 12,
         'circle-stroke-width': 1,
-        'circle-stroke-color': '#fff'
-      }
+        'circle-stroke-color': '#fff',
+      },
     });
 
-    mapbox_library_api.spinner.hide()
+    mapbox_library_api.spinner.hide();
   },
   on_click: function (e) {
-    let list = []
-    jQuery('#geocode-details').show()
+    let list = [];
+    jQuery('#geocode-details').show();
 
-    let content = jQuery('#geocode-details-content')
-    content.empty().html(spinner_html)
+    let content = jQuery('#geocode-details-content');
+    content.empty().html(spinner_html);
 
     jQuery.each(e.features, function (i, v) {
-      if ( i > 10 ){ return; }
+      if (i > 10) {
+        return;
+      }
       let post_id = e.features[i].properties.post_id;
-      let post_type = e.features[i].properties.post_type
-      content.append(`<div class="grid-x" id="list-${window.SHAREDFUNCTIONS.escapeHTML( i )}"></div>`)
-      window.makeRequest('GET', window.SHAREDFUNCTIONS.escapeHTML( post_type ) +'/'+window.SHAREDFUNCTIONS.escapeHTML( post_id )+'/', null, 'dt-posts/v2/' )
-      .done(details=>{
-        list[i] = jQuery('#list-'+i)
-        list[i].append(`
-            <div class="cell"><a target="_blank" href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/${window.SHAREDFUNCTIONS.escapeHTML( post_type )}/${window.SHAREDFUNCTIONS.escapeHTML( details.ID )}">${window.SHAREDFUNCTIONS.escapeHTML( details.title )/*View Record*/}</a></div>
-          `)
-        jQuery('.loading-spinner').hide()
-      })
-    })
+      let post_type = e.features[i].properties.post_type;
+      content.append(
+        `<div class="grid-x" id="list-${window.SHAREDFUNCTIONS.escapeHTML(i)}"></div>`,
+      );
+      window
+        .makeRequest(
+          'GET',
+          window.SHAREDFUNCTIONS.escapeHTML(post_type) +
+            '/' +
+            window.SHAREDFUNCTIONS.escapeHTML(post_id) +
+            '/',
+          null,
+          'dt-posts/v2/',
+        )
+        .done((details) => {
+          list[i] = jQuery('#list-' + i);
+          list[i].append(`
+            <div class="cell"><a target="_blank" href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/${window.SHAREDFUNCTIONS.escapeHTML(post_type)}/${window.SHAREDFUNCTIONS.escapeHTML(details.ID)}">${window.SHAREDFUNCTIONS.escapeHTML(details.title) /*View Record*/}</a></div>
+          `);
+          jQuery('.loading-spinner').hide();
+        });
+    });
   },
-}
+};
 
 let area_map = {
   grid_data: null,
-  previous_grid_list:[],
+  previous_grid_list: [],
   behind_layer: null,
-  setup: async function ( behind_layer = null ){
-    area_map.behind_layer = behind_layer
-    area_map.grid_data = await window.makeRequest( "POST", mapbox_library_api.obj.settings.totals_rest_url, { post_type: mapbox_library_api.obj.settings.post_type, query: mapbox_library_api.query_args || {}} , mapbox_library_api.obj.settings.rest_base_url )
-    await area_map.load_layer()
+  setup: async function (behind_layer = null) {
+    area_map.behind_layer = behind_layer;
+    area_map.grid_data = await window.makeRequest(
+      'POST',
+      mapbox_library_api.obj.settings.totals_rest_url,
+      {
+        post_type: mapbox_library_api.obj.settings.post_type,
+        query: mapbox_library_api.query_args || {},
+      },
+      mapbox_library_api.obj.settings.rest_base_url,
+    );
+    await area_map.load_layer();
     // load new layer on event
-    mapbox_library_api.map.on('zoomend', function() {
-      if ( mapbox_library_api.current_map_type !== 'area'){return;}
-      area_map.load_layer()
-    })
-    mapbox_library_api.map.on('dragend', function() {
-      if ( mapbox_library_api.current_map_type !== 'area'){return;}
-      area_map.load_layer()
-    })
-    mapbox_library_api.map.on('click', function( e ) {
-      if ( mapbox_library_api.current_map_type !== 'area'){return;}
+    mapbox_library_api.map.on('zoomend', function () {
+      if (mapbox_library_api.current_map_type !== 'area') {
+        return;
+      }
+      area_map.load_layer();
+    });
+    mapbox_library_api.map.on('dragend', function () {
+      if (mapbox_library_api.current_map_type !== 'area') {
+        return;
+      }
+      area_map.load_layer();
+    });
+    mapbox_library_api.map.on('click', function (e) {
+      if (mapbox_library_api.current_map_type !== 'area') {
+        return;
+      }
       // this section increments up the result on level because
       // it corresponds better to the viewable user intent for details
-      let level = mapbox_library_api.get_level()
-      area_map.load_detail_panel( e.lngLat.lng, e.lngLat.lat, level )
-    })
+      let level = mapbox_library_api.get_level();
+      area_map.load_detail_panel(e.lngLat.lng, e.lngLat.lat, level);
+    });
   },
-  load_layer: async function ( level = null){
-    mapbox_library_api.spinner.show()
+  load_layer: async function (level = null) {
+    mapbox_library_api.spinner.show();
     // set geocode level, default to auto
-    if ( !level ){
-      level = mapbox_library_api.get_level()
+    if (!level) {
+      level = mapbox_library_api.get_level();
     }
 
-    let bbox =mapbox_library_api.map.getBounds()
+    let bbox = mapbox_library_api.map.getBounds();
 
-    let data = [{ grid_id:'1', parent_id:'1'}]
-    if ( level !== "world" ){
-      data = await window.makeRequest('GET', `${mapbox_library_api.obj.settings.geocoder_url}dt-mapping/location-grid-list-api.php`,
+    let data = [{ grid_id: '1', parent_id: '1' }];
+    if (level !== 'world') {
+      data = await window.makeRequest(
+        'GET',
+        `${mapbox_library_api.obj.settings.geocoder_url}dt-mapping/location-grid-list-api.php`,
         {
           type: 'match_within_bbox',
           north_latitude: bbox._ne.lat,
           south_latitude: bbox._sw.lat,
-          west_longitude: window.mapbox_library_api.standardize_longitude(bbox._sw.lng),
-          east_longitude: window.mapbox_library_api.standardize_longitude(bbox._ne.lng),
+          west_longitude: window.mapbox_library_api.standardize_longitude(
+            bbox._sw.lng,
+          ),
+          east_longitude: window.mapbox_library_api.standardize_longitude(
+            bbox._ne.lng,
+          ),
           level: level,
           nonce: mapbox_library_api.obj.settings.geocoder_nonce,
-          query: mapbox_library_api.query_args || {}
-        }
-      )
+          query: mapbox_library_api.query_args || {},
+        },
+      );
     }
 
     // default layer to world
-    if ( level === 'world' ) {
-      data = [{ grid_id:'1', parent_id:'1'}]
+    if (level === 'world') {
+      data = [{ grid_id: '1', parent_id: '1' }];
     }
 
-    let status404 = window.SHAREDFUNCTIONS.get_json_cookie('geojson_failed', [] )
+    let status404 = window.SHAREDFUNCTIONS.get_json_cookie(
+      'geojson_failed',
+      [],
+    );
 
-    let done = []
-    data.forEach( res=>{
-      let grid_id = res.grid_id
-      let parent_id = res.parent_id
-      let layer_id = 'dt-maps-' + parent_id.toString()
+    let done = [];
+    data.forEach((res) => {
+      let grid_id = res.grid_id;
+      let parent_id = res.parent_id;
+      let layer_id = 'dt-maps-' + parent_id.toString();
       // is new test
-      if ( !window.lodash.find(area_map.previous_grid_list, {parent_id:parent_id}) && !status404.includes(parent_id) && !done.includes(parent_id) ) {
+      if (
+        !window.lodash.find(area_map.previous_grid_list, {
+          parent_id: parent_id,
+        }) &&
+        !status404.includes(parent_id) &&
+        !done.includes(parent_id)
+      ) {
         // is defined test
         let mapLayer = mapbox_library_api.map.getLayer(layer_id);
-        if(typeof mapLayer === 'undefined') {
-
+        if (typeof mapLayer === 'undefined') {
           done.push(parent_id);
           // get geojson collection
-          jQuery.get( mapbox_library_api.obj.settings.map_mirror + 'collection/' + parent_id + '.geojson', null, null, 'json')
-          .done(function (geojson) {
-            // add data to geojson properties
-            let highest_value = 1
-            jQuery.each(geojson.features, function (i, v) {
-              if (area_map.grid_data[geojson.features[i].properties.grid_id]) {
-                geojson.features[i].properties.value = parseInt(area_map.grid_data[geojson.features[i].properties.grid_id].count)
-              } else {
-                geojson.features[i].properties.value = 0
-              }
-              highest_value = Math.max(highest_value,  geojson.features[i].properties.value)
-            })
-            // add source
-            let mapSource = mapbox_library_api.map.getSource(layer_id);
-            if (typeof mapSource==='undefined') {
-              mapbox_library_api.map.addSource(layer_id, {
-                'type': 'geojson',
-                'data': geojson
+          jQuery
+            .get(
+              mapbox_library_api.obj.settings.map_mirror +
+                'collection/' +
+                parent_id +
+                '.geojson',
+              null,
+              null,
+              'json',
+            )
+            .done(function (geojson) {
+              // add data to geojson properties
+              let highest_value = 1;
+              jQuery.each(geojson.features, function (i, v) {
+                if (
+                  area_map.grid_data[geojson.features[i].properties.grid_id]
+                ) {
+                  geojson.features[i].properties.value = parseInt(
+                    area_map.grid_data[geojson.features[i].properties.grid_id]
+                      .count,
+                  );
+                } else {
+                  geojson.features[i].properties.value = 0;
+                }
+                highest_value = Math.max(
+                  highest_value,
+                  geojson.features[i].properties.value,
+                );
               });
-            }
-
-            // add fill layer
-            mapbox_library_api.map.addLayer({
-              'id': layer_id,
-              'type': 'fill',
-              'source': layer_id,
-              'paint': {
-                'fill-color': {
-                  property: 'value',
-                  stops: [[0, 'rgba(0, 0, 0, 0)'], [1, 'rgb(155, 200, 254)'], [highest_value, 'rgb(37, 82, 154)']]
-                },
-                'fill-opacity': 0.75,
-                'fill-outline-color': '#707070',
+              // add source
+              let mapSource = mapbox_library_api.map.getSource(layer_id);
+              if (typeof mapSource === 'undefined') {
+                mapbox_library_api.map.addSource(layer_id, {
+                  type: 'geojson',
+                  data: geojson,
+                });
               }
-            }, area_map.behind_layer);
-          }).catch(()=>{
-            status404.push(parent_id)
-            window.SHAREDFUNCTIONS.save_json_cookie( 'geojson_failed', status404, 'metrics' )
-          })// end get geojson collection
+
+              // add fill layer
+              mapbox_library_api.map.addLayer(
+                {
+                  id: layer_id,
+                  type: 'fill',
+                  source: layer_id,
+                  paint: {
+                    'fill-color': {
+                      property: 'value',
+                      stops: [
+                        [0, 'rgba(0, 0, 0, 0)'],
+                        [1, 'rgb(155, 200, 254)'],
+                        [highest_value, 'rgb(37, 82, 154)'],
+                      ],
+                    },
+                    'fill-opacity': 0.75,
+                    'fill-outline-color': '#707070',
+                  },
+                },
+                area_map.behind_layer,
+              );
+            })
+            .catch(() => {
+              status404.push(parent_id);
+              window.SHAREDFUNCTIONS.save_json_cookie(
+                'geojson_failed',
+                status404,
+                'metrics',
+              );
+            }); // end get geojson collection
         }
       } // end load new layer
-    })
-    area_map.previous_grid_list.forEach(grid_item=>{
-      let layer_id = 'dt-maps-' + grid_item.parent_id
-      let mapLayer =mapbox_library_api.map.getLayer(layer_id);
-      if(typeof mapLayer !== 'undefined' && !window.lodash.find(data, {parent_id:grid_item.parent_id})) {
-        mapbox_library_api.map.removeLayer( layer_id )
-        mapbox_library_api.map.removeSource( layer_id )
-      }
-    })
-    area_map.previous_grid_list = data
-    mapbox_library_api.spinner.hide()
-  },
-  load_detail_panel: function (lng, lat, level){
-    lng = window.mapbox_library_api.standardize_longitude( lng )
-    if ( level === 'world' ) {
-      level = 'admin0'
-    }
-
-    let content = jQuery('#geocode-details-content')
-    content.empty().html( spinner_html )
-
-    jQuery('#geocode-details').show()
-
-    // geocode
-    window.makeRequest('GET', mapbox_library_api.obj.settings.geocoder_url + 'dt-mapping/location-grid-list-api.php',
-      {
-        type:'geocode',
-        longitude:lng,
-        latitude:lat,
-        level:level,
-        nonce:mapbox_library_api.obj.settings.geocoder_nonce,
-        query: mapbox_library_api.query_args || {}
-      }).done(details=>{
-
-      /* hierarchy list*/
-      content.empty().append(`<ul id="hierarchy-list" class="accordion" data-accordion></ul>`)
-      let list = jQuery('#hierarchy-list')
-      if ( details.admin0_grid_id ) {
-        list.append( `
-          <li id="admin0_wrapper" class="accordion-item" data-accordion-item>
-           <a href="#" class="accordion-title">${window.SHAREDFUNCTIONS.escapeHTML( details.admin0_name )} :  <span id="admin0_count">0</span></a>
-            <div class="accordion-content grid-x" data-tab-content><div id="admin0_list" class="grid-x"></div></div>
-          </li>
-        `)
-        if ( details.admin0_grid_id in area_map.grid_data ) {
-          jQuery('#admin0_count').html(area_map.grid_data[details.admin0_grid_id].count)
-        }
-
-      }
-      if ( details.admin1_grid_id ) {
-        list.append( `
-          <li id="admin1_wrapper" class="accordion-item" data-accordion-item >
-            <a href="#" class="accordion-title">${window.SHAREDFUNCTIONS.escapeHTML( details.admin1_name )} : <span id="admin1_count">0</span></a>
-            <div class="accordion-content" data-tab-content><div id="admin1_list" class="grid-x"></div></div>
-          </li>
-        `)
-
-        if ( details.admin1_grid_id in area_map.grid_data ) {
-          jQuery('#admin1_count').html(area_map.grid_data[details.admin1_grid_id].count)
-        }
-
-      }
-      if ( details.admin2_grid_id ) {
-        list.append( `
-          <li id="admin2_wrapper" class="accordion-item" data-accordion-item>
-            <a href="#" class="accordion-title">${window.SHAREDFUNCTIONS.escapeHTML( details.admin2_name )} : <span id="admin2_count">0</span></a>
-            <div class="accordion-content" data-tab-content><div id="admin2_list" class="grid-x"></div></div>
-          </li>
-        `)
-
-        if ( details.admin2_grid_id in area_map.grid_data ) {
-          jQuery('#admin2_count').html(area_map.grid_data[details.admin2_grid_id].count)
-        }
-      }
-
-      jQuery('.accordion-item').last().addClass('is-active')
-      list.foundation()
-      /* end hierarchy list */
-
-      if ( details.admin2_grid_id !== null ) {
-        jQuery('#admin2_list').html( spinner_html )
-        window.makeRequest( "POST", mapbox_library_api.obj.settings.list_by_grid_rest_url, { grid_id: details.admin2_grid_id, post_type: mapbox_library_api.post_type,
-          query: mapbox_library_api.query_args || {} } , mapbox_library_api.obj.settings.rest_base_url )
-        .done(list_by_grid=>{
-          if ( list_by_grid.length > 0 ) {
-            write_list( 'admin2_list', list_by_grid )
-          } else {
-            jQuery('#admin2_list').html( '' )
-          }
-        })
-      } else if ( details.admin1_grid_id !== null ) {
-        jQuery('#admin1_list').html( spinner_html )
-        window.makeRequest( "POST", mapbox_library_api.obj.settings.list_by_grid_rest_url, { grid_id: details.admin1_grid_id, post_type: mapbox_library_api.post_type,
-          query: mapbox_library_api.query_args || {} } , mapbox_library_api.obj.settings.rest_base_url )
-        .done(list_by_grid=>{
-          if ( list_by_grid.length > 0 ) {
-            write_list( 'admin1_list', list_by_grid )
-          } else {
-            jQuery('#admin1_list').html( '' )
-          }
-        })
-      } else if ( details.admin0_grid_id !== null ) {
-        jQuery('#admin0_list').html( spinner_html )
-        window.makeRequest( "POST", mapbox_library_api.obj.settings.list_by_grid_rest_url, { grid_id: details.admin0_grid_id, post_type: mapbox_library_api.post_type,
-          query: mapbox_library_api.query_args || {} } , mapbox_library_api.obj.settings.rest_base_url )
-        .done(list_by_grid=>{
-          if ( list_by_grid.length > 0 ) {
-            write_list( 'admin0_list', list_by_grid )
-          } else {
-            jQuery('#admin0_list').html( '' )
-          }
-        })
-      }
-
-      function write_list( level, list_by_grid ) {
-        let level_list = jQuery('#'+level)
-        level_list.empty()
-        jQuery.each(list_by_grid, function(i,v) {
-          if ( i > 20 ){ return }
-          level_list.append(`<div class="cell"><a target="_blank" href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/${window.SHAREDFUNCTIONS.escapeHTML( mapbox_library_api.post_type )}/${window.SHAREDFUNCTIONS.escapeHTML( v.post_id )}">${window.SHAREDFUNCTIONS.escapeHTML( v.post_title ) }</a></div>`)
-        })
-        if ( list_by_grid.length > 20 ){
-          level_list.append(`<div class="cell">...</div>`)
-        }
+    });
+    area_map.previous_grid_list.forEach((grid_item) => {
+      let layer_id = 'dt-maps-' + grid_item.parent_id;
+      let mapLayer = mapbox_library_api.map.getLayer(layer_id);
+      if (
+        typeof mapLayer !== 'undefined' &&
+        !window.lodash.find(data, { parent_id: grid_item.parent_id })
+      ) {
+        mapbox_library_api.map.removeLayer(layer_id);
+        mapbox_library_api.map.removeSource(layer_id);
       }
     });
-  }
-}
+    area_map.previous_grid_list = data;
+    mapbox_library_api.spinner.hide();
+  },
+  load_detail_panel: function (lng, lat, level) {
+    lng = window.mapbox_library_api.standardize_longitude(lng);
+    if (level === 'world') {
+      level = 'admin0';
+    }
 
-mapbox_library_api.cluster_map = cluster_map
-mapbox_library_api.area_map = area_map
+    let content = jQuery('#geocode-details-content');
+    content.empty().html(spinner_html);
+
+    jQuery('#geocode-details').show();
+
+    // geocode
+    window
+      .makeRequest(
+        'GET',
+        mapbox_library_api.obj.settings.geocoder_url +
+          'dt-mapping/location-grid-list-api.php',
+        {
+          type: 'geocode',
+          longitude: lng,
+          latitude: lat,
+          level: level,
+          nonce: mapbox_library_api.obj.settings.geocoder_nonce,
+          query: mapbox_library_api.query_args || {},
+        },
+      )
+      .done((details) => {
+        /* hierarchy list*/
+        content
+          .empty()
+          .append(
+            `<ul id="hierarchy-list" class="accordion" data-accordion></ul>`,
+          );
+        let list = jQuery('#hierarchy-list');
+        if (details.admin0_grid_id) {
+          list.append(`
+          <li id="admin0_wrapper" class="accordion-item" data-accordion-item>
+           <a href="#" class="accordion-title">${window.SHAREDFUNCTIONS.escapeHTML(details.admin0_name)} :  <span id="admin0_count">0</span></a>
+            <div class="accordion-content grid-x" data-tab-content><div id="admin0_list" class="grid-x"></div></div>
+          </li>
+        `);
+          if (details.admin0_grid_id in area_map.grid_data) {
+            jQuery('#admin0_count').html(
+              area_map.grid_data[details.admin0_grid_id].count,
+            );
+          }
+        }
+        if (details.admin1_grid_id) {
+          list.append(`
+          <li id="admin1_wrapper" class="accordion-item" data-accordion-item >
+            <a href="#" class="accordion-title">${window.SHAREDFUNCTIONS.escapeHTML(details.admin1_name)} : <span id="admin1_count">0</span></a>
+            <div class="accordion-content" data-tab-content><div id="admin1_list" class="grid-x"></div></div>
+          </li>
+        `);
+
+          if (details.admin1_grid_id in area_map.grid_data) {
+            jQuery('#admin1_count').html(
+              area_map.grid_data[details.admin1_grid_id].count,
+            );
+          }
+        }
+        if (details.admin2_grid_id) {
+          list.append(`
+          <li id="admin2_wrapper" class="accordion-item" data-accordion-item>
+            <a href="#" class="accordion-title">${window.SHAREDFUNCTIONS.escapeHTML(details.admin2_name)} : <span id="admin2_count">0</span></a>
+            <div class="accordion-content" data-tab-content><div id="admin2_list" class="grid-x"></div></div>
+          </li>
+        `);
+
+          if (details.admin2_grid_id in area_map.grid_data) {
+            jQuery('#admin2_count').html(
+              area_map.grid_data[details.admin2_grid_id].count,
+            );
+          }
+        }
+
+        jQuery('.accordion-item').last().addClass('is-active');
+        list.foundation();
+        /* end hierarchy list */
+
+        if (details.admin2_grid_id !== null) {
+          jQuery('#admin2_list').html(spinner_html);
+          window
+            .makeRequest(
+              'POST',
+              mapbox_library_api.obj.settings.list_by_grid_rest_url,
+              {
+                grid_id: details.admin2_grid_id,
+                post_type: mapbox_library_api.post_type,
+                query: mapbox_library_api.query_args || {},
+              },
+              mapbox_library_api.obj.settings.rest_base_url,
+            )
+            .done((list_by_grid) => {
+              if (list_by_grid.length > 0) {
+                write_list('admin2_list', list_by_grid);
+              } else {
+                jQuery('#admin2_list').html('');
+              }
+            });
+        } else if (details.admin1_grid_id !== null) {
+          jQuery('#admin1_list').html(spinner_html);
+          window
+            .makeRequest(
+              'POST',
+              mapbox_library_api.obj.settings.list_by_grid_rest_url,
+              {
+                grid_id: details.admin1_grid_id,
+                post_type: mapbox_library_api.post_type,
+                query: mapbox_library_api.query_args || {},
+              },
+              mapbox_library_api.obj.settings.rest_base_url,
+            )
+            .done((list_by_grid) => {
+              if (list_by_grid.length > 0) {
+                write_list('admin1_list', list_by_grid);
+              } else {
+                jQuery('#admin1_list').html('');
+              }
+            });
+        } else if (details.admin0_grid_id !== null) {
+          jQuery('#admin0_list').html(spinner_html);
+          window
+            .makeRequest(
+              'POST',
+              mapbox_library_api.obj.settings.list_by_grid_rest_url,
+              {
+                grid_id: details.admin0_grid_id,
+                post_type: mapbox_library_api.post_type,
+                query: mapbox_library_api.query_args || {},
+              },
+              mapbox_library_api.obj.settings.rest_base_url,
+            )
+            .done((list_by_grid) => {
+              if (list_by_grid.length > 0) {
+                write_list('admin0_list', list_by_grid);
+              } else {
+                jQuery('#admin0_list').html('');
+              }
+            });
+        }
+
+        function write_list(level, list_by_grid) {
+          let level_list = jQuery('#' + level);
+          level_list.empty();
+          jQuery.each(list_by_grid, function (i, v) {
+            if (i > 20) {
+              return;
+            }
+            level_list.append(
+              `<div class="cell"><a target="_blank" href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/${window.SHAREDFUNCTIONS.escapeHTML(mapbox_library_api.post_type)}/${window.SHAREDFUNCTIONS.escapeHTML(v.post_id)}">${window.SHAREDFUNCTIONS.escapeHTML(v.post_title)}</a></div>`,
+            );
+          });
+          if (list_by_grid.length > 20) {
+            level_list.append(`<div class="cell">...</div>`);
+          }
+        }
+      });
+  },
+};
+
+mapbox_library_api.cluster_map = cluster_map;
+mapbox_library_api.area_map = area_map;
 window.mapbox_library_api = mapbox_library_api;
 
-
-jQuery(document).ready(function($) {
-  window.mapbox_library_api.setup_container()
-  let obj = window.dt_mapbox_metrics
-  jQuery('#metrics-sidemenu').foundation('down', jQuery(`#${obj.settings.menu_slug}-menu`));
-})
+jQuery(document).ready(function ($) {
+  window.mapbox_library_api.setup_container();
+  let obj = window.dt_mapbox_metrics;
+  jQuery('#metrics-sidemenu').foundation(
+    'down',
+    jQuery(`#${obj.settings.menu_slug}-menu`),
+  );
+});

--- a/dt-metrics/contacts/baptism-tree.js
+++ b/dt-metrics/contacts/baptism-tree.js
@@ -1,20 +1,20 @@
-jQuery(document).ready(function() {
-  if ( window.wpApiShare.url_path.startsWith( 'metrics/contacts/baptism-tree' ) ) {
-    project_baptism_tree()
+jQuery(document).ready(function () {
+  if (window.wpApiShare.url_path.startsWith('metrics/contacts/baptism-tree')) {
+    project_baptism_tree();
   }
 
   function project_baptism_tree() {
-    "use strict";
-    let chart = jQuery('#chart')
-    let spinner = ' <span class="loading-spinner active"></span> '
+    'use strict';
+    let chart = jQuery('#chart');
+    let spinner = ' <span class="loading-spinner active"></span> ';
 
-    chart.empty().html(spinner)
+    chart.empty().html(spinner);
     jQuery('#metrics-sidemenu').foundation('down', jQuery('#contacts-menu'));
 
-    let translations = window.dtMetricsProject.data.translations
+    let translations = window.dtMetricsProject.data.translations;
 
     chart.empty().html(`
-        <span class="section-header">${ window.SHAREDFUNCTIONS.escapeHTML( translations.title_baptism_tree ) }</span><hr>
+        <span class="section-header">${window.SHAREDFUNCTIONS.escapeHTML(translations.title_baptism_tree)}</span><hr>
         <div class="grid-x grid-padding-x">
             <div class="cell">
                 <div class="scrolling-wrapper" id="generation_map">${spinner}</div>
@@ -22,14 +22,15 @@ jQuery(document).ready(function() {
         </div>
         <div id="modal" class="reveal" data-reveal></div>
         <br><br>
-       `)
+       `);
 
-    window.makeRequest('POST', 'metrics/contacts/baptism_tree' )
-      .then(response => {
+    window
+      .makeRequest('POST', 'metrics/contacts/baptism_tree')
+      .then((response) => {
         // console.log(response)
-        jQuery('#generation_map').empty().html(response)
+        jQuery('#generation_map').empty().html(response);
         jQuery('#generation_map li:last-child').addClass('last');
-        new window.Foundation.Reveal(jQuery('#modal'))
-      })
+        new window.Foundation.Reveal(jQuery('#modal'));
+      });
   }
-})
+});

--- a/dt-metrics/contacts/coaching-tree.js
+++ b/dt-metrics/contacts/coaching-tree.js
@@ -1,19 +1,19 @@
-jQuery(document).ready(function() {
-  if ( window.wpApiShare.url_path.startsWith( 'metrics/contacts/coaching-tree' )) {
-    coaching_tree()
+jQuery(document).ready(function () {
+  if (window.wpApiShare.url_path.startsWith('metrics/contacts/coaching-tree')) {
+    coaching_tree();
   }
 
   function coaching_tree() {
-    "use strict";
-    let chart = jQuery('#chart')
-    let spinner = ' <span class="loading-spinner active"></span> '
-    chart.empty().html(spinner)
+    'use strict';
+    let chart = jQuery('#chart');
+    let spinner = ' <span class="loading-spinner active"></span> ';
+    chart.empty().html(spinner);
     jQuery('#metrics-sidemenu').foundation('down', jQuery('#contacts-menu'));
 
-    let translations = window.dtMetricsProject.data.translations
+    let translations = window.dtMetricsProject.data.translations;
 
     chart.empty().html(`
-        <span class="section-header">${ window.SHAREDFUNCTIONS.escapeHTML( translations.title_coaching_tree ) }</span><hr>
+        <span class="section-header">${window.SHAREDFUNCTIONS.escapeHTML(translations.title_coaching_tree)}</span><hr>
         <div class="grid-x grid-padding-x">
             <div class="cell">
                 <div class="scrolling-wrapper" id="generation_map">${spinner}</div>
@@ -21,14 +21,15 @@ jQuery(document).ready(function() {
         </div>
         <div id="modal" class="reveal" data-reveal></div>
         <br><br>
-       `)
+       `);
 
-    window.makeRequest('POST', 'metrics/contacts/coaching_tree' )
-      .then(response => {
+    window
+      .makeRequest('POST', 'metrics/contacts/coaching_tree')
+      .then((response) => {
         // console.log(response)
-        jQuery('#generation_map').empty().html(response)
+        jQuery('#generation_map').empty().html(response);
         jQuery('#generation_map li:last-child').addClass('last');
-        new window.Foundation.Reveal(jQuery('#modal'))
-      })
+        new window.Foundation.Reveal(jQuery('#modal'));
+      });
   }
-})
+});

--- a/dt-metrics/contacts/milestones.js
+++ b/dt-metrics/contacts/milestones.js
@@ -1,52 +1,53 @@
-jQuery(document).ready(function($) {
-
-  if ( window.wpApiShare.url_path.startsWith( 'metrics/contacts/milestones' ) ) {
-    get_milestones()
+jQuery(document).ready(function ($) {
+  if (window.wpApiShare.url_path.startsWith('metrics/contacts/milestones')) {
+    get_milestones();
   }
 
   function get_milestones() {
     jQuery('#metrics-sidemenu').foundation('down', jQuery('#contacts-menu'));
 
-
-    let chartDiv = jQuery('#chart')
-    let sourceData = window.wp_js_object.data
+    let chartDiv = jQuery('#chart');
+    let sourceData = window.wp_js_object.data;
 
     chartDiv.empty().html(`
-    <div class="section-header">${ window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.milestones) }</div>
-    <div class="section-subheader">${ window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.filter_to_date_range) }:</div>
+    <div class="section-header">${window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.milestones)}</div>
+    <div class="section-subheader">${window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.filter_to_date_range)}:</div>
     <div class="date_range_picker">
         <i class="fi-calendar"></i>&nbsp;
-        <span>${ window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.all_time) }</span>
+        <span>${window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.all_time)}</span>
         <i class="dt_caret down"></i>
     </div>
     <div style="display: inline-block" class="loading-spinner"></div>
     <hr>
     <div id="chartdiv" style="height: 400px"></div>
-  `)
+  `);
 
-    let chart = window.am4core.create("chartdiv", window.am4charts.XYChart);
+    let chart = window.am4core.create('chartdiv', window.am4charts.XYChart);
 
-    chart.data = sourceData.milestones
+    chart.data = sourceData.milestones;
     let categoryAxis = chart.xAxes.push(new window.am4charts.CategoryAxis());
-    categoryAxis.dataFields.category = "milestones";
+    categoryAxis.dataFields.category = 'milestones';
     categoryAxis.renderer.grid.template.location = 0;
     categoryAxis.renderer.minGridDistance = 30;
-    categoryAxis.renderer.labels.template.adapter.add("dy", function (dy, target) {
-      if (target.dataItem && target.dataItem.index & 2 == 2) {
-        return dy + 25;
-      }
-      return dy;
-    });
+    categoryAxis.renderer.labels.template.adapter.add(
+      'dy',
+      function (dy, target) {
+        if (target.dataItem && target.dataItem.index & (2 == 2)) {
+          return dy + 25;
+        }
+        return dy;
+      },
+    );
 
     let valueAxis = chart.yAxes.push(new window.am4charts.ValueAxis());
 
     // Create series
     let series = chart.series.push(new window.am4charts.ColumnSeries());
-    series.dataFields.valueY = "value";
-    series.dataFields.categoryX = "milestones";
-    series.name = "Visits";
-    series.columns.template.tooltipText = "{categoryX}: [bold]{valueY}[/]";
-    series.columns.template.fillOpacity = .8;
+    series.dataFields.valueY = 'value';
+    series.dataFields.categoryX = 'milestones';
+    series.name = 'Visits';
+    series.columns.template.tooltipText = '{categoryX}: [bold]{valueY}[/]';
+    series.columns.template.fillOpacity = 0.8;
 
     let columnTemplate = series.columns.template;
     columnTemplate.strokeWidth = 2;
@@ -56,12 +57,10 @@ jQuery(document).ready(function($) {
       `${window.wp_js_object.rest_endpoints_base}/milestones/`,
       function (data, label) {
         if (data) {
-          $('.date_range_picker span').html( label );
-          chart.data = data
+          $('.date_range_picker span').html(label);
+          chart.data = data;
         }
-      }
-    )
+      },
+    );
   }
-
-
-})
+});

--- a/dt-metrics/contacts/milestones_map.js
+++ b/dt-metrics/contacts/milestones_map.js
@@ -1,13 +1,16 @@
-"use strict";
+'use strict';
 
-jQuery(document).ready(function() {
-  jQuery('#metrics-sidemenu').foundation('down', jQuery(`#${window.wp_js_object.base_slug}-menu`));
+jQuery(document).ready(function () {
+  jQuery('#metrics-sidemenu').foundation(
+    'down',
+    jQuery(`#${window.wp_js_object.base_slug}-menu`),
+  );
 
-  let chartDiv = jQuery('#chart')
+  let chartDiv = jQuery('#chart');
   chartDiv.empty().html(`
     <span class="section-header" title="Showing all contacts from all time with any status">${window.wp_js_object.translations.title}</span>
     <div id="mapping_chart"></div>
-  `)
+  `);
 
-  window.page_mapping_view(window.wp_js_object.rest_endpoints_base)
-})
+  window.page_mapping_view(window.wp_js_object.rest_endpoints_base);
+});

--- a/dt-metrics/contacts/overview.js
+++ b/dt-metrics/contacts/overview.js
@@ -1,17 +1,17 @@
-jQuery(document).ready(function() {
-  if ( window.wpApiShare.url_path.startsWith(  'metrics/contacts/overview' ) ) {
-    project_contacts_overview()
+jQuery(document).ready(function () {
+  if (window.wpApiShare.url_path.startsWith('metrics/contacts/overview')) {
+    project_contacts_overview();
   }
 
   function project_contacts_overview() {
-    "use strict";
-    let chart = jQuery('#chart')
-    let spinner = ' <span class="loading-spinner active"></span> '
-    chart.empty().html(spinner)
+    'use strict';
+    let chart = jQuery('#chart');
+    let spinner = ' <span class="loading-spinner active"></span> ';
+    chart.empty().html(spinner);
     jQuery('#metrics-sidemenu').foundation('down', jQuery('#contacts-menu'));
 
-    let sourceData = window.dtMetricsProject.data
-    let translations = window.dtMetricsProject.data.translations
+    let sourceData = window.dtMetricsProject.data;
+    let translations = window.dtMetricsProject.data.translations;
 
     chart.empty().html(`
         <div class="cell center">
@@ -44,72 +44,78 @@ jQuery(document).ready(function() {
                 <div id="status_chart_div" style="height: 500px; width=100%; margin:0 auto;"></div>
             </div>
         </div>
-        `)
+        `);
 
-    let hero = sourceData.hero_stats
-    jQuery('#active_contacts').html(numberWithCommas(hero.active_contacts))
-    jQuery('#needs_accepted').html(numberWithCommas(hero.needs_accepted))
-    jQuery('#updates_needed').html(numberWithCommas(hero.updates_needed))
-    jQuery('#all_contacts').html(numberWithCommas(hero.total_contacts))
+    let hero = sourceData.hero_stats;
+    jQuery('#active_contacts').html(numberWithCommas(hero.active_contacts));
+    jQuery('#needs_accepted').html(numberWithCommas(hero.needs_accepted));
+    jQuery('#updates_needed').html(numberWithCommas(hero.updates_needed));
+    jQuery('#all_contacts').html(numberWithCommas(hero.total_contacts));
 
     // build charts
     drawMyContactsProgress();
-    draw_status_pie_chart()
+    draw_status_pie_chart();
 
     function drawMyContactsProgress() {
-      let chart = window.am4core.create("my_contacts_progress", window.am4charts.XYChart)
-      let title = chart.titles.create()
-      title.text = `[bold]${window.dtMetricsProject.data.translations.label_follow_up_progress}[/]`
-      chart.data = sourceData.contacts_progress.reverse()
+      let chart = window.am4core.create(
+        'my_contacts_progress',
+        window.am4charts.XYChart,
+      );
+      let title = chart.titles.create();
+      title.text = `[bold]${window.dtMetricsProject.data.translations.label_follow_up_progress}[/]`;
+      chart.data = sourceData.contacts_progress.reverse();
       let categoryAxis = chart.yAxes.push(new window.am4charts.CategoryAxis());
-      categoryAxis.dataFields.category = "label";
+      categoryAxis.dataFields.category = 'label';
       categoryAxis.renderer.grid.template.location = 0;
       categoryAxis.renderer.minGridDistance = 30;
 
       let valueAxis = chart.xAxes.push(new window.am4charts.ValueAxis());
-      valueAxis.title.text = "Number of contacts"
+      valueAxis.title.text = 'Number of contacts';
 
       let series = chart.series.push(new window.am4charts.ColumnSeries());
-      series.dataFields.valueX = "value";
-      series.dataFields.categoryY = "label";
-      series.columns.template.tooltipText = "Total: [bold]{valueX}[/]";
+      series.dataFields.valueX = 'value';
+      series.dataFields.categoryY = 'label';
+      series.columns.template.tooltipText = 'Total: [bold]{valueX}[/]';
 
       // field value label
       let valueLabel = series.bullets.push(new window.am4charts.LabelBullet());
-      valueLabel.label.text = "{valueX}";
-      valueLabel.label.horizontalCenter = "left";
+      valueLabel.label.text = '{valueX}';
+      valueLabel.label.horizontalCenter = 'left';
       valueLabel.label.dx = 10;
       valueLabel.label.hideOversized = false;
       valueLabel.label.truncate = false;
-
     }
 
     function draw_status_pie_chart() {
-      let contact_statuses = sourceData.contact_statuses
+      let contact_statuses = sourceData.contact_statuses;
       window.am4core.useTheme(window.am4themes_animated);
 
-      let container = window.am4core.create("status_chart_div", window.am4core.Container);
+      let container = window.am4core.create(
+        'status_chart_div',
+        window.am4core.Container,
+      );
       container.width = window.am4core.percent(100);
       container.height = window.am4core.percent(100);
-      container.layout = "horizontal";
-
+      container.layout = 'horizontal';
 
       let chart = container.createChild(window.am4charts.PieChart);
-      let title = chart.titles.create()
-      title.text = `[bold]${window.dtMetricsProject.data.translations.title_status_chart}[/]`
+      let title = chart.titles.create();
+      title.text = `[bold]${window.dtMetricsProject.data.translations.title_status_chart}[/]`;
       // Add data
-      chart.data = contact_statuses
+      chart.data = contact_statuses;
 
       // Add and configure Series
       let pieSeries = chart.series.push(new window.am4charts.PieSeries());
-      pieSeries.dataFields.value = "count";
-      pieSeries.dataFields.category = "status";
-      pieSeries.slices.template.states.getKey("active").properties.shiftRadius = 0;
-      pieSeries.labels.template.text = "{category}: {value.percent.formatNumber('#.#')}% ({value}) ";
+      pieSeries.dataFields.value = 'count';
+      pieSeries.dataFields.category = 'status';
+      pieSeries.slices.template.states.getKey('active').properties.shiftRadius =
+        0;
+      pieSeries.labels.template.text =
+        "{category}: {value.percent.formatNumber('#.#')}% ({value}) ";
 
-      pieSeries.slices.template.events.on("hit", function (event) {
+      pieSeries.slices.template.events.on('hit', function (event) {
         selectSlice(event.target.dataItem);
-      })
+      });
 
       let chart2 = container.createChild(window.am4charts.PieChart);
       chart2.width = window.am4core.percent(30);
@@ -117,26 +123,28 @@ jQuery(document).ready(function() {
 
       // Add and configure Series
       let pieSeries2 = chart2.series.push(new window.am4charts.PieSeries());
-      pieSeries2.dataFields.value = "count";
-      pieSeries2.dataFields.category = "reason";
-      pieSeries2.slices.template.states.getKey("active").properties.shiftRadius = 0;
+      pieSeries2.dataFields.value = 'count';
+      pieSeries2.dataFields.category = 'reason';
+      pieSeries2.slices.template.states.getKey(
+        'active',
+      ).properties.shiftRadius = 0;
       pieSeries2.labels.template.disabled = true;
       pieSeries2.ticks.template.disabled = true;
       pieSeries2.alignLabels = false;
-      pieSeries2.events.on("positionchanged", updateLines);
+      pieSeries2.events.on('positionchanged', updateLines);
 
       let interfaceColors = new window.am4core.InterfaceColorSet();
 
       let line1 = container.createChild(window.am4core.Line);
-      line1.strokeDasharray = "2,2";
+      line1.strokeDasharray = '2,2';
       line1.strokeOpacity = 0.5;
-      line1.stroke = interfaceColors.getFor("alternativeBackground");
+      line1.stroke = interfaceColors.getFor('alternativeBackground');
       line1.isMeasured = false;
 
       let line2 = container.createChild(window.am4core.Line);
-      line2.strokeDasharray = "2,2";
+      line2.strokeDasharray = '2,2';
       line2.strokeOpacity = 0.5;
-      line2.stroke = interfaceColors.getFor("alternativeBackground");
+      line2.stroke = interfaceColors.getFor('alternativeBackground');
       line2.isMeasured = false;
 
       let selectedSlice;
@@ -147,39 +155,57 @@ jQuery(document).ready(function() {
         let count = dataItem.dataContext.reasons.length;
         pieSeries2.colors.list = [];
         for (let i = 0; i < count; i++) {
-          pieSeries2.colors.list.push(fill.brighten(i * 2 / count));
+          pieSeries2.colors.list.push(fill.brighten((i * 2) / count));
         }
         chart2.data = dataItem.dataContext.reasons;
         pieSeries2.appear();
 
         let middleAngle = selectedSlice.middleAngle;
         let firstAngle = pieSeries.slices.getIndex(0).startAngle;
-        let animation = pieSeries.animate([{
-          property: "startAngle",
-          to: firstAngle - middleAngle
-        }, {property: "endAngle", to: firstAngle - middleAngle + 360}], 600, window.am4core.ease.sinOut);
-        animation.events.on("animationprogress", updateLines);
+        let animation = pieSeries.animate(
+          [
+            {
+              property: 'startAngle',
+              to: firstAngle - middleAngle,
+            },
+            { property: 'endAngle', to: firstAngle - middleAngle + 360 },
+          ],
+          600,
+          window.am4core.ease.sinOut,
+        );
+        animation.events.on('animationprogress', updateLines);
 
-        selectedSlice.events.on("transformed", updateLines);
-
+        selectedSlice.events.on('transformed', updateLines);
       }
 
       function updateLines() {
         if (selectedSlice) {
           let p11 = {
-            x: selectedSlice.radius * window.am4core.math.cos(selectedSlice.startAngle),
-            y: selectedSlice.radius * window.am4core.math.sin(selectedSlice.startAngle)
+            x:
+              selectedSlice.radius *
+              window.am4core.math.cos(selectedSlice.startAngle),
+            y:
+              selectedSlice.radius *
+              window.am4core.math.sin(selectedSlice.startAngle),
           };
           let p12 = {
-            x: selectedSlice.radius * window.am4core.math.cos(selectedSlice.startAngle + selectedSlice.arc),
-            y: selectedSlice.radius * window.am4core.math.sin(selectedSlice.startAngle + selectedSlice.arc)
+            x:
+              selectedSlice.radius *
+              window.am4core.math.cos(
+                selectedSlice.startAngle + selectedSlice.arc,
+              ),
+            y:
+              selectedSlice.radius *
+              window.am4core.math.sin(
+                selectedSlice.startAngle + selectedSlice.arc,
+              ),
           };
 
           p11 = window.am4core.utils.spritePointToSvg(p11, selectedSlice);
           p12 = window.am4core.utils.spritePointToSvg(p12, selectedSlice);
 
-          let p21 = {x: 0, y: -pieSeries2.pixelRadius};
-          let p22 = {x: 0, y: pieSeries2.pixelRadius};
+          let p21 = { x: 0, y: -pieSeries2.pixelRadius };
+          let p22 = { x: 0, y: pieSeries2.pixelRadius };
 
           p21 = window.am4core.utils.spritePointToSvg(p21, pieSeries2);
           p22 = window.am4core.utils.spritePointToSvg(p22, pieSeries2);
@@ -195,17 +221,15 @@ jQuery(document).ready(function() {
           line2.y2 = p22.y;
         }
       }
-
     }
 
     new window.Foundation.Reveal(jQuery('#dt-project-legend'));
   }
-})
+});
 
 function numberWithCommas(x) {
   x = (x || 0).toString();
   let pattern = /(-?\d+)(\d{3})/;
-  while (pattern.test(x))
-    x = x.replace(pattern, "$1,$2");
+  while (pattern.test(x)) x = x.replace(pattern, '$1,$2');
   return x;
 }

--- a/dt-metrics/contacts/seeker-path.js
+++ b/dt-metrics/contacts/seeker-path.js
@@ -1,59 +1,60 @@
-jQuery(document).ready(function($) {
-
+jQuery(document).ready(function ($) {
   jQuery('#metrics-sidemenu').foundation('down', jQuery('#contacts-menu'));
 
-  let chartDiv = jQuery('#chart')
-  let sourceData = window.wp_js_object.data
+  let chartDiv = jQuery('#chart');
+  let sourceData = window.wp_js_object.data;
 
   chartDiv.empty().html(`
-    <div class="section-header">${window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.seeker_path) }</div>
-    <div class="section-subheader">${ window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.filter_contacts_to_date_range) }</div>
+    <div class="section-header">${window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.seeker_path)}</div>
+    <div class="section-subheader">${window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.filter_contacts_to_date_range)}</div>
     <div class="date_range_picker">
         <i class="fi-calendar"></i>&nbsp;
-        <span>${ window.escape(window.wp_js_object.translations.all_time) }</span> 
+        <span>${window.escape(window.wp_js_object.translations.all_time)}</span> 
         <i class="dt_caret down"></i>
     </div>
     <div style="display: inline-block" class="loading-spinner"></div>
     <hr>
     <div id="chartdiv" style="height: 400px"></div>
-  `)
+  `);
 
-  let chart = window.am4core.create("chartdiv", window.am4charts.XYChart);
+  let chart = window.am4core.create('chartdiv', window.am4charts.XYChart);
 
-  chart.data = sourceData.seeker_path
+  chart.data = sourceData.seeker_path;
   let categoryAxis = chart.xAxes.push(new window.am4charts.CategoryAxis());
-  categoryAxis.dataFields.category = "seeker_path";
+  categoryAxis.dataFields.category = 'seeker_path';
   categoryAxis.renderer.grid.template.location = 0;
   categoryAxis.renderer.minGridDistance = 30;
-  categoryAxis.renderer.labels.template.adapter.add("dy", function(dy, target) {
-    if (target.dataItem && target.dataItem.index & 2 == 2) {
-      return dy + 25;
-    }
-    return dy;
-  });
+  categoryAxis.renderer.labels.template.adapter.add(
+    'dy',
+    function (dy, target) {
+      if (target.dataItem && target.dataItem.index & (2 == 2)) {
+        return dy + 25;
+      }
+      return dy;
+    },
+  );
 
   let valueAxis = chart.yAxes.push(new window.am4charts.ValueAxis());
 
   // Create series
   let series = chart.series.push(new window.am4charts.ColumnSeries());
-  series.dataFields.valueY = "value";
-  series.dataFields.categoryX = "seeker_path";
-  series.name = "Visits";
-  series.columns.template.tooltipText = "{categoryX}: [bold]{valueY}[/]";
-  series.columns.template.fillOpacity = .8;
+  series.dataFields.valueY = 'value';
+  series.dataFields.categoryX = 'seeker_path';
+  series.name = 'Visits';
+  series.columns.template.tooltipText = '{categoryX}: [bold]{valueY}[/]';
+  series.columns.template.fillOpacity = 0.8;
 
   let columnTemplate = series.columns.template;
   columnTemplate.strokeWidth = 2;
   columnTemplate.strokeOpacity = 1;
 
-
   window.METRICS.setupDatePicker(
     `${window.wp_js_object.rest_endpoints_base}/seeker_path/`,
     function (data, label, start, end) {
-      if ( data ){
-        $('.date_range_picker span').html( label );
-        chart.data = data
+      if (data) {
+        $('.date_range_picker span').html(label);
+        chart.data = data;
       }
-    }
-  )
-})
+    },
+  );
+});

--- a/dt-metrics/contacts/sources.js
+++ b/dt-metrics/contacts/sources.js
@@ -1,10 +1,8 @@
-jQuery(document).ready(function($) {
-
+jQuery(document).ready(function ($) {
   jQuery('#metrics-sidemenu').foundation('down', jQuery('#contacts-menu'));
 
   function show_sources_overview() {
-
-    let chartDiv = jQuery('#chart')
+    let chartDiv = jQuery('#chart');
 
     chartDiv.empty().html(`
       <span class="section-header">${window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.sources)}</span>
@@ -18,33 +16,34 @@ jQuery(document).ready(function($) {
       <hr>
 
       <div id="charts"></div>
-    `)
+    `);
 
     window.METRICS.setupDatePicker(
       `${window.wp_js_object.rest_endpoints_base}/sources_chart_data/`,
       function (data, label) {
         if (data) {
           $('.date_range_picker span').html(label);
-          draw_data(data, label)
+          draw_data(data, label);
         }
-      }
-    )
+      },
+    );
 
-    function draw_data(data, label = "all time") {
+    function draw_data(data, label = 'all time') {
       if (!data) {
-        data = window.wp_js_object.data.sources
+        data = window.wp_js_object.data.sources;
       }
-      let chartsDiv = $("#charts").empty()
+      let chartsDiv = $('#charts').empty();
 
       data = Object.values(data);
 
-      let height = Math.min(60 * data.length, 1000) + "px"
+      let height = Math.min(60 * data.length, 1000) + 'px';
 
-      chartDiv.find(".js-loading").remove()
+      chartDiv.find('.js-loading').remove();
 
       let filteringOutText = `${window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.milestones)} ${label}.`;
 
-      chartsDiv.append($("<div>").html(`
+      chartsDiv.append(
+        $('<div>').html(`
 
         <h3>${window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.sources_all_contacts_by_source_and_status)}</h3>
 
@@ -74,9 +73,10 @@ jQuery(document).ready(function($) {
         <p><b>${window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.faith_milestone)}:</b> <select class="js-milestone"></select></p>
 
         <div id="chartdiv3" style="min-height: ${height}"></div>
-      `))
+      `),
+      );
 
-      let localizedObject = window.wp_js_object
+      let localizedObject = window.wp_js_object;
 
       // Prepare data
       for (let item of data) {
@@ -84,33 +84,37 @@ jQuery(document).ready(function($) {
           item.translated_source = 'null (none set)';
         } else {
           item.translated_source =
-            window.lodash.get(localizedObject, `sources.${item.name_of_source}`) || item.name_of_source;
+            window.lodash.get(
+              localizedObject,
+              `sources.${item.name_of_source}`,
+            ) || item.name_of_source;
         }
       }
       // We need to collect all status names, because not all of them are in localizedObject
       const status_names = []; /* eg: ['assigned', 'closed'] */
-      status_names.push(...localizedObject.overall_status_settings.order)
+      status_names.push(...localizedObject.overall_status_settings.order);
 
-      const seeker_path_names = [] /* eg: ['attempted', 'established'] */
-      seeker_path_names.push(...localizedObject.seeker_path_settings.order)
+      const seeker_path_names = []; /* eg: ['attempted', 'established'] */
+      seeker_path_names.push(...localizedObject.seeker_path_settings.order);
 
-      const milestone_names = [] /* eg: ['milestone_belief', 'milestone_has_bible'] */
-      milestone_names.push(...Object.keys(localizedObject.milestone_settings))
+      const milestone_names =
+        []; /* eg: ['milestone_belief', 'milestone_has_bible'] */
+      milestone_names.push(...Object.keys(localizedObject.milestone_settings));
 
       for (let item of data) {
         for (let key of Object.keys(item)) {
           if (key.startsWith('status_')) {
             let status_name = key.replace('status_', '', 1);
             if (!status_names.includes(status_name)) {
-              status_names.push(status_name)
+              status_names.push(status_name);
             }
           } else if (key.startsWith('active_seeker_path_')) {
-            let seeker_path_name = key.replace('active_seeker_path_', '', 1)
+            let seeker_path_name = key.replace('active_seeker_path_', '', 1);
             if (!seeker_path_names.includes(seeker_path_name)) {
-              seeker_path_names.push(seeker_path_name)
+              seeker_path_names.push(seeker_path_name);
             }
           } else if (key.startsWith('active_milestone_')) {
-            let milestone_name = key.replace('active_', '', 1)
+            let milestone_name = key.replace('active_', '', 1);
             if (!milestone_names.includes(milestone_name)) {
               milestone_names.push(milestone_name);
             }
@@ -120,33 +124,53 @@ jQuery(document).ready(function($) {
 
       {
         // Create chart instance
-        let chart = window.am4core.create("chartdiv1", window.am4charts.XYChart);
+        let chart = window.am4core.create(
+          'chartdiv1',
+          window.am4charts.XYChart,
+        );
 
-        chart.data = window.lodash.orderBy(data, (a => {
-          return a["total"] || 0
-        }), ['asc']);
+        chart.data = window.lodash.orderBy(
+          data,
+          (a) => {
+            return a['total'] || 0;
+          },
+          ['asc'],
+        );
 
         // Create axes
-        let categoryAxis = chart.yAxes.push(new window.am4charts.CategoryAxis());
-        categoryAxis.dataFields.category = "translated_source";
-        categoryAxis.title.text = "Source";
+        let categoryAxis = chart.yAxes.push(
+          new window.am4charts.CategoryAxis(),
+        );
+        categoryAxis.dataFields.category = 'translated_source';
+        categoryAxis.title.text = 'Source';
         categoryAxis.renderer.grid.template.location = 0;
         categoryAxis.renderer.minGridDistance = 20;
 
         let valueAxis = chart.xAxes.push(new window.am4charts.ValueAxis());
-        valueAxis.title.text = "Contacts";
+        valueAxis.title.text = 'Contacts';
 
         // Create series
         for (let status of status_names) {
           let series = chart.series.push(new window.am4charts.ColumnSeries());
-          if (window.lodash.get(localizedObject.overall_status_settings.default[status], "color")) {
-            series.columns.template.fill = window.am4core.color(localizedObject.overall_status_settings.default[status].color);
+          if (
+            window.lodash.get(
+              localizedObject.overall_status_settings.default[status],
+              'color',
+            )
+          ) {
+            series.columns.template.fill = window.am4core.color(
+              localizedObject.overall_status_settings.default[status].color,
+            );
           }
-          series.stroke = window.am4core.color("#000000");
-          series.dataFields.valueX = "status_" + status;
-          series.dataFields.categoryY = "translated_source";
-          series.name = window.lodash.get(localizedObject.overall_status_settings.default[status], "label", status);
-          series.tooltipText = "{name}: [bold]{valueX}[/]";
+          series.stroke = window.am4core.color('#000000');
+          series.dataFields.valueX = 'status_' + status;
+          series.dataFields.categoryY = 'translated_source';
+          series.name = window.lodash.get(
+            localizedObject.overall_status_settings.default[status],
+            'label',
+            status,
+          );
+          series.tooltipText = '{name}: [bold]{valueX}[/]';
           series.stacked = true;
         }
 
@@ -157,29 +181,41 @@ jQuery(document).ready(function($) {
       }
 
       {
-
         // Create chart instance
-        let chart2 = window.am4core.create("chartdiv2", window.am4charts.XYChart);
-        chart2.data = window.lodash.orderBy(data, a => a.total_active_seeker_path || 0, ['asc']);
+        let chart2 = window.am4core.create(
+          'chartdiv2',
+          window.am4charts.XYChart,
+        );
+        chart2.data = window.lodash.orderBy(
+          data,
+          (a) => a.total_active_seeker_path || 0,
+          ['asc'],
+        );
 
         // Create axes
-        let categoryAxis = chart2.yAxes.push(new window.am4charts.CategoryAxis());
-        categoryAxis.dataFields.category = "translated_source";
-        categoryAxis.title.text = "Source";
+        let categoryAxis = chart2.yAxes.push(
+          new window.am4charts.CategoryAxis(),
+        );
+        categoryAxis.dataFields.category = 'translated_source';
+        categoryAxis.title.text = 'Source';
         categoryAxis.renderer.grid.template.location = 0;
         categoryAxis.renderer.minGridDistance = 20;
 
         let valueAxis = chart2.xAxes.push(new window.am4charts.ValueAxis());
-        valueAxis.title.text = "Contacts";
+        valueAxis.title.text = 'Contacts';
 
         // Create series
         for (let seeker_path of seeker_path_names) {
           let series = chart2.series.push(new window.am4charts.ColumnSeries());
-          series.dataFields.valueX = "active_seeker_path_" + seeker_path;
-          series.dataFields.categoryY = "translated_source";
-          series.stroke = window.am4core.color("#000");
-          series.name = window.lodash.get(localizedObject, `seeker_path_settings.default[${seeker_path}].label`, seeker_path);
-          series.tooltipText = "{name}: [bold]{valueX}[/]";
+          series.dataFields.valueX = 'active_seeker_path_' + seeker_path;
+          series.dataFields.categoryY = 'translated_source';
+          series.stroke = window.am4core.color('#000');
+          series.name = window.lodash.get(
+            localizedObject,
+            `seeker_path_settings.default[${seeker_path}].label`,
+            seeker_path,
+          );
+          series.tooltipText = '{name}: [bold]{valueX}[/]';
           series.stacked = true;
         }
 
@@ -191,62 +227,73 @@ jQuery(document).ready(function($) {
 
       {
         for (let milestone of milestone_names) {
-          let name = (localizedObject.milestone_settings[milestone] || {}) || milestone;
-          $(".js-milestone").append($("<option>").val(milestone).text(name));
+          let name =
+            localizedObject.milestone_settings[milestone] || {} || milestone;
+          $('.js-milestone').append($('<option>').val(milestone).text(name));
         }
 
         // Create chart instance
         let allSeries = [];
-        let chart3 = window.am4core.create("chartdiv3", window.am4charts.XYChart);
+        let chart3 = window.am4core.create(
+          'chartdiv3',
+          window.am4charts.XYChart,
+        );
         chart3.data = window.lodash.orderBy(data, ['total'], ['asc']);
 
         // Create axes
-        let categoryAxis = chart3.yAxes.push(new window.am4charts.CategoryAxis());
-        categoryAxis.dataFields.category = "translated_source";
-        categoryAxis.title.text = "Source";
+        let categoryAxis = chart3.yAxes.push(
+          new window.am4charts.CategoryAxis(),
+        );
+        categoryAxis.dataFields.category = 'translated_source';
+        categoryAxis.title.text = 'Source';
         categoryAxis.renderer.grid.template.location = 0;
         categoryAxis.renderer.minGridDistance = 20;
 
         let valueAxis = chart3.xAxes.push(new window.am4charts.ValueAxis());
-        valueAxis.title.text = "Contacts";
+        valueAxis.title.text = 'Contacts';
 
         // Create series
         for (let milestone of milestone_names) {
           let series = chart3.series.push(new window.am4charts.ColumnSeries());
-          series.dataFields.valueX = "active_" + milestone;
-          series.dataFields.categoryY = "translated_source";
-          series.stroke = window.am4core.color("#000");
-          series.name = (localizedObject.milestone_settings[milestone] || {}) || milestone;
-          series.tooltipText = "{name}: [bold]{valueX}[/]";
+          series.dataFields.valueX = 'active_' + milestone;
+          series.dataFields.categoryY = 'translated_source';
+          series.stroke = window.am4core.color('#000');
+          series.name =
+            localizedObject.milestone_settings[milestone] || {} || milestone;
+          series.tooltipText = '{name}: [bold]{valueX}[/]';
           // series.stacked = true;
-          series.clustered = false
-          series.hide()
+          series.clustered = false;
+          series.hide();
           allSeries.push(series);
         }
         // Add cursor
         chart3.cursor = new window.am4charts.XYCursor();
-        chart3.events.on("inited", function (ev) {
-          $(".js-milestone").trigger("change");
-        })
+        chart3.events.on('inited', function (ev) {
+          $('.js-milestone').trigger('change');
+        });
 
-        $(".js-milestone").on("change", function () {
+        $('.js-milestone').on('change', function () {
           let milestone = $(this).val();
-          chart3.data = window.lodash.orderBy(data, (a => {
-            return a["active_" + milestone] || 0
-          }), ['asc']);
+          chart3.data = window.lodash.orderBy(
+            data,
+            (a) => {
+              return a['active_' + milestone] || 0;
+            },
+            ['asc'],
+          );
           for (let series of allSeries) {
-            if (series.dataFields.valueX == "active_" + milestone) {
+            if (series.dataFields.valueX == 'active_' + milestone) {
               series.show();
             } else {
               series.hide();
             }
           }
-        })
+        });
       }
     }
 
-    draw_data()
+    draw_data();
   }
 
-  show_sources_overview()
-})
+  show_sources_overview();
+});

--- a/dt-metrics/groups/overview.js
+++ b/dt-metrics/groups/overview.js
@@ -1,21 +1,21 @@
-jQuery(document).ready(function() {
-  if ( window.wpApiShare.url_path.startsWith( 'metrics/groups/overview' ) ) {
-    groups_overview()
+jQuery(document).ready(function () {
+  if (window.wpApiShare.url_path.startsWith('metrics/groups/overview')) {
+    groups_overview();
   }
 
   function groups_overview() {
-    "use strict";
-    let chart = jQuery('#chart')
-    let spinner = ' <span class="loading-spinner active"></span> '
-    chart.empty().html(spinner)
+    'use strict';
+    let chart = jQuery('#chart');
+    let spinner = ' <span class="loading-spinner active"></span> ';
+    chart.empty().html(spinner);
     jQuery('#metrics-sidemenu').foundation('down', jQuery('#groups-menu'));
 
-    let sourceData = window.dtMetricsProject.data
-    let translations = window.dtMetricsProject.data.translations
+    let sourceData = window.dtMetricsProject.data;
+    let translations = window.dtMetricsProject.data.translations;
 
     chart.empty().html(`
         <div class="cell center">
-            <h3>${ window.SHAREDFUNCTIONS.escapeHTML( translations.title_groups_overview ) }</h3>
+            <h3>${window.SHAREDFUNCTIONS.escapeHTML(translations.title_groups_overview)}</h3>
         </div>
         <br>
         <div class="grid-x grid-padding-x grid-padding-y">
@@ -23,10 +23,10 @@ jQuery(document).ready(function() {
                 <div class="cell center callout">
                     <div class="grid-x">
                         <div class="medium-4 cell center">
-                            <h5>${ window.SHAREDFUNCTIONS.escapeHTML( translations.title_total_groups ) }<br><span id="total_groups">0</span></h5>
+                            <h5>${window.SHAREDFUNCTIONS.escapeHTML(translations.title_total_groups)}<br><span id="total_groups">0</span></h5>
                         </div>
                         <div class="medium-4 cell center left-border-grey">
-                            <h5>${ window.SHAREDFUNCTIONS.escapeHTML( translations.title_teams ) }<br><span id="teams">0</span></h5>
+                            <h5>${window.SHAREDFUNCTIONS.escapeHTML(translations.title_teams)}<br><span id="teams">0</span></h5>
                         </div>
                    </div>
                 </div>
@@ -47,36 +47,40 @@ jQuery(document).ready(function() {
             </div>
         </div>
         <br><br>
-        `)
+        `);
 
-    let hero = sourceData.hero_stats
-    jQuery('#total_groups').html( numberWithCommas( hero.total_groups ) )
-    jQuery('#needs_training').html( numberWithCommas( hero.needs_training ) )
-    jQuery('#teams').html( numberWithCommas( hero.teams ) )
+    let hero = sourceData.hero_stats;
+    jQuery('#total_groups').html(numberWithCommas(hero.total_groups));
+    jQuery('#needs_training').html(numberWithCommas(hero.needs_training));
+    jQuery('#teams').html(numberWithCommas(hero.teams));
 
     // build charts
-    if ( sourceData.preferences.groups.church_metrics ) {
+    if (sourceData.preferences.groups.church_metrics) {
       drawMyGroupHealth();
     } else {
-      jQuery('#my_groups_health_container').remove()
+      jQuery('#my_groups_health_container').remove();
     }
     drawGroupTypes();
     drawGroupGenerations();
 
     function drawMyGroupHealth() {
-      let chart = window.am4core.create("my_groups_health", window.am4charts.XYChart);
-      chart.data = sourceData.group_health
-      let title = chart.titles.create()
-      title.text = `[bold]${window.dtMetricsProject.data.translations.label_group_needs_training}[/]`
+      let chart = window.am4core.create(
+        'my_groups_health',
+        window.am4charts.XYChart,
+      );
+      chart.data = sourceData.group_health;
+      let title = chart.titles.create();
+      title.text = `[bold]${window.dtMetricsProject.data.translations.label_group_needs_training}[/]`;
       let categoryAxis = chart.xAxes.push(new window.am4charts.CategoryAxis());
-      categoryAxis.dataFields.category = "label";
+      categoryAxis.dataFields.category = 'label';
       categoryAxis.renderer.grid.template.location = 0;
       categoryAxis.renderer.minGridDistance = 20;
-      categoryAxis.renderer.labels.template.wrap = true
-      categoryAxis.events.on("sizechanged", function(ev) {
+      categoryAxis.renderer.labels.template.wrap = true;
+      categoryAxis.events.on('sizechanged', function (ev) {
         var axis = ev.target;
         var cellWidth = axis.pixelWidth / (axis.endIndex - axis.startIndex);
-        axis.renderer.labels.template.maxWidth = cellWidth > 70 ? cellWidth : 70;
+        axis.renderer.labels.template.maxWidth =
+          cellWidth > 70 ? cellWidth : 70;
         axis.renderer.labels.template.disabled = cellWidth < 70;
       });
 
@@ -86,63 +90,75 @@ jQuery(document).ready(function() {
       valueAxis.strictMinMax = true;
       valueAxis.calculateTotals = true;
       valueAxis.renderer.minWidth = 50;
-      valueAxis.renderer.labels.template.adapter.add("text", function(text) {
-        return text + "%";
+      valueAxis.renderer.labels.template.adapter.add('text', function (text) {
+        return text + '%';
       });
 
       let series1 = chart.series.push(new window.am4charts.ColumnSeries());
       series1.columns.template.width = window.am4core.percent(80);
-      series1.columns.template.tooltipText = "{name}: {valueY}";
-      series1.name = "Practicing";
-      series1.dataFields.categoryX = "label";
-      series1.dataFields.valueY = "practicing";
-      series1.dataFields.valueYShow = "totalPercent";
+      series1.columns.template.tooltipText = '{name}: {valueY}';
+      series1.name = 'Practicing';
+      series1.dataFields.categoryX = 'label';
+      series1.dataFields.valueY = 'practicing';
+      series1.dataFields.valueYShow = 'totalPercent';
       series1.dataItems.template.locations.categoryX = 0.5;
       series1.stacked = true;
-      series1.tooltip.pointerOrientation = "vertical";
+      series1.tooltip.pointerOrientation = 'vertical';
 
       let series2 = chart.series.push(new window.am4charts.ColumnSeries());
-      series2.stroke = window.am4core.color("#da7070"); // red
-      series2.fill = window.am4core.color("#da7070"); // red
+      series2.stroke = window.am4core.color('#da7070'); // red
+      series2.fill = window.am4core.color('#da7070'); // red
       series2.columns.template.width = window.am4core.percent(80);
-      series2.columns.template.tooltipText =
-        "{name}: {valueY}";
-      series2.name = "Not Practicing";
-      series2.dataFields.categoryX = "label";
-      series2.dataFields.valueY = "remaining";
-      series2.dataFields.valueYShow = "totalPercent";
+      series2.columns.template.tooltipText = '{name}: {valueY}';
+      series2.name = 'Not Practicing';
+      series2.dataFields.categoryX = 'label';
+      series2.dataFields.valueY = 'remaining';
+      series2.dataFields.valueYShow = 'totalPercent';
       series2.dataItems.template.locations.categoryX = 0.5;
       series2.stacked = true;
-      series2.tooltip.pointerOrientation = "vertical";
+      series2.tooltip.pointerOrientation = 'vertical';
       chart.legend = new window.am4charts.Legend();
     }
 
     function drawGroupTypes() {
-      let chart = window.am4core.create("group_types", window.am4charts.PieChart);
-      let title = chart.titles.create()
-      title.text = `[bold]${window.dtMetricsProject.data.translations.label_group_types}[/]`
-      chart.data = sourceData.group_types
+      let chart = window.am4core.create(
+        'group_types',
+        window.am4charts.PieChart,
+      );
+      let title = chart.titles.create();
+      title.text = `[bold]${window.dtMetricsProject.data.translations.label_group_types}[/]`;
+      chart.data = sourceData.group_types;
       let pieSeries = chart.series.push(new window.am4charts.PieSeries());
-      pieSeries.dataFields.value = "count";
-      pieSeries.dataFields.category = "label";
+      pieSeries.dataFields.value = 'count';
+      pieSeries.dataFields.category = 'label';
       pieSeries.labels.template.disabled = true;
       chart.innerRadius = window.am4core.percent(30);
       chart.legend = new window.am4charts.Legend();
     }
 
     function drawGroupGenerations() {
-      let chart = window.am4core.create("group_generations", window.am4charts.XYChart);
-      let title = chart.titles.create()
-      title.text = `[bold]${ window.dtMetricsProject.data.translations.title_generations }[/]`
+      let chart = window.am4core.create(
+        'group_generations',
+        window.am4charts.XYChart,
+      );
+      let title = chart.titles.create();
+      title.text = `[bold]${window.dtMetricsProject.data.translations.title_generations}[/]`;
 
-      chart.data = sourceData.group_generations.reverse()
+      chart.data = sourceData.group_generations.reverse();
 
       let categoryAxis = chart.yAxes.push(new window.am4charts.CategoryAxis());
-      categoryAxis.dataFields.category = "generation";
+      categoryAxis.dataFields.category = 'generation';
       categoryAxis.renderer.grid.template.location = 0;
-      categoryAxis.renderer.labels.template.adapter.add("text", function(text) {
-        return window.dtMetricsProject.data.translations.label_generation + ' ' + text;
-      });
+      categoryAxis.renderer.labels.template.adapter.add(
+        'text',
+        function (text) {
+          return (
+            window.dtMetricsProject.data.translations.label_generation +
+            ' ' +
+            text
+          );
+        },
+      );
 
       let valueAxis = chart.xAxes.push(new window.am4charts.ValueAxis());
       valueAxis.renderer.inside = true;
@@ -164,12 +180,14 @@ jQuery(document).ready(function() {
         let series = chart.series.push(new window.am4charts.ColumnSeries());
         series.name = name;
         series.dataFields.valueX = field;
-        series.dataFields.categoryY = "generation";
+        series.dataFields.categoryY = 'generation';
         series.stacked = true;
         series.columns.template.width = window.am4core.percent(60);
-        series.columns.template.tooltipText = "[bold]{name}[/]\n {valueX}";
-        let labelBullet = series.bullets.push(new window.am4charts.LabelBullet());
-        labelBullet.label.text = "{valueX}";
+        series.columns.template.tooltipText = '[bold]{name}[/]\n {valueX}';
+        let labelBullet = series.bullets.push(
+          new window.am4charts.LabelBullet(),
+        );
+        labelBullet.label.text = '{valueX}';
         labelBullet.locationX = 0.5;
         return series;
       }
@@ -179,7 +197,13 @@ jQuery(document).ready(function() {
       jQuery.each(chart.data, function (idx, generation) {
         jQuery.each(generation, function (key, value) {
           let group_type = fetchGroupType(key);
-          if (group_type && !Object.prototype.hasOwnProperty.call(group_type_set, group_type['type'])) {
+          if (
+            group_type &&
+            !Object.prototype.hasOwnProperty.call(
+              group_type_set,
+              group_type['type'],
+            )
+          ) {
             group_type_set[group_type['type']] = group_type;
           }
         });
@@ -193,12 +217,11 @@ jQuery(document).ready(function() {
       chart.legend = new window.am4charts.Legend();
     }
   }
-})
+});
 
 function numberWithCommas(x) {
   x = (x || 0).toString();
   let pattern = /(-?\d+)(\d{3})/;
-  while (pattern.test(x))
-    x = x.replace(pattern, "$1,$2");
+  while (pattern.test(x)) x = x.replace(pattern, '$1,$2');
   return x;
 }

--- a/dt-metrics/groups/tree.js
+++ b/dt-metrics/groups/tree.js
@@ -1,27 +1,27 @@
-jQuery(document).ready(function() {
-  if ( window.wpApiShare.url_path.startsWith( 'metrics/groups/tree' ) ) {
-    project_group_tree()
+jQuery(document).ready(function () {
+  if (window.wpApiShare.url_path.startsWith('metrics/groups/tree')) {
+    project_group_tree();
   }
 
   function project_group_tree() {
-    "use strict";
-    let chart = jQuery('#chart')
-    let spinner = ' <span class="loading-spinner active"></span> '
+    'use strict';
+    let chart = jQuery('#chart');
+    let spinner = ' <span class="loading-spinner active"></span> ';
 
-    chart.empty().html(spinner)
+    chart.empty().html(spinner);
     jQuery('#metrics-sidemenu').foundation('down', jQuery('#groups-menu'));
 
-    let translations = window.dtMetricsProject.data.translations
+    let translations = window.dtMetricsProject.data.translations;
 
     chart.empty().html(`
           <span class="section-header">${window.SHAREDFUNCTIONS.escapeHTML(translations.title_group_tree)}</span><hr>
            <div class="grid-x grid-padding-x">
            <div class="cell">
                <span>
-                  <button class="button hollow toggle-singles" id="highlight-active" onclick="highlight_active();">${window.SHAREDFUNCTIONS.escapeHTML(translations.highlight_active)/*Highlight Active*/}</button>
+                  <button class="button hollow toggle-singles" id="highlight-active" onclick="highlight_active();">${window.SHAREDFUNCTIONS.escapeHTML(translations.highlight_active) /*Highlight Active*/}</button>
                </span>
               <span>
-                  <button class="button hollow toggle-singles" id="highlight-churches" onclick="highlight_churches();">${window.SHAREDFUNCTIONS.escapeHTML(translations.highlight_churches)/*Highlight Churches*/}</button>
+                  <button class="button hollow toggle-singles" id="highlight-churches" onclick="highlight_churches();">${window.SHAREDFUNCTIONS.escapeHTML(translations.highlight_churches) /*Highlight Churches*/}</button>
               </span>
           </div>
               <div class="cell">
@@ -30,89 +30,99 @@ jQuery(document).ready(function() {
           </div>
            <div id="modal" class="reveal" data-reveal></div>
            <br><br>
-       `)
+       `);
 
-    window.makeRequest('POST', 'metrics/group/tree' )
-      .then(response => {
-        // console.log(response)
-        jQuery('#generation_map').empty().html(response)
-        jQuery('#generation_map li:last-child').addClass('last');
-        new window.Foundation.Reveal(jQuery('#modal'))
-      })
+    window.makeRequest('POST', 'metrics/group/tree').then((response) => {
+      // console.log(response)
+      jQuery('#generation_map').empty().html(response);
+      jQuery('#generation_map li:last-child').addClass('last');
+      new window.Foundation.Reveal(jQuery('#modal'));
+    });
   }
-})
+});
 
-function open_modal_details( id ) {
-  let modal = jQuery('#modal')
-  let spinner = ' <span class="loading-spinner active"></span> '
-  let translations = window.dtMetricsProject.data.translations
+function open_modal_details(id) {
+  let modal = jQuery('#modal');
+  let spinner = ' <span class="loading-spinner active"></span> ';
+  let translations = window.dtMetricsProject.data.translations;
 
-  modal.empty().html(spinner).foundation('open')
+  modal.empty().html(spinner).foundation('open');
 
-  window.makeRequest('GET', 'groups/'+window.SHAREDFUNCTIONS.escapeHTML( id ), null, 'dt-posts/v2/' )
-    .then(data => {
+  window
+    .makeRequest(
+      'GET',
+      'groups/' + window.SHAREDFUNCTIONS.escapeHTML(id),
+      null,
+      'dt-posts/v2/',
+    )
+    .then((data) => {
       // console.log(data)
-      if( data ) {
-        let list = '<dt>'+window.SHAREDFUNCTIONS.escapeHTML( translations.members )+'</dt><ul>'
-        jQuery.each(data.members, function(i, v)  { list += `<li><a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/contacts/${window.SHAREDFUNCTIONS.escapeHTML( data.members[i].ID )}">${window.SHAREDFUNCTIONS.escapeHTML( data.members[i].post_title )}</a></li>` } )
-        let assigned_to = ''
+      if (data) {
+        let list =
+          '<dt>' +
+          window.SHAREDFUNCTIONS.escapeHTML(translations.members) +
+          '</dt><ul>';
+        jQuery.each(data.members, function (i, v) {
+          list += `<li><a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/contacts/${window.SHAREDFUNCTIONS.escapeHTML(data.members[i].ID)}">${window.SHAREDFUNCTIONS.escapeHTML(data.members[i].post_title)}</a></li>`;
+        });
+        let assigned_to = '';
         if (typeof data.assigned_to !== 'undefined') {
-          assigned_to = data.assigned_to['display']
+          assigned_to = data.assigned_to['display'];
         }
-        list += '</ul>'
+        list += '</ul>';
         modal.empty().append(`
           <div class="grid-x">
-              <div class="cell"><span class="section-header">${window.SHAREDFUNCTIONS.escapeHTML( data.title )}</span><hr style="max-width:100%;"></div>
+              <div class="cell"><span class="section-header">${window.SHAREDFUNCTIONS.escapeHTML(data.title)}</span><hr style="max-width:100%;"></div>
               <div class="cell">
                   <dl>
-                      <dd><strong>${window.SHAREDFUNCTIONS.escapeHTML( translations.status ) /*Status*/}: </strong>${window.SHAREDFUNCTIONS.escapeHTML( data.group_status.label )}</dd>
-                      <dd><strong>${window.SHAREDFUNCTIONS.escapeHTML( translations.assigned_to )/*Assigned to*/}: </strong>${window.SHAREDFUNCTIONS.escapeHTML( assigned_to)}</dd>
-                      <dd><strong>${window.SHAREDFUNCTIONS.escapeHTML( translations.total_members ) /*Total Members*/}: </strong>${window.SHAREDFUNCTIONS.escapeHTML( data.member_count )}</dd>
+                      <dd><strong>${window.SHAREDFUNCTIONS.escapeHTML(translations.status) /*Status*/}: </strong>${window.SHAREDFUNCTIONS.escapeHTML(data.group_status.label)}</dd>
+                      <dd><strong>${window.SHAREDFUNCTIONS.escapeHTML(translations.assigned_to) /*Assigned to*/}: </strong>${window.SHAREDFUNCTIONS.escapeHTML(assigned_to)}</dd>
+                      <dd><strong>${window.SHAREDFUNCTIONS.escapeHTML(translations.total_members) /*Total Members*/}: </strong>${window.SHAREDFUNCTIONS.escapeHTML(data.member_count)}</dd>
                       ${list}
                   </dl>
               </div>
-              <div class="cell center"><hr><a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/groups/${window.SHAREDFUNCTIONS.escapeHTML( id )}">${translations.view_group /*View Group*/}</a></div>
+              <div class="cell center"><hr><a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/groups/${window.SHAREDFUNCTIONS.escapeHTML(id)}">${translations.view_group /*View Group*/}</a></div>
           </div>
           <button class="close-button" data-close aria-label="Close modal" type="button">
               <span aria-hidden="true">&times;</span>
           </button>
-        `)
+        `);
       }
-    })
+    });
 }
 
-function toggle_multiplying_only () {
-  let list = jQuery('#generation_map .li-gen-1:not(:has(li.li-gen-2))')
-  let button = jQuery('#multiplying-only')
-  if( button.hasClass('hollow') ) {
-    list.hide()
-    button.removeClass('hollow')
+function toggle_multiplying_only() {
+  let list = jQuery('#generation_map .li-gen-1:not(:has(li.li-gen-2))');
+  let button = jQuery('#multiplying-only');
+  if (button.hasClass('hollow')) {
+    list.hide();
+    button.removeClass('hollow');
   } else {
-    button.addClass('hollow')
-    list.show()
+    button.addClass('hollow');
+    list.show();
   }
 }
 
 function highlight_active() {
-  let list = jQuery('.inactive')
-  let button = jQuery('#highlight-active')
-  if( button.hasClass('hollow') ) {
-    list.addClass('inactive-gray')
-    button.removeClass('hollow')
+  let list = jQuery('.inactive');
+  let button = jQuery('#highlight-active');
+  if (button.hasClass('hollow')) {
+    list.addClass('inactive-gray');
+    button.removeClass('hollow');
   } else {
-    button.addClass('hollow')
-    list.removeClass('inactive-gray')
+    button.addClass('hollow');
+    list.removeClass('inactive-gray');
   }
 }
 
 function highlight_churches() {
-  let list = jQuery('#generation_map span:not(.church)')
-  let button = jQuery('#highlight-churches')
-  if( button.hasClass('hollow') ) {
-    list.addClass('not-church-gray')
-    button.removeClass('hollow')
+  let list = jQuery('#generation_map span:not(.church)');
+  let button = jQuery('#highlight-churches');
+  if (button.hasClass('hollow')) {
+    list.addClass('not-church-gray');
+    button.removeClass('hollow');
   } else {
-    button.addClass('hollow')
-    list.removeClass('not-church-gray')
+    button.addClass('hollow');
+    list.removeClass('not-church-gray');
   }
 }

--- a/dt-metrics/personal/activity-highlights.js
+++ b/dt-metrics/personal/activity-highlights.js
@@ -1,22 +1,26 @@
-jQuery(document).ready(function($) {
-  if ( window.wpApiShare.url_path.startsWith( 'metrics/personal/activity-highlights' ) ) {
-    my_stats()
+jQuery(document).ready(function ($) {
+  if (
+    window.wpApiShare.url_path.startsWith(
+      'metrics/personal/activity-highlights',
+    )
+  ) {
+    my_stats();
   }
 
   function my_stats() {
-    "use strict";
-    let chartDiv = jQuery('#chart')
-    let sourceData = window.dtMetricsActivity.data
-    let translations = window.dtMetricsActivity.translations
+    'use strict';
+    let chartDiv = jQuery('#chart');
+    let sourceData = window.dtMetricsActivity.data;
+    let translations = window.dtMetricsActivity.translations;
 
     jQuery('#metrics-sidemenu').foundation('down', jQuery('#personal-menu'));
 
-    const title = window.SHAREDFUNCTIONS.escapeHTML( translations.title )
+    const title = window.SHAREDFUNCTIONS.escapeHTML(translations.title);
 
     /* highlights */
     chartDiv.empty().html(`
       <div class="cell center">
-        <h3>${ title }</h3>
+        <h3>${title}</h3>
       </div>
       <div class="section-subheader">${window.SHAREDFUNCTIONS.escapeHTML(translations.filter_contacts_to_date_range)}</div>
       <div class="date_range_picker">
@@ -28,24 +32,24 @@ jQuery(document).ready(function($) {
       <hr>
 
       <div id="activity_highlights"></div>
-    `)
+    `);
 
     window.METRICS.setupDatePicker(
       `${window.dtMetricsActivity.rest_endpoints_base}/highlights_data/`,
       function (data, label) {
         if (data) {
           $('.date_range_picker span').html(label);
-          buildHighlights(data, label)
+          buildHighlights(data, label);
         }
-      }
-    )
+      },
+    );
 
-    buildHighlights(sourceData.highlights)
+    buildHighlights(sourceData.highlights);
   }
-})
+});
 
-function buildHighlights(data, label = "all time") {
-  console.log(data, label)
+function buildHighlights(data, label = 'all time') {
+  console.log(data, label);
 
   const {
     baptisms,
@@ -63,7 +67,7 @@ function buildHighlights(data, label = "all time") {
     quick_actions_done,
     seeker_path_changed,
     seeker_path_changed_by_others,
-  } = data
+  } = data;
 
   const {
     field_I_changed,
@@ -73,9 +77,11 @@ function buildHighlights(data, label = "all time") {
     baptism_by_others,
     comments_I_liked,
     comments_I_posted,
-  } = window.SHAREDFUNCTIONS.escapeObject(window.dtMetricsActivity.translations)
+  } = window.SHAREDFUNCTIONS.escapeObject(
+    window.dtMetricsActivity.translations,
+  );
 
-  const chartDiv = jQuery('#activity_highlights')
+  const chartDiv = jQuery('#activity_highlights');
 
   chartDiv.html(`
     <div class="grid-x grid-margin-x">
@@ -136,29 +142,31 @@ function buildHighlights(data, label = "all time") {
         </div>
       </div>
     </div>
-    `)
+    `);
 
-    const filterComments = (e) => {
-      const { value } = e.target
+  const filterComments = (e) => {
+    const { value } = e.target;
 
-      if (value === 'all') {
-        jQuery('.liked-comments').show()
-      } else {
-        jQuery('.liked-comments').hide()
-        jQuery(`.comment.${value}`).show()
-      }
+    if (value === 'all') {
+      jQuery('.liked-comments').show();
+    } else {
+      jQuery('.liked-comments').hide();
+      jQuery(`.comment.${value}`).show();
     }
+  };
 
-    document.querySelector('#comment-filter').addEventListener('change' , filterComments)
+  document
+    .querySelector('#comment-filter')
+    .addEventListener('change', filterComments);
 }
 
 function makeTitle(data, title_text) {
-  const { field_label, post_type_label } = data
+  const { field_label, post_type_label } = data;
 
   let title = title_text.replace('%1$s', field_label);
 
   if (post_type_label) {
-    title = title.replace('%2$s', post_type_label)
+    title = title.replace('%2$s', post_type_label);
   }
 
   return title;
@@ -170,7 +178,7 @@ function makeDataTable(data) {
     <div class="left-margin">
       ${none()}
     </div>
-    `
+    `;
   }
 
   return `
@@ -187,11 +195,11 @@ function makeDataTable(data) {
               <td>${info.label}</td>
               <td>${info.count}</td>
             </tr>
-          `
+          `;
         }, '')}
       </tbody>
     </table>
-  `
+  `;
 }
 
 function makeSentence(data) {
@@ -203,10 +211,10 @@ function makeSentence(data) {
           <p>
             <span>${info.count}</span> ${info.label}
           </p>
-        `
+        `;
       }, '')}
     </div>
-  `
+  `;
 }
 
 function makeBaptismsSection(data) {
@@ -215,10 +223,12 @@ function makeBaptismsSection(data) {
     <div class="left-margin">
       ${none()}
     </div>
-    `
+    `;
   }
 
-  const { date, contact } = window.SHAREDFUNCTIONS.escapeObject( window.dtMetricsActivity.translations )
+  const { date, contact } = window.SHAREDFUNCTIONS.escapeObject(
+    window.dtMetricsActivity.translations,
+  );
 
   return `
     <div>
@@ -238,12 +248,12 @@ function makeBaptismsSection(data) {
                 <td>${window.SHAREDFUNCTIONS.formatDate(info.baptism_date)}</td>
                 <td><a href="/contacts/${info.ID}">${info.contact}</a></td>
               </tr>
-            `
+            `;
           }, '')}
         </tbody>
       </table>
     </div>
-  `
+  `;
 }
 
 function makeBaptismsByOthersSection(data) {
@@ -252,12 +262,14 @@ function makeBaptismsByOthersSection(data) {
     <div class="left-margin">
       ${none()}
     </div>
-    `
+    `;
   }
 
-  const { date, contact, baptized_by } = window.SHAREDFUNCTIONS.escapeObject( window.dtMetricsActivity.translations )
+  const { date, contact, baptized_by } = window.SHAREDFUNCTIONS.escapeObject(
+    window.dtMetricsActivity.translations,
+  );
 
-  const baptisms = []
+  const baptisms = [];
 
   return `
     <div>
@@ -271,22 +283,41 @@ function makeBaptismsByOthersSection(data) {
         </thead>
         <tbody>
           ${data.reduce((html, info) => {
+            const {
+              from_name,
+              from_id,
+              to_name,
+              to_id,
+              connection_direction,
+              baptism_date,
+            } = info;
 
-            const {from_name, from_id, to_name, to_id, connection_direction, baptism_date} = info
+            const baptizer_to_baptized_direction =
+              connection_direction === 'connection to';
 
-            const baptizer_to_baptized_direction = connection_direction === 'connection to';
-
-            const baptizer_name = baptizer_to_baptized_direction ? from_name : to_name
-            const baptizer_id = baptizer_to_baptized_direction ? from_id : to_id
-            const contact = baptizer_to_baptized_direction ? to_name : from_name
-            const contact_id = baptizer_to_baptized_direction ? to_id : from_id
+            const baptizer_name = baptizer_to_baptized_direction
+              ? from_name
+              : to_name;
+            const baptizer_id = baptizer_to_baptized_direction
+              ? from_id
+              : to_id;
+            const contact = baptizer_to_baptized_direction
+              ? to_name
+              : from_name;
+            const contact_id = baptizer_to_baptized_direction ? to_id : from_id;
 
             // Don't display duplicate baptisms
-            const baptism = { baptizer_id, contact_id, baptism_date }
+            const baptism = { baptizer_id, contact_id, baptism_date };
 
-            if (baptisms.find((b) => b.baptizer_id === baptizer_id && b.contact_id === contact_id)) return html
+            if (
+              baptisms.find(
+                (b) =>
+                  b.baptizer_id === baptizer_id && b.contact_id === contact_id,
+              )
+            )
+              return html;
 
-            baptisms.push(baptism)
+            baptisms.push(baptism);
 
             return `
               ${html}
@@ -295,34 +326,36 @@ function makeBaptismsByOthersSection(data) {
                 <td><a href="/contacts/${contact_id}">${contact}</a></td>
                 <td>${baptizer_name}</td>
               </tr>
-            `
+            `;
           }, '')}
         </tbody>
       </table>
     </div>
-  `
+  `;
 }
 
 function makeCommentsSection(data) {
   if (empty(data)) {
-    return none()
+    return none();
   }
 
-  const { group, contact } = window.dtMetricsActivity.translations
+  const { group, contact } = window.dtMetricsActivity.translations;
 
   const postTypeLabels = {
-    'contacts': window.SHAREDFUNCTIONS.escapeHTML(contact),
-    'groups': window.SHAREDFUNCTIONS.escapeHTML(group),
-  }
+    contacts: window.SHAREDFUNCTIONS.escapeHTML(contact),
+    groups: window.SHAREDFUNCTIONS.escapeHTML(group),
+  };
 
   return `
     <div id="comment-activity-section">
       ${data.reduce((html, info) => {
         const reactionClasses = info.reactions
-          ? [{key: 'liked-comments'}, ...info.reactions].map((reaction) => reaction.key).join(' ')
-          : ''
+          ? [{ key: 'liked-comments' }, ...info.reactions]
+              .map((reaction) => reaction.key)
+              .join(' ')
+          : '';
 
-        const epochDateTime = (new Date(info.comment_date)).getTime() / 1000;
+        const epochDateTime = new Date(info.comment_date).getTime() / 1000;
 
         return `
           ${html}
@@ -336,25 +369,30 @@ function makeCommentsSection(data) {
               <div class="comment-bubble">${window.SHAREDFUNCTIONS.formatComment(info.comment_content)}</div>
               <div class="comment-controls">
                 <div class="comment-reactions">
-                  ${info.reactions
-                      ? info.reactions.reduce((reactionsHtml, { name, emoji, path }) => {
-                          return `
+                  ${
+                    info.reactions
+                      ? info.reactions.reduce(
+                          (reactionsHtml, { name, emoji, path }) => {
+                            return `
                             ${reactionsHtml}
                             <div class="comment-reaction" title="${name}">
                               <span>
                                 ${displayReaction({ path, emoji })}
                               </span>
-                            </div>`
-                        }, '')
-                      : ''}
+                            </div>`;
+                          },
+                          '',
+                        )
+                      : ''
+                  }
                 </div>
               </div>
             </div>
           </div>
-        `
+        `;
       }, '')}
     </div>
-  `
+  `;
 }
 
 function makeRecordsCreatedSection(data) {
@@ -366,30 +404,34 @@ function makeRecordsCreatedSection(data) {
 }
 
 function makeCommentFilterSelect() {
-  const { reaction_options, translations } = window.dtMetricsActivity
+  const { reaction_options, translations } = window.dtMetricsActivity;
 
-  const { all } = translations
+  const { all } = translations;
 
   return `
     <select id="comment-filter">
       <option value="all">${window.SHAREDFUNCTIONS.escapeHTML(all)}</option>
-      ${Object.entries(reaction_options).map(([key, reaction]) => `
+      ${Object.entries(reaction_options).map(
+        ([key, reaction]) => `
         <option value="${key}">${displayReaction(reaction)}</option>
-      `)}
+      `,
+      )}
     </select>
-  `
+  `;
 }
 
 function displayReaction({ emoji, path }) {
-  return (emoji && emoji !== '') ? emoji : `<img class="emoji" src="${path}">`
+  return emoji && emoji !== '' ? emoji : `<img class="emoji" src="${path}">`;
 }
 
 function empty(data) {
-  return !data || data.length === 0
+  return !data || data.length === 0;
 }
 
 function none() {
-  const { none } = window.SHAREDFUNCTIONS.escapeObject(window.dtMetricsActivity.translations)
+  const { none } = window.SHAREDFUNCTIONS.escapeObject(
+    window.dtMetricsActivity.translations,
+  );
 
   return none;
 }

--- a/dt-metrics/personal/activity-log.js
+++ b/dt-metrics/personal/activity-log.js
@@ -1,49 +1,55 @@
-jQuery(document).ready(function() {
-  if ( window.wpApiShare.url_path.startsWith( 'metrics/personal/activity-log' ) ) {
-    my_stats()
+jQuery(document).ready(function () {
+  if (window.wpApiShare.url_path.startsWith('metrics/personal/activity-log')) {
+    my_stats();
   }
 
   function my_stats() {
-    "use strict";
-    const metricsContentDiv = jQuery('#metrics-content')
+    'use strict';
+    const metricsContentDiv = jQuery('#metrics-content');
 
     metricsContentDiv.removeClass(function (index, className) {
-      return (className.match (/(^|\s)large-\S+/g) || []).join(' ');
-    })
-    metricsContentDiv.addClass('large-6')
-    let chartDiv = jQuery('#chart')
-    let sourceData = window.dtMetricsActivity.data
-    let translations = window.dtMetricsActivity.data.translations
+      return (className.match(/(^|\s)large-\S+/g) || []).join(' ');
+    });
+    metricsContentDiv.addClass('large-6');
+    let chartDiv = jQuery('#chart');
+    let sourceData = window.dtMetricsActivity.data;
+    let translations = window.dtMetricsActivity.data.translations;
 
     jQuery('#metrics-sidemenu').foundation('down', jQuery('#personal-menu'));
 
     /* activity */
-    const user_id = sourceData.user_id
+    const user_id = sourceData.user_id;
 
-    window.makeRequest( "get", `activity-log`, null , 'dt-users/v1/')
-    .done(activity=>{
+    window
+      .makeRequest('get', `activity-log`, null, 'dt-users/v1/')
+      .done((activity) => {
+        const title = makeTitle(
+          window.SHAREDFUNCTIONS.escapeHTML(translations.title),
+        );
+        const activity_html = window.dtActivityLogs.makeActivityList(
+          activity,
+          translations,
+        );
 
-      const title = makeTitle(window.SHAREDFUNCTIONS.escapeHTML( translations.title ))
-      const activity_html = window.dtActivityLogs.makeActivityList(activity, translations)
-
-      let html = `
+        let html = `
         ${title}
         <div className="activity">
           ${activity_html}
         </div>
-      `
-      chartDiv.empty().html( html )
-    }).catch((e)=>{
-      console.log( 'error in activity')
-      console.log( e)
-    })
+      `;
+        chartDiv.empty().html(html);
+      })
+      .catch((e) => {
+        console.log('error in activity');
+        console.log(e);
+      });
   }
-})
+});
 
 function makeTitle(title) {
   return `
     <div class="cell center">
-      <h3>${ title }</h3>
+      <h3>${title}</h3>
     </div>
-  `
+  `;
 }

--- a/dt-metrics/personal/baptism-tree.js
+++ b/dt-metrics/personal/baptism-tree.js
@@ -1,20 +1,20 @@
-jQuery(document).ready(function() {
-  if ( window.wpApiShare.url_path.startsWith( 'metrics/personal/baptism-tree' ) ) {
-    baptism_tree()
+jQuery(document).ready(function () {
+  if (window.wpApiShare.url_path.startsWith('metrics/personal/baptism-tree')) {
+    baptism_tree();
   }
 
   function baptism_tree() {
-    "use strict";
-    let chart = jQuery('#chart')
-    let spinner = ' <span class="loading-spinner active"></span> '
+    'use strict';
+    let chart = jQuery('#chart');
+    let spinner = ' <span class="loading-spinner active"></span> ';
 
-    chart.empty().html(spinner)
+    chart.empty().html(spinner);
     jQuery('#metrics-sidemenu').foundation('down', jQuery('#personal-menu'));
 
-    let translations = window.dtMetricsProject.data.translations
+    let translations = window.dtMetricsProject.data.translations;
 
     chart.empty().html(`
-        <span class="section-header">${ window.SHAREDFUNCTIONS.escapeHTML( translations.title_baptism_tree ) }</span><hr>
+        <span class="section-header">${window.SHAREDFUNCTIONS.escapeHTML(translations.title_baptism_tree)}</span><hr>
         <div class="grid-x grid-padding-x">
             <div class="cell">
                 <div class="scrolling-wrapper" id="generation_map">${spinner}</div>
@@ -22,14 +22,13 @@ jQuery(document).ready(function() {
         </div>
         <div id="modal" class="reveal" data-reveal></div>
         <br><br>
-       `)
+       `);
 
-    window.makeRequest('POST', 'metrics/my/baptism_tree' )
-      .then(response => {
-        // console.log(response)
-        jQuery('#generation_map').empty().html(response)
-        jQuery('#generation_map li:last-child').addClass('last');
-        new window.Foundation.Reveal(jQuery('#modal'))
-      })
+    window.makeRequest('POST', 'metrics/my/baptism_tree').then((response) => {
+      // console.log(response)
+      jQuery('#generation_map').empty().html(response);
+      jQuery('#generation_map li:last-child').addClass('last');
+      new window.Foundation.Reveal(jQuery('#modal'));
+    });
   }
-})
+});

--- a/dt-metrics/personal/coaching-tree.js
+++ b/dt-metrics/personal/coaching-tree.js
@@ -1,19 +1,19 @@
-jQuery(document).ready(function() {
-  if ( window.wpApiShare.url_path.startsWith( 'metrics/personal/coaching-tree' ) ) {
-    coaching_tree()
+jQuery(document).ready(function () {
+  if (window.wpApiShare.url_path.startsWith('metrics/personal/coaching-tree')) {
+    coaching_tree();
   }
 
   function coaching_tree() {
-    "use strict";
-    let chart = jQuery('#chart')
-    let spinner = ' <span class="loading-spinner active"></span> '
-    chart.empty().html(spinner)
+    'use strict';
+    let chart = jQuery('#chart');
+    let spinner = ' <span class="loading-spinner active"></span> ';
+    chart.empty().html(spinner);
     jQuery('#metrics-sidemenu').foundation('down', jQuery('#personal-menu'));
 
-    let translations = window.dtMetricsProject.data.translations
+    let translations = window.dtMetricsProject.data.translations;
 
     chart.empty().html(`
-        <span class="section-header">${ window.SHAREDFUNCTIONS.escapeHTML( translations.title_coaching_tree ) }</span><hr>
+        <span class="section-header">${window.SHAREDFUNCTIONS.escapeHTML(translations.title_coaching_tree)}</span><hr>
         <div class="grid-x grid-padding-x">
             <div class="cell">
                 <div class="scrolling-wrapper" id="generation_map">${spinner}</div>
@@ -21,15 +21,13 @@ jQuery(document).ready(function() {
         </div>
         <div id="modal" class="reveal" data-reveal></div>
         <br><br>
-       `)
+       `);
 
-    window.makeRequest('POST', 'metrics/my/coaching_tree' )
-      .then(response => {
-        // console.log(response)
-        jQuery('#generation_map').empty().html(response)
-        jQuery('#generation_map li:last-child').addClass('last');
-        new window.Foundation.Reveal(jQuery('#modal'))
-      })
+    window.makeRequest('POST', 'metrics/my/coaching_tree').then((response) => {
+      // console.log(response)
+      jQuery('#generation_map').empty().html(response);
+      jQuery('#generation_map li:last-child').addClass('last');
+      new window.Foundation.Reveal(jQuery('#modal'));
+    });
   }
-
-})
+});

--- a/dt-metrics/personal/group-tree.js
+++ b/dt-metrics/personal/group-tree.js
@@ -1,27 +1,27 @@
-"use strict";
-jQuery(document).ready(function() {
-  if ( window.wpApiShare.url_path.startsWith( 'metrics/personal/group-tree' )) {
-    group_tree()
+'use strict';
+jQuery(document).ready(function () {
+  if (window.wpApiShare.url_path.startsWith('metrics/personal/group-tree')) {
+    group_tree();
   }
 
   function group_tree() {
-    let chart = jQuery('#chart')
-    let spinner = ' <span class="loading-spinner active"></span> '
+    let chart = jQuery('#chart');
+    let spinner = ' <span class="loading-spinner active"></span> ';
 
-    chart.empty().html(spinner)
+    chart.empty().html(spinner);
     jQuery('#metrics-sidemenu').foundation('down', jQuery('#personal-menu'));
 
-    let translations = window.dtMetricsProject.data.translations
+    let translations = window.dtMetricsProject.data.translations;
 
     chart.empty().html(`
           <span class="section-header">${window.SHAREDFUNCTIONS.escapeHTML(translations.title_group_tree)}</span><hr>
            <div class="grid-x grid-padding-x">
            <div class="cell">
                <span>
-                  <button class="button hollow toggle-singles" id="highlight-active" onclick="highlight_active();">${window.SHAREDFUNCTIONS.escapeHTML(translations.highlight_active)/*Highlight Active*/}</button>
+                  <button class="button hollow toggle-singles" id="highlight-active" onclick="highlight_active();">${window.SHAREDFUNCTIONS.escapeHTML(translations.highlight_active) /*Highlight Active*/}</button>
                </span>
               <span>
-                  <button class="button hollow toggle-singles" id="highlight-churches" onclick="highlight_churches();">${window.SHAREDFUNCTIONS.escapeHTML(translations.highlight_churches)/*Highlight Churches*/}</button>
+                  <button class="button hollow toggle-singles" id="highlight-churches" onclick="highlight_churches();">${window.SHAREDFUNCTIONS.escapeHTML(translations.highlight_churches) /*Highlight Churches*/}</button>
               </span>
           </div>
               <div class="cell">
@@ -30,90 +30,95 @@ jQuery(document).ready(function() {
           </div>
            <div id="modal" class="reveal" data-reveal></div>
            <br><br>
-       `)
+       `);
 
-    window.makeRequest('POST', 'metrics/my/group_tree' )
-      .then(response => {
-        // console.log(response)
-        jQuery('#generation_map').empty().html(response)
-        jQuery('#generation_map li:last-child').addClass('last');
-        new window.Foundation.Reveal(jQuery('#modal'))
-      })
+    window.makeRequest('POST', 'metrics/my/group_tree').then((response) => {
+      // console.log(response)
+      jQuery('#generation_map').empty().html(response);
+      jQuery('#generation_map li:last-child').addClass('last');
+      new window.Foundation.Reveal(jQuery('#modal'));
+    });
   }
-})
+});
 
-function open_modal_details( id ) {
-  let modal = jQuery('#modal')
-  let spinner = ' <span class="loading-spinner active"></span> '
-  let translations = window.dtMetricsProject.data.translations
+function open_modal_details(id) {
+  let modal = jQuery('#modal');
+  let spinner = ' <span class="loading-spinner active"></span> ';
+  let translations = window.dtMetricsProject.data.translations;
 
-  modal.empty().html(spinner).foundation('open')
+  modal.empty().html(spinner).foundation('open');
 
-  window.makeRequest('GET', 'groups/'+id, null, 'dt-posts/v2/' )
-    .then(data => {
+  window
+    .makeRequest('GET', 'groups/' + id, null, 'dt-posts/v2/')
+    .then((data) => {
       // console.log(data)
-      if( data ) {
-        let list = '<dt>'+window.SHAREDFUNCTIONS.escapeHTML( translations.members )+'</dt><ul>'
-        jQuery.each(data.members, function(i, v)  { list += `<li><a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/contacts/${window.SHAREDFUNCTIONS.escapeHTML( data.members[i].ID )}">${window.SHAREDFUNCTIONS.escapeHTML( data.members[i].post_title )}</a></li>` } )
-        let assigned_to = ''
+      if (data) {
+        let list =
+          '<dt>' +
+          window.SHAREDFUNCTIONS.escapeHTML(translations.members) +
+          '</dt><ul>';
+        jQuery.each(data.members, function (i, v) {
+          list += `<li><a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/contacts/${window.SHAREDFUNCTIONS.escapeHTML(data.members[i].ID)}">${window.SHAREDFUNCTIONS.escapeHTML(data.members[i].post_title)}</a></li>`;
+        });
+        let assigned_to = '';
         if (typeof data.assigned_to !== 'undefined') {
-          assigned_to = data.assigned_to['display']
+          assigned_to = data.assigned_to['display'];
         }
-        list += '</ul>'
+        list += '</ul>';
         let content = `
                 <div class="grid-x">
-                    <div class="cell"><span class="section-header">${window.SHAREDFUNCTIONS.escapeHTML( data.title )}</span><hr style="max-width:100%;"></div>
+                    <div class="cell"><span class="section-header">${window.SHAREDFUNCTIONS.escapeHTML(data.title)}</span><hr style="max-width:100%;"></div>
                     <div class="cell">
                         <dl>
-                            <dd><strong>${window.SHAREDFUNCTIONS.escapeHTML( translations.status ) /*Status*/}: </strong>${window.SHAREDFUNCTIONS.escapeHTML( data.group_status.label )}</dd>
-                      <dd><strong>${window.SHAREDFUNCTIONS.escapeHTML( translations.assigned_to )/*Assigned to*/}: </strong>${window.SHAREDFUNCTIONS.escapeHTML( assigned_to )}</dd>
-                      <dd><strong>${window.SHAREDFUNCTIONS.escapeHTML( translations.total_members ) /*Total Members*/}: </strong>${window.SHAREDFUNCTIONS.escapeHTML( data.member_count )}</dd>
+                            <dd><strong>${window.SHAREDFUNCTIONS.escapeHTML(translations.status) /*Status*/}: </strong>${window.SHAREDFUNCTIONS.escapeHTML(data.group_status.label)}</dd>
+                      <dd><strong>${window.SHAREDFUNCTIONS.escapeHTML(translations.assigned_to) /*Assigned to*/}: </strong>${window.SHAREDFUNCTIONS.escapeHTML(assigned_to)}</dd>
+                      <dd><strong>${window.SHAREDFUNCTIONS.escapeHTML(translations.total_members) /*Total Members*/}: </strong>${window.SHAREDFUNCTIONS.escapeHTML(data.member_count)}</dd>
                             ${list}
                         </dl>
                     </div>
-                    <div class="cell center"><hr><a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/groups/${window.SHAREDFUNCTIONS.escapeHTML( id )}">${window.SHAREDFUNCTIONS.escapeHTML(translations.view_group)}</a></div>
+                    <div class="cell center"><hr><a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/groups/${window.SHAREDFUNCTIONS.escapeHTML(id)}">${window.SHAREDFUNCTIONS.escapeHTML(translations.view_group)}</a></div>
                 </div>
                 <button class="close-button" data-close aria-label="Close modal" type="button">
                     <span aria-hidden="true">&times;</span>
                   </button>
-                `
-        modal.empty().html(content)
+                `;
+        modal.empty().html(content);
       }
-    })
+    });
 }
 
-function toggle_multiplying_only () {
-  let list = jQuery('#generation_map .li-gen-1:not(:has(li.li-gen-2))')
-  let button = jQuery('#multiplying-only')
-  if( button.hasClass('hollow') ) {
-    list.hide()
-    button.removeClass('hollow')
+function toggle_multiplying_only() {
+  let list = jQuery('#generation_map .li-gen-1:not(:has(li.li-gen-2))');
+  let button = jQuery('#multiplying-only');
+  if (button.hasClass('hollow')) {
+    list.hide();
+    button.removeClass('hollow');
   } else {
-    button.addClass('hollow')
-    list.show()
+    button.addClass('hollow');
+    list.show();
   }
 }
 
 function highlight_active() {
-  let list = jQuery('.inactive')
-  let button = jQuery('#highlight-active')
-  if( button.hasClass('hollow') ) {
-    list.addClass('inactive-gray')
-    button.removeClass('hollow')
+  let list = jQuery('.inactive');
+  let button = jQuery('#highlight-active');
+  if (button.hasClass('hollow')) {
+    list.addClass('inactive-gray');
+    button.removeClass('hollow');
   } else {
-    button.addClass('hollow')
-    list.removeClass('inactive-gray')
+    button.addClass('hollow');
+    list.removeClass('inactive-gray');
   }
 }
 
 function highlight_churches() {
-  let list = jQuery('#generation_map span:not(.church)')
-  let button = jQuery('#highlight-churches')
-  if( button.hasClass('hollow') ) {
-    list.addClass('not-church-gray')
-    button.removeClass('hollow')
+  let list = jQuery('#generation_map span:not(.church)');
+  let button = jQuery('#highlight-churches');
+  if (button.hasClass('hollow')) {
+    list.addClass('not-church-gray');
+    button.removeClass('hollow');
   } else {
-    button.addClass('hollow')
-    list.removeClass('not-church-gray')
+    button.addClass('hollow');
+    list.removeClass('not-church-gray');
   }
 }

--- a/dt-metrics/personal/overview.js
+++ b/dt-metrics/personal/overview.js
@@ -1,56 +1,59 @@
-jQuery(function() {
-  if ('metrics' === window.wpApiShare.url_path || 'metrics/' === window.wpApiShare.url_path || window.wpApiShare.url_path.startsWith( 'metrics/personal/overview' ) ) {
-    my_stats()
+jQuery(function () {
+  if (
+    'metrics' === window.wpApiShare.url_path ||
+    'metrics/' === window.wpApiShare.url_path ||
+    window.wpApiShare.url_path.startsWith('metrics/personal/overview')
+  ) {
+    my_stats();
   }
 
   async function my_stats() {
-    "use strict";
-    let chartDiv = jQuery('#chart')
+    'use strict';
+    let chartDiv = jQuery('#chart');
 
-    let sourceData = await fetch(
-      window.dtMetricsPersonal.rest_url + '/data',
-      { headers: { 'X-WP-Nonce': window.dtMetricsPersonal.nonce } }
-    ).then( response => response.json() )
+    let sourceData = await fetch(window.dtMetricsPersonal.rest_url + '/data', {
+      headers: { 'X-WP-Nonce': window.dtMetricsPersonal.nonce },
+    }).then((response) => response.json());
 
-    let translations = window.dtMetricsPersonal.translations
+    let translations = window.dtMetricsPersonal.translations;
 
     jQuery('#metrics-sidemenu').foundation('down', jQuery('#personal-menu'));
 
     let html = `
       <div class="cell center">
-          <h3 >${ window.SHAREDFUNCTIONS.escapeHTML( translations.title ) }</h3>
+          <h3 >${window.SHAREDFUNCTIONS.escapeHTML(translations.title)}</h3>
       </div>
       <br><br>
       <div class="grid-x grid-padding-x grid-padding-y">
-        <h3 class="section-header">${ window.SHAREDFUNCTIONS.escapeHTML( translations.title_contacts ) }</h3>
+        <h3 class="section-header">${window.SHAREDFUNCTIONS.escapeHTML(translations.title_contacts)}</h3>
         <div class="cell center callout">
             <div class="grid-x">
                 <div class="medium-4 cell center ">
-                    <h5>${ window.SHAREDFUNCTIONS.escapeHTML( translations.title_waiting_on_accept ) }<br><span id="needs_accepted">0</span></h5>
+                    <h5>${window.SHAREDFUNCTIONS.escapeHTML(translations.title_waiting_on_accept)}<br><span id="needs_accepted">0</span></h5>
                 </div>
                 <div class="medium-4 cell center left-border-grey">
-                    <h5>${ window.SHAREDFUNCTIONS.escapeHTML( translations.title_waiting_on_update ) }<br><span id="updates_needed">0</span></h5>
+                    <h5>${window.SHAREDFUNCTIONS.escapeHTML(translations.title_waiting_on_update)}<br><span id="updates_needed">0</span></h5>
                 </div>
                 <div class="medium-4 cell center left-border-grey">
-                    <h5>${ window.SHAREDFUNCTIONS.escapeHTML( translations.label_active_contacts ) }<br><span id="contacts">0</span></h5>
+                    <h5>${window.SHAREDFUNCTIONS.escapeHTML(translations.label_active_contacts)}<br><span id="contacts">0</span></h5>
                 </div>
             </div>
-        </div>`
-      if ( sourceData.contacts_progress ){
-        html += `<div class="cell">
+        </div>`;
+    if (sourceData.contacts_progress) {
+      html += `<div class="cell">
             <div id="my_contacts_progress" style="height: 350px; width=100%"></div>
-        </div>`
-      }
+        </div>`;
+    }
 
-      html += `<h3 class="section-header" style="margin-top:40px;">${ window.SHAREDFUNCTIONS.escapeHTML( translations.title_groups ) }</h3>
+    html += `<h3 class="section-header" style="margin-top:40px;">${window.SHAREDFUNCTIONS.escapeHTML(translations.title_groups)}</h3>
         <div class="cell">
             <div class="cell center callout">
                 <div class="grid-x">
                     <div class="medium-4 cell center">
-                        <h5>${ window.SHAREDFUNCTIONS.escapeHTML( translations.title_total_groups ) }<br><span id="total_groups">0</span></h5>
+                        <h5>${window.SHAREDFUNCTIONS.escapeHTML(translations.title_total_groups)}<br><span id="total_groups">0</span></h5>
                     </div>
                     <div class="medium-4 cell center left-border-grey">
-                        <h5>${ window.SHAREDFUNCTIONS.escapeHTML( translations.title_teams ) }<br><span id="teams">0</span></h5>
+                        <h5>${window.SHAREDFUNCTIONS.escapeHTML(translations.title_teams)}<br><span id="teams">0</span></h5>
                     </div>
                </div>
             </div>
@@ -70,75 +73,79 @@ jQuery(function() {
                 </div>
             </div>
         </div>
-      </div>`
+      </div>`;
 
-    chartDiv.empty().html( html )
+    chartDiv.empty().html(html);
 
-    let hero = sourceData.hero_stats
-    jQuery('#contacts').html( numberWithCommas( hero.contacts ) )
-    jQuery('#needs_accepted').html( numberWithCommas( hero.needs_accept ) )
-    jQuery('#updates_needed').html( numberWithCommas( hero.needs_update ) )
+    let hero = sourceData.hero_stats;
+    jQuery('#contacts').html(numberWithCommas(hero.contacts));
+    jQuery('#needs_accepted').html(numberWithCommas(hero.needs_accept));
+    jQuery('#updates_needed').html(numberWithCommas(hero.needs_update));
 
-    jQuery('#total_groups').html( numberWithCommas( hero.groups ) )
-    jQuery('#teams').html( numberWithCommas( hero.teams ) )
+    jQuery('#total_groups').html(numberWithCommas(hero.groups));
+    jQuery('#teams').html(numberWithCommas(hero.teams));
 
-
-
-    if ( sourceData.contacts_progress ){
+    if (sourceData.contacts_progress) {
       // build charts
-      drawMyContactsProgress()
+      drawMyContactsProgress();
     }
-    if ( sourceData.preferences.groups.church_metrics ) {
+    if (sourceData.preferences.groups.church_metrics) {
       drawMyGroupHealth();
     } else {
-      jQuery('#my_groups_health_container').remove()
+      jQuery('#my_groups_health_container').remove();
     }
     drawGroupTypes();
     drawGroupGenerations();
 
     function drawMyContactsProgress() {
-      let chart = window.am4core.create("my_contacts_progress", window.am4charts.XYChart)
-      let title = chart.titles.create()
-      title.text = `[bold]${ translations.label_my_follow_up_progress }[/]`
-      chart.data = sourceData.contacts_progress.reverse()
+      let chart = window.am4core.create(
+        'my_contacts_progress',
+        window.am4charts.XYChart,
+      );
+      let title = chart.titles.create();
+      title.text = `[bold]${translations.label_my_follow_up_progress}[/]`;
+      chart.data = sourceData.contacts_progress.reverse();
 
       let categoryAxis = chart.yAxes.push(new window.am4charts.CategoryAxis());
-      categoryAxis.dataFields.category = "label";
+      categoryAxis.dataFields.category = 'label';
       categoryAxis.renderer.grid.template.location = 0;
       categoryAxis.renderer.minGridDistance = 30;
 
       let valueAxis = chart.xAxes.push(new window.am4charts.ValueAxis());
-      valueAxis.title.text = "Number of contacts"
+      valueAxis.title.text = 'Number of contacts';
 
       let series = chart.series.push(new window.am4charts.ColumnSeries());
-      series.dataFields.valueX = "value";
-      series.dataFields.categoryY = "label";
-      series.columns.template.tooltipText = "Total: [bold]{valueX}[/]";
+      series.dataFields.valueX = 'value';
+      series.dataFields.categoryY = 'label';
+      series.columns.template.tooltipText = 'Total: [bold]{valueX}[/]';
 
       // field value label
       let valueLabel = series.bullets.push(new window.am4charts.LabelBullet());
-      valueLabel.label.text = "{valueX}";
-      valueLabel.label.horizontalCenter = "left";
+      valueLabel.label.text = '{valueX}';
+      valueLabel.label.horizontalCenter = 'left';
       valueLabel.label.dx = 10;
       valueLabel.label.hideOversized = false;
       valueLabel.label.truncate = false;
-
     }
 
     function drawMyGroupHealth() {
-      let chart = window.am4core.create("my_groups_health", window.am4charts.XYChart);
-      chart.data = sourceData.group_health
-      let title = chart.titles.create()
-      title.text = `[bold]${ translations.label_group_needing_training }[/]`
+      let chart = window.am4core.create(
+        'my_groups_health',
+        window.am4charts.XYChart,
+      );
+      chart.data = sourceData.group_health;
+      let title = chart.titles.create();
+      title.text = `[bold]${translations.label_group_needing_training}[/]`;
       let categoryAxis = chart.xAxes.push(new window.am4charts.CategoryAxis());
-      categoryAxis.dataFields.category = "label";
+      categoryAxis.dataFields.category = 'label';
       categoryAxis.renderer.grid.template.location = 0;
       categoryAxis.renderer.minGridDistance = 20;
-      categoryAxis.renderer.labels.template.wrap = true
-      categoryAxis.events.on("sizechanged", function(ev) {
+      categoryAxis.renderer.labels.template.wrap = true;
+      categoryAxis.events.on('sizechanged', function (ev) {
         var axis = ev.target;
         var cellWidth = axis.pixelWidth / (axis.endIndex - axis.startIndex);
-        axis.renderer.labels.template.maxWidth = cellWidth > 70 ? cellWidth : 70;
+        axis.renderer.labels.template.maxWidth =
+          cellWidth > 70 ? cellWidth : 70;
         axis.renderer.labels.template.disabled = cellWidth < 70;
       });
 
@@ -148,63 +155,70 @@ jQuery(function() {
       valueAxis.strictMinMax = true;
       valueAxis.calculateTotals = true;
       valueAxis.renderer.minWidth = 50;
-      valueAxis.renderer.labels.template.adapter.add("text", function(text) {
-        return text + "%";
+      valueAxis.renderer.labels.template.adapter.add('text', function (text) {
+        return text + '%';
       });
 
       let series1 = chart.series.push(new window.am4charts.ColumnSeries());
       series1.columns.template.width = window.am4core.percent(80);
-      series1.columns.template.tooltipText = "{name}: {valueY}";
-      series1.name = "Practicing";
-      series1.dataFields.categoryX = "label";
-      series1.dataFields.valueY = "practicing";
-      series1.dataFields.valueYShow = "totalPercent";
+      series1.columns.template.tooltipText = '{name}: {valueY}';
+      series1.name = 'Practicing';
+      series1.dataFields.categoryX = 'label';
+      series1.dataFields.valueY = 'practicing';
+      series1.dataFields.valueYShow = 'totalPercent';
       series1.dataItems.template.locations.categoryX = 0.5;
       series1.stacked = true;
-      series1.tooltip.pointerOrientation = "vertical";
+      series1.tooltip.pointerOrientation = 'vertical';
 
       let series2 = chart.series.push(new window.am4charts.ColumnSeries());
-      series2.stroke = window.am4core.color("#da7070"); // red
-      series2.fill = window.am4core.color("#da7070"); // red
+      series2.stroke = window.am4core.color('#da7070'); // red
+      series2.fill = window.am4core.color('#da7070'); // red
       series2.columns.template.width = window.am4core.percent(80);
-      series2.columns.template.tooltipText =
-        "{name}: {valueY}";
-      series2.name = "Not Practicing";
-      series2.dataFields.categoryX = "label";
-      series2.dataFields.valueY = "remaining";
-      series2.dataFields.valueYShow = "totalPercent";
+      series2.columns.template.tooltipText = '{name}: {valueY}';
+      series2.name = 'Not Practicing';
+      series2.dataFields.categoryX = 'label';
+      series2.dataFields.valueY = 'remaining';
+      series2.dataFields.valueYShow = 'totalPercent';
       series2.dataItems.template.locations.categoryX = 0.5;
       series2.stacked = true;
-      series2.tooltip.pointerOrientation = "vertical";
+      series2.tooltip.pointerOrientation = 'vertical';
       chart.legend = new window.am4charts.Legend();
-
     }
 
     function drawGroupTypes() {
-      let chart = window.am4core.create("group_types", window.am4charts.PieChart);
-      let title = chart.titles.create()
-      title.text = `[bold]${ translations.title_group_types }[/]`
-      chart.data = sourceData.group_types
+      let chart = window.am4core.create(
+        'group_types',
+        window.am4charts.PieChart,
+      );
+      let title = chart.titles.create();
+      title.text = `[bold]${translations.title_group_types}[/]`;
+      chart.data = sourceData.group_types;
       let pieSeries = chart.series.push(new window.am4charts.PieSeries());
-      pieSeries.dataFields.value = "count";
-      pieSeries.dataFields.category = "label";
+      pieSeries.dataFields.value = 'count';
+      pieSeries.dataFields.category = 'label';
       pieSeries.labels.template.disabled = true;
       chart.innerRadius = window.am4core.percent(30);
       chart.legend = new window.am4charts.Legend();
     }
 
     function drawGroupGenerations() {
-      let chart = window.am4core.create("group_generations", window.am4charts.XYChart);
-      let title = chart.titles.create()
-      title.text = `[bold]${ translations.title_generations }[/]`
+      let chart = window.am4core.create(
+        'group_generations',
+        window.am4charts.XYChart,
+      );
+      let title = chart.titles.create();
+      title.text = `[bold]${translations.title_generations}[/]`;
 
-      chart.data = sourceData.group_generations.reverse()
+      chart.data = sourceData.group_generations.reverse();
       let categoryAxis = chart.yAxes.push(new window.am4charts.CategoryAxis());
-      categoryAxis.dataFields.category = "generation";
+      categoryAxis.dataFields.category = 'generation';
       categoryAxis.renderer.grid.template.location = 0;
-      categoryAxis.renderer.labels.template.adapter.add("text", function(text) {
-        return translations.label_generation + ' ' + text;
-      });
+      categoryAxis.renderer.labels.template.adapter.add(
+        'text',
+        function (text) {
+          return translations.label_generation + ' ' + text;
+        },
+      );
 
       let valueAxis = chart.xAxes.push(new window.am4charts.ValueAxis());
       valueAxis.renderer.inside = true;
@@ -226,12 +240,14 @@ jQuery(function() {
         let series = chart.series.push(new window.am4charts.ColumnSeries());
         series.name = name;
         series.dataFields.valueX = field;
-        series.dataFields.categoryY = "generation";
+        series.dataFields.categoryY = 'generation';
         series.stacked = true;
         series.columns.template.width = window.am4core.percent(60);
-        series.columns.template.tooltipText = "[bold]{name}[/]\n {valueX}";
-        let labelBullet = series.bullets.push(new window.am4charts.LabelBullet());
-        labelBullet.label.text = "{valueX}";
+        series.columns.template.tooltipText = '[bold]{name}[/]\n {valueX}';
+        let labelBullet = series.bullets.push(
+          new window.am4charts.LabelBullet(),
+        );
+        labelBullet.label.text = '{valueX}';
         labelBullet.locationX = 0.5;
         return series;
       }
@@ -241,7 +257,13 @@ jQuery(function() {
       jQuery.each(chart.data, function (idx, generation) {
         jQuery.each(generation, function (key, value) {
           let group_type = fetchGroupType(key);
-          if (group_type && !Object.prototype.hasOwnProperty.call(group_type_set, group_type['type'])) {
+          if (
+            group_type &&
+            !Object.prototype.hasOwnProperty.call(
+              group_type_set,
+              group_type['type'],
+            )
+          ) {
             group_type_set[group_type['type']] = group_type;
           }
         });
@@ -256,14 +278,12 @@ jQuery(function() {
     }
 
     new window.Foundation.Reveal(jQuery('.dt-project-legend'));
-
   }
-})
+});
 
 function numberWithCommas(x) {
   x = (x || 0).toString();
   let pattern = /(-?\d+)(\d{3})/;
-  while (pattern.test(x))
-    x = x.replace(pattern, "$1,$2");
+  while (pattern.test(x)) x = x.replace(pattern, '$1,$2');
   return x;
 }

--- a/dt-metrics/records/date-range-activity.js
+++ b/dt-metrics/records/date-range-activity.js
@@ -1,19 +1,21 @@
 jQuery(function () {
-  if (window.wpApiShare.url_path.startsWith('metrics/records/date_range_activity')) {
+  if (
+    window.wpApiShare.url_path.startsWith('metrics/records/date_range_activity')
+  ) {
     project_activity_during_date_range();
   }
 });
 
 const getFieldSettings = (postType) =>
-  window.makeRequest('GET', `metrics/date_range_field_settings/${postType}`)
+  window.makeRequest('GET', `metrics/date_range_field_settings/${postType}`);
 
 const renderFieldHtml = (data) =>
-  window.makeRequest('GET', `metrics/render_field_html`, data)
+  window.makeRequest('GET', `metrics/render_field_html`, data);
 
 const getDateRangeActivity = (data) =>
-  window.makeRequest('POST', `metrics/date_range_activity`, data)
+  window.makeRequest('POST', `metrics/date_range_activity`, data);
 
-const escapeObject = window.SHAREDFUNCTIONS.escapeObject
+const escapeObject = window.SHAREDFUNCTIONS.escapeObject;
 
 function project_activity_during_date_range() {
   const chartDiv = document.querySelector('#chart');
@@ -28,10 +30,12 @@ function project_activity_during_date_range() {
     total_label,
     results_table_head_title_label,
     results_table_head_date_label,
-    results_table_head_new_value_label
+    results_table_head_new_value_label,
   } = escapeObject(window.dtMetricsProject.translations);
 
-  const postTypeOptions = escapeObject(window.dtMetricsProject.select_options.post_type_select_options);
+  const postTypeOptions = escapeObject(
+    window.dtMetricsProject.select_options.post_type_select_options,
+  );
 
   jQuery('#metrics-sidemenu').foundation('down', jQuery('#records-menu'));
 
@@ -41,9 +45,11 @@ function project_activity_during_date_range() {
     <section class="chart-controls">
         <label class="section-subheader" for="post-type-select">${post_type_select_label}</label>
         <select class="select-field" id="post-type-select">
-            ${Object.entries(postTypeOptions).map(([value, label]) => `
+            ${Object.entries(postTypeOptions).map(
+              ([value, label]) => `
                 <option value="${value}"> ${label} </option>
-            `)}
+            `,
+            )}
         </select>
 
         <label class="section-subheader" for="post-field-select">${post_field_select_label}</label>
@@ -55,7 +61,7 @@ function project_activity_during_date_range() {
         <label class="section-subheader" for="date-select">${date_select_label}</label>
         <div class="date_range_picker">
             <i class="fi-calendar"></i>&nbsp;
-            <span>${window.moment().format("YYYY")}</span>
+            <span>${window.moment().format('YYYY')}</span>
             <i class="dt_caret down"></i>
         </div>
 
@@ -81,234 +87,265 @@ function project_activity_during_date_range() {
   `;
 
   // Activate date range picker element.
-  window.METRICS.setupDatePickerWithoutEndpoint(
-    function (start, end, label) {
-      jQuery('.date_range_picker span').html(label);
-      jQuery('#post-field-submit-button').click();
-    },
-    window.moment().startOf('year')
-  );
+  window.METRICS.setupDatePickerWithoutEndpoint(function (start, end, label) {
+    jQuery('.date_range_picker span').html(label);
+    jQuery('#post-field-submit-button').click();
+  }, window.moment().startOf('year'));
 
   // Add post type event listener.
-  const fieldSelectElement = document.querySelector('#post-field-select')
-  document.querySelector('#post-type-select').addEventListener('change', (e) => {
-    const postType = e.target.value
-    window.dtMetricsProject.state.post_type = postType;
-    getFieldSettings(postType)
-    .promise()
-    .then((data) => {
-      window.dtMetricsProject.field_settings = data;
-      fieldSelectElement.innerHTML = buildFieldSelectOptions();
+  const fieldSelectElement = document.querySelector('#post-field-select');
+  document
+    .querySelector('#post-type-select')
+    .addEventListener('change', (e) => {
+      const postType = e.target.value;
+      window.dtMetricsProject.state.post_type = postType;
+      getFieldSettings(postType)
+        .promise()
+        .then((data) => {
+          window.dtMetricsProject.field_settings = data;
+          fieldSelectElement.innerHTML = buildFieldSelectOptions();
 
-      // Update selection based on detected defaults.
-      if ( e.detail && e.detail.field ) {
-        jQuery('#post-field-select').val(e.detail.field);
-        fieldSelectElement.dispatchEvent(new CustomEvent('change', {'detail': e.detail}));
-
-      } else {
-        fieldSelectElement.dispatchEvent(new Event('change'));
-      }
-
-    })
-    .catch((error) => {
-      console.log(error)
+          // Update selection based on detected defaults.
+          if (e.detail && e.detail.field) {
+            jQuery('#post-field-select').val(e.detail.field);
+            fieldSelectElement.dispatchEvent(
+              new CustomEvent('change', { detail: e.detail }),
+            );
+          } else {
+            fieldSelectElement.dispatchEvent(new Event('change'));
+          }
+        })
+        .catch((error) => {
+          console.log(error);
+        });
     });
-  });
 
   // Add field event listener.
   fieldSelectElement.addEventListener('change', (e) => {
-    refreshFieldValueEntryElement( e.detail, function () {
-
+    refreshFieldValueEntryElement(e.detail, function () {
       // Default to any specified date ranges.
-      if (e.detail ) {
+      if (e.detail) {
         if (e.detail.date_start && e.detail.date_end) {
-          let date_range_picker = jQuery('.date_range_picker').data('daterangepicker');
+          let date_range_picker =
+            jQuery('.date_range_picker').data('daterangepicker');
           date_range_picker.setStartDate(window.moment(e.detail.date_start));
           date_range_picker.setEndDate(window.moment(e.detail.date_end));
 
           // Default to custom range label if no search parameter detected.
-          jQuery('.date_range_picker span').html(window.lodash.escape(e.detail.label ? e.detail.label : date_select_custom_label));
+          jQuery('.date_range_picker span').html(
+            window.lodash.escape(
+              e.detail.label ? e.detail.label : date_select_custom_label,
+            ),
+          );
         }
         jQuery('#post-field-submit-button').click();
       }
-    } );
+    });
   });
 
   // Add submit button event listener.
-  document.querySelector('#post-field-submit-button').addEventListener('click', (e) => {
-    let field_settings = window.dtMetricsProject.field_settings;
-    let date_range_picker = jQuery('.date_range_picker').data('daterangepicker');
-    let post_type = jQuery('#post-type-select').val();
-    let field_id =  jQuery('#post-field-select').val();
-    let field_type = field_settings[field_id]['type'];
-    let value = jQuery('#post-field-value').val();
-    let loadingSpinner = document.querySelector('#chart-loading-spinner');
-    loadingSpinner.classList.add('active');
+  document
+    .querySelector('#post-field-submit-button')
+    .addEventListener('click', (e) => {
+      let field_settings = window.dtMetricsProject.field_settings;
+      let date_range_picker =
+        jQuery('.date_range_picker').data('daterangepicker');
+      let post_type = jQuery('#post-type-select').val();
+      let field_id = jQuery('#post-field-select').val();
+      let field_type = field_settings[field_id]['type'];
+      let value = jQuery('#post-field-value').val();
+      let loadingSpinner = document.querySelector('#chart-loading-spinner');
+      loadingSpinner.classList.add('active');
 
-    // Capture Typeahead values if special field type is selected.
-    if (window.lodash.includes(['connection', 'user_select', 'location'], field_type)) {
-      let typeahead = window.Typeahead['.js-typeahead-' + field_id];
-      if (typeahead) {
-        switch (field_type) {
-          case 'connection':
-          case 'location': {
-            value = typeahead.items;
-            break;
+      // Capture Typeahead values if special field type is selected.
+      if (
+        window.lodash.includes(
+          ['connection', 'user_select', 'location'],
+          field_type,
+        )
+      ) {
+        let typeahead = window.Typeahead['.js-typeahead-' + field_id];
+        if (typeahead) {
+          switch (field_type) {
+            case 'connection':
+            case 'location': {
+              value = typeahead.items;
+              break;
+            }
+            case 'user_select': {
+              value = typeahead.item;
+              break;
+            }
           }
-          case 'user_select': {
-            value = typeahead.item;
-            break;
-          }
+        } else {
+          value = {};
         }
-      } else {
-        value = {};
       }
-    }
 
-    // Create payload.
-    let ts_start = (date_range_picker.startDate.unix() > 0) ? date_range_picker.startDate.unix() : 0;
-    let ts_end = date_range_picker.endDate.unix();
+      // Create payload.
+      let ts_start =
+        date_range_picker.startDate.unix() > 0
+          ? date_range_picker.startDate.unix()
+          : 0;
+      let ts_end = date_range_picker.endDate.unix();
 
-    let payload = {
-      'post_type': post_type,
-      'field': field_id,
-      'value': value,
-      'date_start': window.moment.unix(ts_start).format('YYYY-MM-DD'),
-      'date_end': window.moment.unix(ts_end).format('YYYY-MM-DD')
-    };
+      let payload = {
+        post_type: post_type,
+        field: field_id,
+        value: value,
+        date_start: window.moment.unix(ts_start).format('YYYY-MM-DD'),
+        date_end: window.moment.unix(ts_end).format('YYYY-MM-DD'),
+      };
 
-    // Determine search param value shape to be adopted.
-    let search_param_value = value;
-    if ( Array.isArray( value ) && window.lodash.includes(['connection', 'location'], field_type) ) {
-      search_param_value = value.filter((x) => x.ID !== null)
-      .map((x) => x.ID)
-      .join(',');
+      // Determine search param value shape to be adopted.
+      let search_param_value = value;
+      if (
+        Array.isArray(value) &&
+        window.lodash.includes(['connection', 'location'], field_type)
+      ) {
+        search_param_value = value
+          .filter((x) => x.ID !== null)
+          .map((x) => x.ID)
+          .join(',');
+      } else if (
+        value &&
+        value.ID &&
+        window.lodash.includes(['user_select'], field_type)
+      ) {
+        search_param_value = value.ID;
+      }
 
-    } else if ( (value && value.ID) && window.lodash.includes(['user_select'], field_type) ) {
-      search_param_value = value.ID;
-    }
+      // Dynamically update URL parameters.
+      const url = new URL(window.location);
+      url.searchParams.set('record_type', post_type);
+      url.searchParams.set('field', field_id);
+      url.searchParams.set('value', search_param_value);
+      url.searchParams.set('date_start', payload.date_start);
+      url.searchParams.set('date_end', payload.date_end);
+      url.searchParams.set('label', jQuery('.date_range_picker span').html());
+      window.history.pushState(null, document.title, url.search);
 
-    // Dynamically update URL parameters.
-    const url = new URL(window.location);
-    url.searchParams.set('record_type', post_type);
-    url.searchParams.set('field', field_id);
-    url.searchParams.set('value', search_param_value );
-    url.searchParams.set('date_start', payload.date_start);
-    url.searchParams.set('date_end', payload.date_end);
-    url.searchParams.set('label', jQuery('.date_range_picker span').html());
-    window.history.pushState(null, document.title, url.search);
+      // Fetch records matching activity within specified date range.
+      getDateRangeActivity(payload)
+        .promise()
+        .then((response) => {
+          let total = response['total'];
+          let posts = response['posts'];
 
-    // Fetch records matching activity within specified date range.
-    getDateRangeActivity(payload)
-    .promise()
-    .then((response) => {
+          let activity_results_div = jQuery('#activity_results_div');
 
-      let total = response['total'];
-      let posts = response['posts'];
+          // Refresh activity during date range results display.
+          activity_results_div.fadeOut('fast', function () {
+            jQuery('#activity_results_total').html(total);
 
-      let activity_results_div = jQuery('#activity_results_div');
+            // Refresh and re-populate results table.
+            let table = activity_results_div.find('table');
+            table.fadeOut('fast');
+            if (total && total > 0) {
+              let tbody = table.find('tbody');
+              tbody.empty();
 
-      // Refresh activity during date range results display.
-      activity_results_div.fadeOut('fast', function () {
-        jQuery('#activity_results_total').html(total);
+              posts.forEach(function (post) {
+                if (post['id'] && post['name'] && post['timestamp']) {
+                  let post_url =
+                    window.dtMetricsProject.site_url +
+                    '/' +
+                    post['post_type'] +
+                    '/' +
+                    post['id'];
+                  let new_value = window.SHAREDFUNCTIONS.escapeHTML(
+                    post['new_value'],
+                  );
 
-        // Refresh and re-populate results table.
-        let table = activity_results_div.find('table');
-        table.fadeOut('fast');
-        if(total && (total > 0)) {
+                  // Apply custom styling.
+                  if (
+                    post['field_type'] &&
+                    post['field_type'] === 'connection' &&
+                    post['deleted'] &&
+                    post['deleted'] === true
+                  ) {
+                    new_value = `<s>${window.SHAREDFUNCTIONS.escapeHTML(post['new_value'])}</s>`;
+                  }
 
-          let tbody = table.find('tbody');
-          tbody.empty();
-
-          posts.forEach(function (post) {
-            if (post['id'] && post['name'] && post['timestamp']) {
-              let post_url = window.dtMetricsProject.site_url + '/' + post['post_type'] + '/' + post['id'];
-              let new_value = window.SHAREDFUNCTIONS.escapeHTML(post['new_value']);
-
-              // Apply custom styling.
-              if ((post['field_type'] && post['field_type'] === 'connection') && (post['deleted'] && post['deleted'] === true)) {
-                new_value = `<s>${window.SHAREDFUNCTIONS.escapeHTML(post['new_value'])}</s>`;
-              }
-
-              tbody.append(`
+                  tbody.append(`
                 <tr>
                     <td><a href="${post_url}" target="_blank">${window.SHAREDFUNCTIONS.escapeHTML(post['name'])}</a></td>
                     <td>${window.SHAREDFUNCTIONS.escapeHTML(window.moment.unix(post['timestamp']).format('dddd, MMMM Do YYYY, h:mm:ss A'))}</td>
                     <td>${new_value}</td>
                 </tr>
               `);
+                }
+              });
+
+              table.fadeIn('fast');
             }
+
+            // Display result findings.
+            activity_results_div.fadeIn('fast');
+            loadingSpinner.classList.remove('active');
           });
-
-          table.fadeIn('fast');
-        }
-
-        // Display result findings.
-        activity_results_div.fadeIn('fast');
-        loadingSpinner.classList.remove('active');
-
-      });
-
-    })
-    .catch((error) => {
-      console.log(error);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
     });
-
-  });
 
   // Handle any available request defaults.
   handleRequestDefaults();
 }
 
 function fetchURLSearchParams() {
-    const url_search_params = new URLSearchParams(window.location.search);
+  const url_search_params = new URLSearchParams(window.location.search);
 
-    let request_params = {};
-    for ( const param of url_search_params ) {
-        if ( Array.isArray( param ) && param.length === 2 ) {
-            request_params[ param[0] ] = param[1];
-        }
+  let request_params = {};
+  for (const param of url_search_params) {
+    if (Array.isArray(param) && param.length === 2) {
+      request_params[param[0]] = param[1];
     }
+  }
 
-    return request_params;
+  return request_params;
 }
 
 function handleRequestDefaults() {
-    const request_params = fetchURLSearchParams();
+  const request_params = fetchURLSearchParams();
 
-    // Ensure required parts are present, in order to proceed.
-    if ( request_params && request_params.record_type && request_params.field ) {
-
-        // Update selected post type and forward request params to change event.
-        jQuery('#post-type-select').val(request_params.record_type);
-        document.querySelector('#post-type-select').dispatchEvent(new CustomEvent('change', {'detail': request_params}));
-
-    } else {
-
-        // Display field value entry accordingly based on selected field.
-        refreshFieldValueEntryElement();
-    }
+  // Ensure required parts are present, in order to proceed.
+  if (request_params && request_params.record_type && request_params.field) {
+    // Update selected post type and forward request params to change event.
+    jQuery('#post-type-select').val(request_params.record_type);
+    document
+      .querySelector('#post-type-select')
+      .dispatchEvent(new CustomEvent('change', { detail: request_params }));
+  } else {
+    // Display field value entry accordingly based on selected field.
+    refreshFieldValueEntryElement();
+  }
 }
 
 function buildFieldSelectOptions() {
-    const unescapedOptions = Object.entries(window.dtMetricsProject.field_settings)
-        .reduce((options, [ key, setting ]) => {
-            options[key] = setting.name
-            return options
-        }, {})
-    const postFieldOptions = escapeObject(unescapedOptions)
-    const sortedOptions = Object.entries(postFieldOptions).sort(([key1, value1], [key2, value2]) => {
-        if (value1 < value2) return -1
-        if (value1 === value2) return 0
-        if (value1 > value2) return 1
-    })
-    return sortedOptions.map(([value, label]) => `
+  const unescapedOptions = Object.entries(
+    window.dtMetricsProject.field_settings,
+  ).reduce((options, [key, setting]) => {
+    options[key] = setting.name;
+    return options;
+  }, {});
+  const postFieldOptions = escapeObject(unescapedOptions);
+  const sortedOptions = Object.entries(postFieldOptions).sort(
+    ([key1, value1], [key2, value2]) => {
+      if (value1 < value2) return -1;
+      if (value1 === value2) return 0;
+      if (value1 > value2) return 1;
+    },
+  );
+  return sortedOptions.map(
+    ([value, label]) => `
         <option value="${value}"> ${label} </option>
-    `)
+    `,
+  );
 }
 
-function refreshFieldValueEntryElement( details = null, callback = null ) {
-
+function refreshFieldValueEntryElement(details = null, callback = null) {
   // Empty any previous entries.
   let entry_div = jQuery('#post-field-value-entry-div');
   entry_div.empty();
@@ -317,185 +354,221 @@ function refreshFieldValueEntryElement( details = null, callback = null ) {
   let field_settings = window.dtMetricsProject.field_settings;
   let field_id = jQuery('#post-field-select').val();
   if (field_id && field_settings[field_id]) {
-
     // Based on field type & associated defaults, determine html element style to be adopted.
-    if (field_settings[field_id]['default'] && Object.keys(field_settings[field_id]['default']).length > 0) {
+    if (
+      field_settings[field_id]['default'] &&
+      Object.keys(field_settings[field_id]['default']).length > 0
+    ) {
       let options_html = `<option value="">[ ${window.SHAREDFUNCTIONS.escapeHTML(window.dtMetricsProject.translations['post_field_select_any_activity_label'])} ]</option>`;
-      Object.entries(field_settings[field_id]['default']).forEach(([key, option]) => {
-        options_html += `<option value="${key}">${option['label']}</option>`;
-      });
-      entry_div.html(`<select class="select-field" id="post-field-value">${options_html}</select>`);
+      Object.entries(field_settings[field_id]['default']).forEach(
+        ([key, option]) => {
+          options_html += `<option value="${key}">${option['label']}</option>`;
+        },
+      );
+      entry_div.html(
+        `<select class="select-field" id="post-field-value">${options_html}</select>`,
+      );
 
       // Select any requested default field values.
-      if ( details && details.value !== null ) {
+      if (details && details.value !== null) {
         jQuery('#post-field-value').val(details.value);
       }
 
-      if ( callback ) {
+      if (callback) {
         callback();
       }
-
-    } else if (window.lodash.includes(['connection', 'user_select', 'location'], field_settings[field_id]['type'])) {
-
+    } else if (
+      window.lodash.includes(
+        ['connection', 'user_select', 'location'],
+        field_settings[field_id]['type'],
+      )
+    ) {
       // Fetch html rendering for selected field.
       renderFieldHtml({
-        'post_type': jQuery('#post-type-select').val(),
-        'field_id': field_id
-      }).promise()
-      .then((response) => {
-        let execute_callback = true;
-        if (response['html']) {
-          entry_div.html(response['html']);
-          activateSpecialFieldValueControls(field_id, field_settings[field_id]);
+        post_type: jQuery('#post-type-select').val(),
+        field_id: field_id,
+      })
+        .promise()
+        .then((response) => {
+          let execute_callback = true;
+          if (response['html']) {
+            entry_div.html(response['html']);
+            activateSpecialFieldValueControls(
+              field_id,
+              field_settings[field_id],
+            );
 
-          // Select any requested default field values.
-          if ( details && details.value !== null ) {
-            switch (field_settings[field_id]['type']) {
-              case 'connection': {
+            // Select any requested default field values.
+            if (details && details.value !== null) {
+              switch (field_settings[field_id]['type']) {
+                case 'connection': {
+                  // Short-circuit main parent callback flow.
+                  execute_callback = false;
 
-                // Short-circuit main parent callback flow.
-                execute_callback = false;
-
-                // First attempt to obtain a handle onto recently instantiated typeahead object.
-                let connection_typeahead_field_input = '.js-typeahead-' + field_id;
-                let connection_typeahead = window.Typeahead[connection_typeahead_field_input];
-                if ( connection_typeahead && field_settings[field_id]['post_type'] ) {
-
-                  // Support multiple post ids; by first concatenating corresponding promises.
-                  let promises = [];
-                  jQuery.each(String(details.value).split(','), function (idx, id) {
-                    promises.push(
-                      window.API.get_post(field_settings[field_id]['post_type'], id)
-                      .then(post => {
-
-                        // On a successful hit, add as item to multi select typeahead field.
-                        if (post && post['ID'] && post['title']) {
-                          connection_typeahead.addMultiselectItemLayout({
-                            'ID': post['ID'],
-                            'label': post['title'],
-                            'name': post['title']
-                          });
-                          connection_typeahead.hideLayout();
-                          connection_typeahead.resetInput();
-                        }
-                      })
+                  // First attempt to obtain a handle onto recently instantiated typeahead object.
+                  let connection_typeahead_field_input =
+                    '.js-typeahead-' + field_id;
+                  let connection_typeahead =
+                    window.Typeahead[connection_typeahead_field_input];
+                  if (
+                    connection_typeahead &&
+                    field_settings[field_id]['post_type']
+                  ) {
+                    // Support multiple post ids; by first concatenating corresponding promises.
+                    let promises = [];
+                    jQuery.each(
+                      String(details.value).split(','),
+                      function (idx, id) {
+                        promises.push(
+                          window.API.get_post(
+                            field_settings[field_id]['post_type'],
+                            id,
+                          ).then((post) => {
+                            // On a successful hit, add as item to multi select typeahead field.
+                            if (post && post['ID'] && post['title']) {
+                              connection_typeahead.addMultiselectItemLayout({
+                                ID: post['ID'],
+                                label: post['title'],
+                                name: post['title'],
+                              });
+                              connection_typeahead.hideLayout();
+                              connection_typeahead.resetInput();
+                            }
+                          }),
+                        );
+                      },
                     );
-                  });
 
-                  // Execute all promises within a chained fashion.
-                  jQuery.when.apply(null, promises)
-                  .done(result => {
-
-                    // Executing callback if available; once all promises have finished.
-                    if (callback) {
-                      callback();
-                    }
-                  });
+                    // Execute all promises within a chained fashion.
+                    jQuery.when.apply(null, promises).done((result) => {
+                      // Executing callback if available; once all promises have finished.
+                      if (callback) {
+                        callback();
+                      }
+                    });
+                  }
+                  break;
                 }
-                break;
-              }
-              case 'location': {
+                case 'location': {
+                  // Short-circuit main parent callback flow.
+                  execute_callback = false;
 
-                // Short-circuit main parent callback flow.
-                execute_callback = false;
-
-                // First attempt to obtain a handle onto recently instantiated typeahead object.
-                let location_typeahead_field_input = '.js-typeahead-' + field_id;
-                let location_typeahead = window.Typeahead[location_typeahead_field_input];
-                if ( location_typeahead ) {
-
-                  // Support multiple post ids; by first concatenating corresponding promises.
-                  let promises = [];
-                  jQuery.each(String(details.value).split(','), function (idx, id) {
-                      promises.push(
-                          window.makeRequest('POST', window.dtMetricsProject['root'] + 'dt/v1/mapping_module/get_map_by_grid_id', {
-                              'grid_id': id
-                          }).then(location => {
-
+                  // First attempt to obtain a handle onto recently instantiated typeahead object.
+                  let location_typeahead_field_input =
+                    '.js-typeahead-' + field_id;
+                  let location_typeahead =
+                    window.Typeahead[location_typeahead_field_input];
+                  if (location_typeahead) {
+                    // Support multiple post ids; by first concatenating corresponding promises.
+                    let promises = [];
+                    jQuery.each(
+                      String(details.value).split(','),
+                      function (idx, id) {
+                        promises.push(
+                          window
+                            .makeRequest(
+                              'POST',
+                              window.dtMetricsProject['root'] +
+                                'dt/v1/mapping_module/get_map_by_grid_id',
+                              {
+                                grid_id: id,
+                              },
+                            )
+                            .then((location) => {
                               // On a successful hit, add as item to multi select typeahead field.
-                              if ( location && location['self'] && location['self']['id'] && location['self']['name'] ) {
-                                  location_typeahead.addMultiselectItemLayout({
-                                      'ID': location['self']['id'],
-                                      'matchedKey': 'name',
-                                      'name': location['self']['name']
-                                  });
-                                  location_typeahead.hideLayout();
-                                  location_typeahead.resetInput();
+                              if (
+                                location &&
+                                location['self'] &&
+                                location['self']['id'] &&
+                                location['self']['name']
+                              ) {
+                                location_typeahead.addMultiselectItemLayout({
+                                  ID: location['self']['id'],
+                                  matchedKey: 'name',
+                                  name: location['self']['name'],
+                                });
+                                location_typeahead.hideLayout();
+                                location_typeahead.resetInput();
                               }
-                          })
-                      );
-                  });
+                            }),
+                        );
+                      },
+                    );
 
-                  // Execute all promises within a chained fashion.
-                  jQuery.when.apply(null, promises)
-                  .done(result => {
-
-                    // Executing callback if available; once all promises have finished.
-                    if (callback) {
-                      callback();
-                    }
-                  });
+                    // Execute all promises within a chained fashion.
+                    jQuery.when.apply(null, promises).done((result) => {
+                      // Executing callback if available; once all promises have finished.
+                      if (callback) {
+                        callback();
+                      }
+                    });
+                  }
+                  break;
                 }
-                break;
-              }
-              case 'user_select': {
+                case 'user_select': {
+                  // Short-circuit main parent callback flow.
+                  execute_callback = false;
 
-                // Short-circuit main parent callback flow.
-                execute_callback = false;
+                  // First attempt to obtain a handle onto recently instantiated typeahead object.
+                  let user_typeahead_field_input = '.js-typeahead-' + field_id;
+                  let user_typeahead =
+                    window.Typeahead[user_typeahead_field_input];
+                  if (user_typeahead) {
+                    // Next, proceed with attempting to locate corresponding location grid record from the backend.
+                    window
+                      .makeRequest(
+                        'GET',
+                        window.dtMetricsProject['root'] +
+                          'dt/v1/users/contact-id',
+                        {
+                          user_id: details.value,
+                        },
+                      )
+                      .then((contact_id) => {
+                        // Next, attempt to fetch corresponding contact post record.
+                        if (contact_id) {
+                          window.API.get_post('contacts', contact_id).then(
+                            (post) => {
+                              if (post && post['ID'] && post['title']) {
+                                // On a successful hit, add as item to multi select typeahead field.
+                                user_typeahead.item = {
+                                  ID: details.value,
+                                  contact_id: post['ID'],
+                                  matchedKey: 'name',
+                                  name: post['title'],
+                                };
+                                user_typeahead.hideLayout();
+                                user_typeahead.resetInput();
+                                jQuery(`input.js-typeahead-${field_id}`).val(
+                                  post['title'],
+                                );
 
-                // First attempt to obtain a handle onto recently instantiated typeahead object.
-                let user_typeahead_field_input = '.js-typeahead-' + field_id;
-                let user_typeahead = window.Typeahead[user_typeahead_field_input];
-                if ( user_typeahead ) {
-
-                  // Next, proceed with attempting to locate corresponding location grid record from the backend.
-                  window.makeRequest('GET', window.dtMetricsProject['root'] + 'dt/v1/users/contact-id', {
-                    'user_id': details.value
-                  }).then(contact_id => {
-
-                    // Next, attempt to fetch corresponding contact post record.
-                    if (contact_id) {
-                      window.API.get_post('contacts', contact_id)
-                      .then(post => {
-                        if (post && post['ID'] && post['title']) {
-
-                          // On a successful hit, add as item to multi select typeahead field.
-                          user_typeahead.item = {
-                            'ID': details.value,
-                            'contact_id': post['ID'],
-                            'matchedKey': 'name',
-                            'name': post['title']
-                          };
-                          user_typeahead.hideLayout();
-                          user_typeahead.resetInput();
-                          jQuery(`input.js-typeahead-${field_id}`).val(post['title']);
-
-                          if ( callback ) {
-                            callback();
-                          }
+                                if (callback) {
+                                  callback();
+                                }
+                              }
+                            },
+                          );
                         }
                       });
-                    }
-                  });
+                  }
+                  break;
                 }
-                break;
               }
             }
           }
-        }
 
-        if ( execute_callback && callback ) {
-          callback();
-        }
-
-      }).catch((error) => {
-        console.log(error);
-      });
-
+          if (execute_callback && callback) {
+            callback();
+          }
+        })
+        .catch((error) => {
+          console.log(error);
+        });
     } else {
       entry_div.html('<input type="hidden" id="post-field-value" value="" />');
 
-      if ( callback ) {
+      if (callback) {
         callback();
       }
     }
@@ -509,7 +582,9 @@ function activateSpecialFieldValueControls(field_id, field_settings) {
   switch (field_type) {
     case 'connection': {
       let connection_typeahead_field_input = '.js-typeahead-' + field_id;
-      jQuery('#post-field-value-entry-div').find(connection_typeahead_field_input).typeahead({
+      jQuery('#post-field-value-entry-div')
+        .find(connection_typeahead_field_input)
+        .typeahead({
           input: connection_typeahead_field_input,
           minLength: 0,
           accent: true,
@@ -517,146 +592,183 @@ function activateSpecialFieldValueControls(field_id, field_settings) {
           maxItem: 20,
           template: window.TYPEAHEADS.contactListRowTemplate,
           source: window.TYPEAHEADS.typeaheadPostsSource(post_type, field_id),
-          display: ["name", "label"],
+          display: ['name', 'label'],
           templateValue: function () {
             if (this.items[this.items.length - 1].label) {
-              return "{{label}}"
+              return '{{label}}';
             } else {
-              return "{{name}}"
+              return '{{name}}';
             }
           },
           dynamic: true,
           multiselect: {
-            matchOn: ["ID"],
+            matchOn: ['ID'],
             data: [],
             callback: {
-              onCancel: function (node, item) {
-              }
-            }
+              onCancel: function (node, item) {},
+            },
           },
           callback: {
             onResult: function (node, query, result, resultCount) {
-              let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result);
+              let text = window.TYPEAHEADS.typeaheadHelpText(
+                resultCount,
+                query,
+                result,
+              );
               jQuery(`#${field_id}-result-container`).html(text);
             },
             onHideLayout: function () {
-              jQuery(`#${field_id}-result-container`).html("");
+              jQuery(`#${field_id}-result-container`).html('');
             },
             onClick: function (node, a, item, event) {
               // Stop list from opening again
-              this.addMultiselectItemLayout(item)
-              event.preventDefault()
+              this.addMultiselectItemLayout(item);
+              event.preventDefault();
               this.hideLayout();
               this.resetInput();
-            }
-          }
+            },
+          },
         });
       break;
     }
     case 'location': {
       let location_typeahead_field_input = '.js-typeahead-' + field_id;
-      jQuery('#post-field-value-entry-div').find(location_typeahead_field_input).typeahead({
+      jQuery('#post-field-value-entry-div')
+        .find(location_typeahead_field_input)
+        .typeahead({
           input: location_typeahead_field_input,
           minLength: 0,
           accent: true,
           searchOnFocus: true,
           maxItem: 20,
-          dropdownFilter: [{
-            key: 'group',
-            value: 'focus',
-            template: window.SHAREDFUNCTIONS.escapeHTML(window.dtMetricsProject['translations']['regions_of_focus']),
-            all: window.SHAREDFUNCTIONS.escapeHTML(window.dtMetricsProject['translations']['all_locations'])
-          }],
+          dropdownFilter: [
+            {
+              key: 'group',
+              value: 'focus',
+              template: window.SHAREDFUNCTIONS.escapeHTML(
+                window.dtMetricsProject['translations']['regions_of_focus'],
+              ),
+              all: window.SHAREDFUNCTIONS.escapeHTML(
+                window.dtMetricsProject['translations']['all_locations'],
+              ),
+            },
+          ],
           source: {
             focus: {
-              display: "name",
+              display: 'name',
               ajax: {
-                url: window.dtMetricsProject['root'] + 'dt/v1/mapping_module/search_location_grid_by_name',
+                url:
+                  window.dtMetricsProject['root'] +
+                  'dt/v1/mapping_module/search_location_grid_by_name',
                 data: {
-                  s: "{{query}}",
+                  s: '{{query}}',
                   filter: function () {
-                    return window.lodash.get(window.Typeahead[location_typeahead_field_input].filters.dropdown, 'value', 'all');
-                  }
+                    return window.lodash.get(
+                      window.Typeahead[location_typeahead_field_input].filters
+                        .dropdown,
+                      'value',
+                      'all',
+                    );
+                  },
                 },
                 beforeSend: function (xhr) {
-                  xhr.setRequestHeader('X-WP-Nonce', window.dtMetricsProject['nonce']);
+                  xhr.setRequestHeader(
+                    'X-WP-Nonce',
+                    window.dtMetricsProject['nonce'],
+                  );
                 },
                 callback: {
                   done: function (data) {
                     return data.location_grid;
-                  }
-                }
-              }
-            }
+                  },
+                },
+              },
+            },
           },
-          display: "name",
-          templateValue: "{{name}}",
+          display: 'name',
+          templateValue: '{{name}}',
           dynamic: true,
           multiselect: {
-            matchOn: ["ID"],
+            matchOn: ['ID'],
             data: function () {
               return [];
-            }, callback: {
-              onCancel: function (node, item) {
-              }
-            }
+            },
+            callback: {
+              onCancel: function (node, item) {},
+            },
           },
           callback: {
-            onClick: function (node, a, item, event) {
-            },
+            onClick: function (node, a, item, event) {},
             onReady() {
               this.filters.dropdown = {
-                key: "group",
-                value: "focus",
-                template: window.SHAREDFUNCTIONS.escapeHTML(window.dtMetricsProject['translations']['regions_of_focus'])
+                key: 'group',
+                value: 'focus',
+                template: window.SHAREDFUNCTIONS.escapeHTML(
+                  window.dtMetricsProject['translations']['regions_of_focus'],
+                ),
               };
               this.container
-              .removeClass("filter")
-              .find("." + this.options.selector.filterButton)
-              .html(window.SHAREDFUNCTIONS.escapeHTML(window.dtMetricsProject['translations']['regions_of_focus']));
-            }
-          }
+                .removeClass('filter')
+                .find('.' + this.options.selector.filterButton)
+                .html(
+                  window.SHAREDFUNCTIONS.escapeHTML(
+                    window.dtMetricsProject['translations']['regions_of_focus'],
+                  ),
+                );
+            },
+          },
         });
       break;
     }
     case 'user_select': {
       let user_select_typeahead_field_input = '.js-typeahead-' + field_id;
-      jQuery('#post-field-value-entry-div').find(user_select_typeahead_field_input).typeahead({
-        input: user_select_typeahead_field_input,
-        minLength: 0,
-        maxItem: 0,
-        accent: true,
-        searchOnFocus: true,
-        source: window.TYPEAHEADS.typeaheadUserSource(),
-        templateValue: "{{name}}",
-        template: function (query, item) {
-          return `<div class="assigned-to-row" dir="auto">
+      jQuery('#post-field-value-entry-div')
+        .find(user_select_typeahead_field_input)
+        .typeahead({
+          input: user_select_typeahead_field_input,
+          minLength: 0,
+          maxItem: 0,
+          accent: true,
+          searchOnFocus: true,
+          source: window.TYPEAHEADS.typeaheadUserSource(),
+          templateValue: '{{name}}',
+          template: function (query, item) {
+            return `<div class="assigned-to-row" dir="auto">
                   <span>
                       <span class="avatar"><img style="vertical-align: text-bottom" src="{{avatar}}"/></span>
                       ${window.SHAREDFUNCTIONS.escapeHTML(item.name)}
                   </span>
                   ${item.status_color ? `<span class="status-square" style="background-color: ${window.SHAREDFUNCTIONS.escapeHTML(item.status_color)};">&nbsp;</span>` : ''}
-                  ${item.update_needed && item.update_needed > 0 ? `<span>
+                  ${
+                    item.update_needed && item.update_needed > 0
+                      ? `<span>
                     <img style="height: 12px;" src="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.template_dir)}/dt-assets/images/broken.svg"/>
                     <span style="font-size: 14px">${window.SHAREDFUNCTIONS.escapeHTML(item.update_needed)}</span>
-                  </span>` : ''}
+                  </span>`
+                      : ''
+                  }
                 </div>`;
-        },
-        dynamic: true,
-        hint: true,
-        emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.no_records_found),
-        callback: {
-          onClick: function (node, a, item) {
           },
-          onResult: function (node, query, result, resultCount) {
-            let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
-            jQuery(`#${field_id}-result-container`).html(text);
+          dynamic: true,
+          hint: true,
+          emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(
+            window.wpApiShare.translations.no_records_found,
+          ),
+          callback: {
+            onClick: function (node, a, item) {},
+            onResult: function (node, query, result, resultCount) {
+              let text = window.TYPEAHEADS.typeaheadHelpText(
+                resultCount,
+                query,
+                result,
+              );
+              jQuery(`#${field_id}-result-container`).html(text);
+            },
+            onHideLayout: function () {
+              jQuery(`.${field_id}-result-container`).html('');
+            },
           },
-          onHideLayout: function () {
-            jQuery(`.${field_id}-result-container`).html("");
-          }
-        }
-      });
+        });
       break;
     }
   }

--- a/dt-metrics/records/dynamic-records-map.js
+++ b/dt-metrics/records/dynamic-records-map.js
@@ -1,5 +1,6 @@
-jQuery(document).ready(function($) {
-  let spinner_html = '<span class="loading-spinner users-spinner active"></span>'
+jQuery(document).ready(function ($) {
+  let spinner_html =
+    '<span class="loading-spinner users-spinner active"></span>';
   let mapbox_library_api = {
     container_set_up: false,
     current_map_type: 'points',
@@ -10,47 +11,80 @@ jQuery(document).ready(function($) {
     spinner: null,
     map_query_layer_payloads: {},
     dt_maps_layers_cookie_id: 'dt-maps-layers-cookie',
-    recursive_load: async function (body, data = {}, offset = 0, limit = 50000) {
+    recursive_load: async function (
+      body,
+      data = {},
+      offset = 0,
+      limit = 50000,
+    ) {
       jQuery('#loading-spinner').show();
-      if ( data.response === undefined ){
+      if (data.response === undefined) {
         data = {
           request: {},
           response: {
-            type: "FeatureCollection",
-            features: []
-          }
-        }
+            type: 'FeatureCollection',
+            features: [],
+          },
+        };
       }
 
-      body.offset = offset
-      body.limit = limit
-      let query = await window.makeRequest("POST", mapbox_library_api.obj.settings.post_type_rest_url, body, mapbox_library_api.obj.settings.rest_base_url)
+      body.offset = offset;
+      body.limit = limit;
+      let query = await window.makeRequest(
+        'POST',
+        mapbox_library_api.obj.settings.post_type_rest_url,
+        body,
+        mapbox_library_api.obj.settings.rest_base_url,
+      );
 
-      data.request = query.request
-      data.response.features = data.response.features.concat(query.response.features)
-      jQuery('#loading-legend').html(`<span>(${data.response.features.length.toLocaleString()})</span>`)
+      data.request = query.request;
+      data.response.features = data.response.features.concat(
+        query.response.features,
+      );
+      jQuery('#loading-legend').html(
+        `<span>(${data.response.features.length.toLocaleString()})</span>`,
+      );
 
-
-      let max = mapbox_library_api.current_map_type === 'points' && data.response.features.length > 500000;
-      if ( !max && query.response.features.length > 0 && query.response.features.length === limit ) {
-        return mapbox_library_api.recursive_load(body, data, offset + limit, limit)
+      let max =
+        mapbox_library_api.current_map_type === 'points' &&
+        data.response.features.length > 500000;
+      if (
+        !max &&
+        query.response.features.length > 0 &&
+        query.response.features.length === limit
+      ) {
+        return mapbox_library_api.recursive_load(
+          body,
+          data,
+          offset + limit,
+          limit,
+        );
       }
       jQuery('#loading-legend').html('');
       jQuery('#loading-spinner').hide();
-      return data
-
+      return data;
     },
     setup_container: function () {
-      if ( this.container_set_up ){ return; }
-      if ( typeof window.dt_mapbox_metrics.settings === 'undefined' ) { return; }
+      if (this.container_set_up) {
+        return;
+      }
+      if (typeof window.dt_mapbox_metrics.settings === 'undefined') {
+        return;
+      }
 
       let chart = jQuery('#chart');
 
       // Ensure a valid mapbox key has been specified.
       if (!window.dt_mapbox_metrics.settings.map_key) {
         chart.empty();
-        let mapping_settings_url = window.wpApiShare.site_url + '/wp-admin/admin.php?page=dt_mapping_module&tab=geocoding';
-        chart.empty().html(`<a href="${window.lodash.escape(mapping_settings_url)}">${window.lodash.escape(window.dt_mapbox_metrics.settings.no_map_key_msg)}</a>`);
+        let mapping_settings_url =
+          window.wpApiShare.site_url +
+          '/wp-admin/admin.php?page=dt_mapping_module&tab=geocoding';
+        chart
+          .empty()
+          .html(
+            `<a href="${window.lodash.escape(mapping_settings_url)}">${window.lodash.escape(window.dt_mapbox_metrics.settings.no_map_key_msg)}</a>`,
+          );
 
         return;
       }
@@ -78,20 +112,20 @@ jQuery(document).ready(function($) {
           <div id='legend' class='legend'>
             <div id="legend-bar" class="grid-x grid-margin-x grid-padding-x">
               <div class="cell small-2 center info-bar-font">
-                  ${window.lodash.escape( this.title )}
+                  ${window.lodash.escape(this.title)}
                   <span id="loading-spinner" style="display: inline-block" class="loading-spinner active"></span>
                   <div id="loading-legend"></div>
               </div>
               <div id="map-type" class="border-left">
-                <button class="button small select-button ${mapbox_library_api.current_map_type === 'cluster' ? 'selected-select-button': ' empty-select-button' }"
+                <button class="button small select-button ${mapbox_library_api.current_map_type === 'cluster' ? 'selected-select-button' : ' empty-select-button'}"
                   id="cluster">
                   <img src="${window.lodash.escape(window.wpApiShare.template_dir)}/dt-assets/images/dots.svg">
                 </button>
-                <button class="button small select-button ${mapbox_library_api.current_map_type === 'points' ? 'selected-select-button': ' empty-select-button' }"
+                <button class="button small select-button ${mapbox_library_api.current_map_type === 'points' ? 'selected-select-button' : ' empty-select-button'}"
                   id="points">
                   <img src="${window.lodash.escape(window.wpApiShare.template_dir)}/dt-assets/images/dot.svg">
                 </button>
-                <!--<button class="button small select-button ${mapbox_library_api.current_map_type === 'area' ? 'selected-select-button': ' empty-select-button' }"
+                <!--<button class="button small select-button ${mapbox_library_api.current_map_type === 'area' ? 'selected-select-button' : ' empty-select-button'}"
                   id="area">
                   <img src="${window.lodash.escape(window.wpApiShare.template_dir)}/dt-assets/images/location_shape.svg">
                 </button>-->
@@ -100,13 +134,13 @@ jQuery(document).ready(function($) {
           </div>
           <div id="spinner">${spinner_html}</div>
           <div id="geocode-details" class="geocode-details">
-            ${window.lodash.escape( this.title )}<span class="close-details" style="float:right;"><i class="fi-x"></i></span>
+            ${window.lodash.escape(this.title)}<span class="close-details" style="float:right;"><i class="fi-x"></i></span>
             <hr style="margin:10px 5px;">
             <div id="geocode-details-content"></div>
           </div>
           <div id="add_records_div" class="add-records-div">
             <input id="add_records_div_layer_id" type="hidden" value="" />
-            <span id="add_records_div_title">${window.lodash.escape( this.obj.translations.add_records.title )}</span><span class="close-add-records-div" style="float:right;"><i class="fi-x"></i></span>
+            <span id="add_records_div_title">${window.lodash.escape(this.obj.translations.add_records.title)}</span><span class="close-add-records-div" style="float:right;"><i class="fi-x"></i></span>
             <hr style="margin:10px 5px;">
             <div id="add_records_div_content">
               <table>
@@ -116,22 +150,26 @@ jQuery(document).ready(function($) {
                             <select id="add_records_div_content_post_type">
                               <optgroup label="${window.lodash.escape(this.obj.translations.add_records.post_type_select_opt_group_record_types)}">
                               ${(function (obj) {
-
                                 let html = ``;
-                                jQuery.each(obj.settings.post_types, function(idx, post_type){
-                                  html += `<option value="${window.lodash.escape(idx)}">${window.lodash.escape(post_type['label'])}</option>`;
-                                });
+                                jQuery.each(
+                                  obj.settings.post_types,
+                                  function (idx, post_type) {
+                                    html += `<option value="${window.lodash.escape(idx)}">${window.lodash.escape(post_type['label'])}</option>`;
+                                  },
+                                );
 
                                 return html;
                               })(this.obj)}
                               </optgroup>
                               <optgroup label="${window.lodash.escape(this.obj.translations.add_records.post_type_select_opt_group_system)}">
                               ${(function (obj) {
-
                                 let html = ``;
-                                jQuery.each(obj.settings.post_types_system_options, function(idx, post_type_system){
-                                  html += `<option value="system-${window.lodash.escape(idx)}">${window.lodash.escape(post_type_system['label'])}</option>`;
-                                });
+                                jQuery.each(
+                                  obj.settings.post_types_system_options,
+                                  function (idx, post_type_system) {
+                                    html += `<option value="system-${window.lodash.escape(idx)}">${window.lodash.escape(post_type_system['label'])}</option>`;
+                                  },
+                                );
 
                                 return html;
                               })(this.obj)}
@@ -165,82 +203,147 @@ jQuery(document).ready(function($) {
       `);
 
       // Setup add records div content initial field states.
-      let add_records_div_content_post_type = $('#add_records_div_content_post_type');
-      let add_records_div_content_post_type_fields = $('#add_records_div_content_post_type_fields');
-      let add_records_div_content_post_type_field_values = $('#add_records_div_content_post_type_field_values');
-      $(add_records_div_content_post_type_fields).empty().html(mapbox_library_api.add_records_build_post_type_field_select_options($(add_records_div_content_post_type).val()));
-      mapbox_library_api.add_records_refresh_post_type_field_value_entry_element($(add_records_div_content_post_type).val(), $(add_records_div_content_post_type_fields).val());
+      let add_records_div_content_post_type = $(
+        '#add_records_div_content_post_type',
+      );
+      let add_records_div_content_post_type_fields = $(
+        '#add_records_div_content_post_type_fields',
+      );
+      let add_records_div_content_post_type_field_values = $(
+        '#add_records_div_content_post_type_field_values',
+      );
+      $(add_records_div_content_post_type_fields)
+        .empty()
+        .html(
+          mapbox_library_api.add_records_build_post_type_field_select_options(
+            $(add_records_div_content_post_type).val(),
+          ),
+        );
+      mapbox_library_api.add_records_refresh_post_type_field_value_entry_element(
+        $(add_records_div_content_post_type).val(),
+        $(add_records_div_content_post_type_fields).val(),
+      );
 
       // Assign add records div content initial field event listeners.
-      $(add_records_div_content_post_type).on('change', function (e, layer_settings) {
-        let div_layer_id = $('#add_records_div_layer_id').val();
-        let adopt_layer_settings = (div_layer_id && (typeof layer_settings !== 'undefined') && ('' + div_layer_id === '' + layer_settings.id));
+      $(add_records_div_content_post_type).on(
+        'change',
+        function (e, layer_settings) {
+          let div_layer_id = $('#add_records_div_layer_id').val();
+          let adopt_layer_settings =
+            div_layer_id &&
+            typeof layer_settings !== 'undefined' &&
+            '' + div_layer_id === '' + layer_settings.id;
 
-        // Determine post type to be adopted.
-        if (adopt_layer_settings) {
-          $(this).val(layer_settings.post_type);
-          $(this).prop('disabled', true);
-
-        } else {
-          $(this).prop('disabled', false);
-        }
-
-        let selected_post_type = $(this).val();
-        $(add_records_div_content_post_type_field_values).fadeOut('fast', function () {
-          $(add_records_div_content_post_type_fields).fadeOut('fast', function () {
-            $(add_records_div_content_post_type_fields).empty().html(mapbox_library_api.add_records_build_post_type_field_select_options(selected_post_type));
-            $(add_records_div_content_post_type_fields).fadeIn('fast', function () {
-
-              // Determine post type field to be adopted.
-              if (adopt_layer_settings) {
-                $(add_records_div_content_post_type_fields).val(layer_settings.field_key);
-                $(add_records_div_content_post_type_fields).prop('disabled', true);
-
-              } else {
-                $(add_records_div_content_post_type_fields).prop('disabled', false);
-              }
-
-              $(add_records_div_content_post_type_fields).trigger('change', [layer_settings]);
-            });
-          });
-        });
-      });
-
-      $(add_records_div_content_post_type_fields).on('change', function (e, layer_settings) {
-        let div_layer_id = $('#add_records_div_layer_id').val();
-        let adopt_layer_settings = (div_layer_id && (typeof layer_settings !== 'undefined') && ('' + div_layer_id === '' + layer_settings.id));
-
-        mapbox_library_api.add_records_refresh_post_type_field_value_entry_element($(add_records_div_content_post_type).val(), $(this).val(), function () {
+          // Determine post type to be adopted.
           if (adopt_layer_settings) {
-            let field_values_div = $('#add_records_div_content_post_type_field_values');
-
-            // Determine post type field values to be adopted.
-            switch (layer_settings.field_type) {
-              case 'key_select':
-              case 'multi_select': {
-
-                // Disable by default and check any previously selected.
-                $(field_values_div).find('.add-records-div-content-post-type-field-values-checkbox').each(function () {
-                  let checkbox = $(this);
-                  $(checkbox).prop('disabled', true);
-                  $(checkbox).prop('checked', (window.lodash.includes(layer_settings.field_values, $(checkbox).val())));
-                });
-
-                break;
-              }
-            }
+            $(this).val(layer_settings.post_type);
+            $(this).prop('disabled', true);
+          } else {
+            $(this).prop('disabled', false);
           }
-        });
-      });
+
+          let selected_post_type = $(this).val();
+          $(add_records_div_content_post_type_field_values).fadeOut(
+            'fast',
+            function () {
+              $(add_records_div_content_post_type_fields).fadeOut(
+                'fast',
+                function () {
+                  $(add_records_div_content_post_type_fields)
+                    .empty()
+                    .html(
+                      mapbox_library_api.add_records_build_post_type_field_select_options(
+                        selected_post_type,
+                      ),
+                    );
+                  $(add_records_div_content_post_type_fields).fadeIn(
+                    'fast',
+                    function () {
+                      // Determine post type field to be adopted.
+                      if (adopt_layer_settings) {
+                        $(add_records_div_content_post_type_fields).val(
+                          layer_settings.field_key,
+                        );
+                        $(add_records_div_content_post_type_fields).prop(
+                          'disabled',
+                          true,
+                        );
+                      } else {
+                        $(add_records_div_content_post_type_fields).prop(
+                          'disabled',
+                          false,
+                        );
+                      }
+
+                      $(add_records_div_content_post_type_fields).trigger(
+                        'change',
+                        [layer_settings],
+                      );
+                    },
+                  );
+                },
+              );
+            },
+          );
+        },
+      );
+
+      $(add_records_div_content_post_type_fields).on(
+        'change',
+        function (e, layer_settings) {
+          let div_layer_id = $('#add_records_div_layer_id').val();
+          let adopt_layer_settings =
+            div_layer_id &&
+            typeof layer_settings !== 'undefined' &&
+            '' + div_layer_id === '' + layer_settings.id;
+
+          mapbox_library_api.add_records_refresh_post_type_field_value_entry_element(
+            $(add_records_div_content_post_type).val(),
+            $(this).val(),
+            function () {
+              if (adopt_layer_settings) {
+                let field_values_div = $(
+                  '#add_records_div_content_post_type_field_values',
+                );
+
+                // Determine post type field values to be adopted.
+                switch (layer_settings.field_type) {
+                  case 'key_select':
+                  case 'multi_select': {
+                    // Disable by default and check any previously selected.
+                    $(field_values_div)
+                      .find(
+                        '.add-records-div-content-post-type-field-values-checkbox',
+                      )
+                      .each(function () {
+                        let checkbox = $(this);
+                        $(checkbox).prop('disabled', true);
+                        $(checkbox).prop(
+                          'checked',
+                          window.lodash.includes(
+                            layer_settings.field_values,
+                            $(checkbox).val(),
+                          ),
+                        );
+                      });
+
+                    break;
+                  }
+                }
+              }
+            },
+          );
+        },
+      );
 
       // Reference map spinner.
-      this.spinner = $("#spinner");
+      this.spinner = $('#spinner');
 
       //set_info_boxes
-      let map_wrapper = jQuery('#map-wrapper')
-      jQuery('.legend').css( 'width', map_wrapper.innerWidth() - 20 )
-      jQuery( window ).resize(function() {
-        jQuery('.legend').css( 'width', map_wrapper.innerWidth() - 20 )
+      let map_wrapper = jQuery('#map-wrapper');
+      jQuery('.legend').css('width', map_wrapper.innerWidth() - 20);
+      jQuery(window).resize(function () {
+        jQuery('.legend').css('width', map_wrapper.innerWidth() - 20);
       });
 
       mapbox_library_api.setup_map_type();
@@ -251,10 +354,11 @@ jQuery(document).ready(function($) {
 
         switch (id) {
           default: {
-
             // Reset all map type buttons and select caller.
-            $('#map-type button').removeClass("selected-select-button").addClass("empty-select-button");
-            $(map_type_button).addClass("selected-select-button");
+            $('#map-type button')
+              .removeClass('selected-select-button')
+              .addClass('empty-select-button');
+            $(map_type_button).addClass('selected-select-button');
 
             mapbox_library_api.current_map_type = id;
             mapbox_library_api.setup_map_type();
@@ -269,22 +373,33 @@ jQuery(document).ready(function($) {
 
         switch (id) {
           case 'add_records_request': {
-            let payload = mapbox_library_api.add_records_capture_state_snapshot_payload();
-            mapbox_library_api.recursive_load(payload).then(response => {
-              if (response && response.request && response.response && mapbox_library_api.map) {
-
+            let payload =
+              mapbox_library_api.add_records_capture_state_snapshot_payload();
+            mapbox_library_api.recursive_load(payload).then((response) => {
+              if (
+                response &&
+                response.request &&
+                response.response &&
+                mapbox_library_api.map
+              ) {
                 // Remove existing map query layer sources.
                 mapbox_library_api.remove_map_record_layer(response.request.id);
 
                 // Generate layer color.
-                let layer_color = mapbox_library_api.add_records_generate_hex_color();
+                let layer_color =
+                  mapbox_library_api.add_records_generate_hex_color();
 
                 // Add corresponding mqp query source and layer.
-                mapbox_library_api.add_map_record_layer(response.request.id, layer_color, response.response);
+                mapbox_library_api.add_map_record_layer(
+                  response.request.id,
+                  layer_color,
+                  response.response,
+                );
 
                 // Create a corresponding layers tab button.
                 let map_layers_tab = $('#map_layers_tab');
-                let map_layers_tab_count = $(map_layers_tab).children().length + 1;
+                let map_layers_tab_count =
+                  $(map_layers_tab).children().length + 1;
                 let map_layers_tab_button_html = `
               <button
                 class="button map-layers-tab-button"
@@ -306,15 +421,25 @@ jQuery(document).ready(function($) {
                 // Persist query layer payload details.
                 let cookie = response.request;
                 cookie['color'] = layer_color;
-                mapbox_library_api.map_query_layer_payloads[response.request.id] = cookie;
+                mapbox_library_api.map_query_layer_payloads[
+                  response.request.id
+                ] = cookie;
 
                 // Assign to main parent layers cookie.
-                let dt_maps_layers_cookie = window.SHAREDFUNCTIONS.get_json_from_local_storage(mapbox_library_api.dt_maps_layers_cookie_id, {});
+                let dt_maps_layers_cookie =
+                  window.SHAREDFUNCTIONS.get_json_from_local_storage(
+                    mapbox_library_api.dt_maps_layers_cookie_id,
+                    {},
+                  );
                 if (!dt_maps_layers_cookie) {
                   dt_maps_layers_cookie = {};
                 }
                 dt_maps_layers_cookie['' + response.request.id] = cookie;
-                window.SHAREDFUNCTIONS.save_json_to_local_storage(mapbox_library_api.dt_maps_layers_cookie_id, dt_maps_layers_cookie, null);
+                window.SHAREDFUNCTIONS.save_json_to_local_storage(
+                  mapbox_library_api.dt_maps_layers_cookie_id,
+                  dt_maps_layers_cookie,
+                  null,
+                );
 
                 // Adjust all map layer points.
                 mapbox_library_api.adjust_layer_point_sizes();
@@ -326,18 +451,35 @@ jQuery(document).ready(function($) {
             break;
           }
           case 'delete_records_request': {
-            let map_query_layer_payload = mapbox_library_api.map_query_layer_payloads[div_layer_id];
-            if (map_query_layer_payload && confirm(window.lodash.escape(mapbox_library_api.obj.translations.add_records.confirm_delete_layer))) {
-
+            let map_query_layer_payload =
+              mapbox_library_api.map_query_layer_payloads[div_layer_id];
+            if (
+              map_query_layer_payload &&
+              confirm(
+                window.lodash.escape(
+                  mapbox_library_api.obj.translations.add_records
+                    .confirm_delete_layer,
+                ),
+              )
+            ) {
               // Remove existing map query layer sources.
-              mapbox_library_api.remove_map_record_layer(map_query_layer_payload.id);
+              mapbox_library_api.remove_map_record_layer(
+                map_query_layer_payload.id,
+              );
 
               // Remove cookie.
-              let dt_maps_layers_cookie = window.SHAREDFUNCTIONS.get_json_from_local_storage(mapbox_library_api.dt_maps_layers_cookie_id);
+              let dt_maps_layers_cookie =
+                window.SHAREDFUNCTIONS.get_json_from_local_storage(
+                  mapbox_library_api.dt_maps_layers_cookie_id,
+                );
               if (dt_maps_layers_cookie['' + map_query_layer_payload.id]) {
                 delete dt_maps_layers_cookie['' + map_query_layer_payload.id];
 
-                window.SHAREDFUNCTIONS.save_json_to_local_storage(mapbox_library_api.dt_maps_layers_cookie_id, dt_maps_layers_cookie, null);
+                window.SHAREDFUNCTIONS.save_json_to_local_storage(
+                  mapbox_library_api.dt_maps_layers_cookie_id,
+                  dt_maps_layers_cookie,
+                  null,
+                );
               }
 
               // Remove from map memory.
@@ -351,14 +493,17 @@ jQuery(document).ready(function($) {
 
               // Adjust all map layer points.
               mapbox_library_api.adjust_layer_point_sizes();
-
             }
             break;
           }
           case 'display_records_toggle': {
-            let layer_settings = mapbox_library_api.map_query_layer_payloads[div_layer_id];
+            let layer_settings =
+              mapbox_library_api.map_query_layer_payloads[div_layer_id];
             if (layer_settings) {
-              if (layer_settings['displayed'] && layer_settings['displayed'] === true) {
+              if (
+                layer_settings['displayed'] &&
+                layer_settings['displayed'] === true
+              ) {
                 layer_settings['displayed'] = false;
 
                 // Remove layer data points.
@@ -366,41 +511,63 @@ jQuery(document).ready(function($) {
 
                 // Adjust all map layer points.
                 mapbox_library_api.adjust_layer_point_sizes();
-
               } else {
                 layer_settings['displayed'] = true;
 
                 // Fetch and display latest data points.
-                mapbox_library_api.recursive_load(layer_settings).then(response => {
-                  if (response && response.request && response.response && mapbox_library_api.map) {
+                mapbox_library_api
+                  .recursive_load(layer_settings)
+                  .then((response) => {
+                    if (
+                      response &&
+                      response.request &&
+                      response.response &&
+                      mapbox_library_api.map
+                    ) {
+                      // Remove existing map query layer sources.
+                      mapbox_library_api.remove_map_record_layer(
+                        response.request.id,
+                      );
 
-                    // Remove existing map query layer sources.
-                    mapbox_library_api.remove_map_record_layer(response.request.id);
+                      // Ensure valid features have been returned.
+                      if (
+                        response.response.features &&
+                        response.response.features.length > 0
+                      ) {
+                        // Add corresponding mqp query source and layer.
+                        mapbox_library_api.add_map_record_layer(
+                          response.request.id,
+                          layer_settings.color,
+                          response.response,
+                        );
 
-                    // Ensure valid features have been returned.
-                    if (response.response.features && response.response.features.length > 0) {
-
-                      // Add corresponding mqp query source and layer.
-                      mapbox_library_api.add_map_record_layer(response.request.id, layer_settings.color, response.response);
-
-                      // Adjust all map layer points.
-                      mapbox_library_api.adjust_layer_point_sizes();
-
+                        // Adjust all map layer points.
+                        mapbox_library_api.adjust_layer_point_sizes();
+                      }
                     }
-                  }
-                });
+                  });
               }
 
               // Persist layer updates.
-              mapbox_library_api.map_query_layer_payloads[div_layer_id] = layer_settings;
+              mapbox_library_api.map_query_layer_payloads[div_layer_id] =
+                layer_settings;
 
               // Toggle display button icon, based on current display flag.
-              mapbox_library_api.refresh_display_records_button_icon(div_layer_id);
+              mapbox_library_api.refresh_display_records_button_icon(
+                div_layer_id,
+              );
 
               // Update cookie, to ensure changes persist following refreshes.
-              let dt_maps_layers_cookie = window.SHAREDFUNCTIONS.get_json_from_local_storage(mapbox_library_api.dt_maps_layers_cookie_id);
+              let dt_maps_layers_cookie =
+                window.SHAREDFUNCTIONS.get_json_from_local_storage(
+                  mapbox_library_api.dt_maps_layers_cookie_id,
+                );
               dt_maps_layers_cookie['' + div_layer_id] = layer_settings;
-              window.SHAREDFUNCTIONS.save_json_to_local_storage(mapbox_library_api.dt_maps_layers_cookie_id, dt_maps_layers_cookie, null);
+              window.SHAREDFUNCTIONS.save_json_to_local_storage(
+                mapbox_library_api.dt_maps_layers_cookie_id,
+                dt_maps_layers_cookie,
+                null,
+              );
             }
             break;
           }
@@ -442,38 +609,58 @@ jQuery(document).ready(function($) {
       $(document).on('click', '.map-layers-tab-button', function (e) {
         let query_layer_title = $(this).text().trim();
         let query_payload_id = $(this).data('query_id');
-        let query_payload = mapbox_library_api.map_query_layer_payloads[query_payload_id];
+        let query_payload =
+          mapbox_library_api.map_query_layer_payloads[query_payload_id];
 
         // Display Add Records modal window in edit mode with required functionality.
-        mapbox_library_api.show_records_modal_edit_mode(query_payload_id, query_payload, query_layer_title);
+        mapbox_library_api.show_records_modal_edit_mode(
+          query_payload_id,
+          query_payload,
+          query_layer_title,
+        );
       });
     },
     reload_record_layers: function (reload_data = true, callback) {
-
       // Reload to be based on currently stored cookie settings.
-      let dt_maps_layers_cookie = window.SHAREDFUNCTIONS.get_json_from_local_storage(mapbox_library_api.dt_maps_layers_cookie_id, false);
+      let dt_maps_layers_cookie =
+        window.SHAREDFUNCTIONS.get_json_from_local_storage(
+          mapbox_library_api.dt_maps_layers_cookie_id,
+          false,
+        );
 
       // Convert parent object to array of layer objects.
       let layer_cookies = [];
-      if (!Array.isArray(dt_maps_layers_cookie) && !window.lodash.isEmpty(dt_maps_layers_cookie)) {
-        layer_cookies = Object.entries(dt_maps_layers_cookie).map(([k, v]) => v);
+      if (
+        !Array.isArray(dt_maps_layers_cookie) &&
+        !window.lodash.isEmpty(dt_maps_layers_cookie)
+      ) {
+        layer_cookies = Object.entries(dt_maps_layers_cookie).map(
+          ([k, v]) => v,
+        );
       }
       // Default to showing all contacts if no cookies detected.
       if (layer_cookies.length === 0 && dt_maps_layers_cookie === false) {
         let default_cookie = {
-          'post_type': 'contacts',
-          'field_key': 'query_all',
-          'display_order': 0,
-          'displayed': true,
-          'color': mapbox_library_api.add_records_generate_hex_color()
+          post_type: 'contacts',
+          field_key: 'query_all',
+          display_order: 0,
+          displayed: true,
+          color: mapbox_library_api.add_records_generate_hex_color(),
         };
-        default_cookie['id'] = mapbox_library_api.add_records_generate_captured_state_snapshot_payload_id(default_cookie);
+        default_cookie['id'] =
+          mapbox_library_api.add_records_generate_captured_state_snapshot_payload_id(
+            default_cookie,
+          );
         layer_cookies.push(default_cookie);
 
         // Persist default cookie.
         dt_maps_layers_cookie = {};
         dt_maps_layers_cookie['' + default_cookie['id']] = default_cookie;
-        window.SHAREDFUNCTIONS.save_json_to_local_storage(mapbox_library_api.dt_maps_layers_cookie_id, dt_maps_layers_cookie, null);
+        window.SHAREDFUNCTIONS.save_json_to_local_storage(
+          mapbox_library_api.dt_maps_layers_cookie_id,
+          dt_maps_layers_cookie,
+          null,
+        );
 
         // Force a reload.
         reload_data = true;
@@ -515,18 +702,28 @@ jQuery(document).ready(function($) {
         mapbox_library_api.refresh_display_records_button_icon(cookie.id);
 
         // If requested, fetch latest query results based on loaded cookie settings.
-        if (reload_data && (cookie.displayed && cookie.displayed === true)) {
-          mapbox_library_api.recursive_load(cookie).then(response => {
-            if (response && response.request && response.response && mapbox_library_api.map) {
-
+        if (reload_data && cookie.displayed && cookie.displayed === true) {
+          mapbox_library_api.recursive_load(cookie).then((response) => {
+            if (
+              response &&
+              response.request &&
+              response.response &&
+              mapbox_library_api.map
+            ) {
               // Remove existing map query layer sources.
               mapbox_library_api.remove_map_record_layer(response.request.id);
 
               // Ensure valid features have been returned.
-              if (response.response.features && response.response.features.length > 0) {
-
+              if (
+                response.response.features &&
+                response.response.features.length > 0
+              ) {
                 // Add corresponding mqp query source and layer.
-                mapbox_library_api.add_map_record_layer(response.request.id, cookie.color, response.response);
+                mapbox_library_api.add_map_record_layer(
+                  response.request.id,
+                  cookie.color,
+                  response.response,
+                );
               }
 
               if (callback) {
@@ -538,7 +735,7 @@ jQuery(document).ready(function($) {
       });
 
       // Adjust left border display accordingly, based on available map layers.
-      if( $(map_layers_tab).children().length > 0 ) {
+      if ($(map_layers_tab).children().length > 0) {
         $(map_layers_tab).addClass('border-left');
       } else {
         $(map_layers_tab).removeClass('border-left');
@@ -555,11 +752,18 @@ jQuery(document).ready(function($) {
         mapbox_library_api.map.removeLayer(query_layer_key);
       }
 
-      if (typeof mapbox_library_api.map.getLayer(query_layer_key_clustered) !== 'undefined') {
+      if (
+        typeof mapbox_library_api.map.getLayer(query_layer_key_clustered) !==
+        'undefined'
+      ) {
         mapbox_library_api.map.removeLayer(query_layer_key_clustered);
       }
 
-      if (typeof mapbox_library_api.map.getLayer(query_layer_key_clustered_count) !== 'undefined') {
+      if (
+        typeof mapbox_library_api.map.getLayer(
+          query_layer_key_clustered_count,
+        ) !== 'undefined'
+      ) {
         mapbox_library_api.map.removeLayer(query_layer_key_clustered_count);
       }
 
@@ -575,10 +779,13 @@ jQuery(document).ready(function($) {
       let query_layer_key_clustered_count = `dt-maps-${layer_id}-layer-clustered-count`;
 
       // Add query layer source.
-      if (typeof mapbox_library_api.map.getSource(query_source_key) === 'undefined') {
+      if (
+        typeof mapbox_library_api.map.getSource(query_source_key) ===
+        'undefined'
+      ) {
         let source_options = {
           type: 'geojson',
-          data: geojson_data
+          data: geojson_data,
         };
 
         if (mapbox_library_api.current_map_type === 'cluster') {
@@ -591,7 +798,9 @@ jQuery(document).ready(function($) {
       }
 
       // Add corresponding query layers based on global map type.
-      if (typeof mapbox_library_api.map.getLayer(query_layer_key) === 'undefined') {
+      if (
+        typeof mapbox_library_api.map.getLayer(query_layer_key) === 'undefined'
+      ) {
         mapbox_library_api.map.addLayer({
           id: query_layer_key,
           type: 'circle',
@@ -601,17 +810,21 @@ jQuery(document).ready(function($) {
             'circle-color': layer_color,
             'circle-radius': 12,
             'circle-stroke-width': 1,
-            'circle-stroke-color': '#fff'
+            'circle-stroke-color': '#fff',
           },
-          metadata: { // Custom metadata for downstream processing.
+          metadata: {
+            // Custom metadata for downstream processing.
             is_record_map: true,
-            layer_id: layer_id
-          }
+            layer_id: layer_id,
+          },
         });
       }
 
       if (mapbox_library_api.current_map_type === 'cluster') {
-        if (typeof mapbox_library_api.map.getLayer(query_layer_key_clustered) === 'undefined') {
+        if (
+          typeof mapbox_library_api.map.getLayer(query_layer_key_clustered) ===
+          'undefined'
+        ) {
           mapbox_library_api.map.addLayer({
             id: query_layer_key_clustered,
             type: 'circle',
@@ -625,7 +838,7 @@ jQuery(document).ready(function($) {
                 100,
                 layer_color,
                 750,
-                layer_color
+                layer_color,
               ],
               'circle-radius': [
                 'step',
@@ -634,17 +847,22 @@ jQuery(document).ready(function($) {
                 100,
                 30,
                 750,
-                40
-              ]
+                40,
+              ],
             },
-            metadata: { // Custom metadata for downstream processing.
+            metadata: {
+              // Custom metadata for downstream processing.
               is_record_map: true,
-              layer_id: layer_id
-            }
+              layer_id: layer_id,
+            },
           });
         }
 
-        if (typeof mapbox_library_api.map.getLayer(query_layer_key_clustered_count) === 'undefined') {
+        if (
+          typeof mapbox_library_api.map.getLayer(
+            query_layer_key_clustered_count,
+          ) === 'undefined'
+        ) {
           mapbox_library_api.map.addLayer({
             id: query_layer_key_clustered_count,
             type: 'symbol',
@@ -653,50 +871,73 @@ jQuery(document).ready(function($) {
             layout: {
               'text-field': '{point_count_abbreviated}',
               'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
-              'text-size': 12
+              'text-size': 12,
             },
-            metadata: { // Custom metadata for downstream processing.
+            metadata: {
+              // Custom metadata for downstream processing.
               is_record_map: true,
-              layer_id: layer_id
-            }
+              layer_id: layer_id,
+            },
           });
         }
 
         // Handle various point events.
-        mapbox_library_api.map.on('mouseenter', query_layer_key_clustered, function () {
-          mapbox_library_api.map.getCanvas().style.cursor = 'pointer';
-        });
+        mapbox_library_api.map.on(
+          'mouseenter',
+          query_layer_key_clustered,
+          function () {
+            mapbox_library_api.map.getCanvas().style.cursor = 'pointer';
+          },
+        );
 
-        mapbox_library_api.map.on('mouseenter', query_layer_key_clustered_count, function () {
-          mapbox_library_api.map.getCanvas().style.cursor = 'pointer';
-        });
+        mapbox_library_api.map.on(
+          'mouseenter',
+          query_layer_key_clustered_count,
+          function () {
+            mapbox_library_api.map.getCanvas().style.cursor = 'pointer';
+          },
+        );
 
-        mapbox_library_api.map.on('mouseleave', query_layer_key_clustered, function () {
-          mapbox_library_api.map.getCanvas().style.cursor = '';
-        });
+        mapbox_library_api.map.on(
+          'mouseleave',
+          query_layer_key_clustered,
+          function () {
+            mapbox_library_api.map.getCanvas().style.cursor = '';
+          },
+        );
 
-        mapbox_library_api.map.on('mouseleave', query_layer_key_clustered_count, function () {
-          mapbox_library_api.map.getCanvas().style.cursor = '';
-        });
+        mapbox_library_api.map.on(
+          'mouseleave',
+          query_layer_key_clustered_count,
+          function () {
+            mapbox_library_api.map.getCanvas().style.cursor = '';
+          },
+        );
 
-        mapbox_library_api.map.on('click', query_layer_key_clustered, function (e) {
-          let features = mapbox_library_api.map.queryRenderedFeatures(e.point, {
-            layers: [query_layer_key_clustered]
-          });
+        mapbox_library_api.map.on(
+          'click',
+          query_layer_key_clustered,
+          function (e) {
+            let features = mapbox_library_api.map.queryRenderedFeatures(
+              e.point,
+              {
+                layers: [query_layer_key_clustered],
+              },
+            );
 
-          let clusterId = features[0].properties.cluster_id;
-          mapbox_library_api.map.getSource(query_source_key).getClusterExpansionZoom(
-            clusterId,
-            function (err, zoom) {
-              if (err) return;
+            let clusterId = features[0].properties.cluster_id;
+            mapbox_library_api.map
+              .getSource(query_source_key)
+              .getClusterExpansionZoom(clusterId, function (err, zoom) {
+                if (err) return;
 
-              mapbox_library_api.map.easeTo({
-                center: features[0].geometry.coordinates,
-                zoom: zoom
+                mapbox_library_api.map.easeTo({
+                  center: features[0].geometry.coordinates,
+                  zoom: zoom,
+                });
               });
-            }
-          );
-        });
+          },
+        );
       }
 
       // Handle various point events.
@@ -719,7 +960,10 @@ jQuery(document).ready(function($) {
         let b2 = [point.x + width / 2, point.y + height / 2];
 
         let features = [];
-        let rendered_features = mapbox_library_api.map.queryRenderedFeatures([b1, b2]);
+        let rendered_features = mapbox_library_api.map.queryRenderedFeatures([
+          b1,
+          b2,
+        ]);
 
         $.each(rendered_features, function (idx, feature) {
           if (feature.source && feature.source.startsWith('dt-maps-')) {
@@ -734,9 +978,15 @@ jQuery(document).ready(function($) {
 
           let content_html = ``;
           $.each(features, function (idx, feature) {
-            if ( idx > 20 ){ return }
-            if (feature.properties && feature.properties.post_type && feature.properties.post_id && feature.properties.name) {
-
+            if (idx > 20) {
+              return;
+            }
+            if (
+              feature.properties &&
+              feature.properties.post_type &&
+              feature.properties.post_id &&
+              feature.properties.name
+            ) {
               // Ensure the correct post type is adopted for system based query layers.
               let post_type = feature.properties.post_type;
               switch (post_type) {
@@ -747,7 +997,7 @@ jQuery(document).ready(function($) {
               }
 
               content_html += `
-                <div class="grid-x" id="list-${window.lodash.escape( idx )}">
+                <div class="grid-x" id="list-${window.lodash.escape(idx)}">
                   <div class="cell">
                       <a target="_blank" href="${window.lodash.escape(window.wpApiShare.site_url)}/${window.lodash.escape(post_type)}/${window.lodash.escape(feature.properties.post_id)}">${window.lodash.escape(feature.properties.name)}</a>
                   </div>
@@ -767,7 +1017,7 @@ jQuery(document).ready(function($) {
     adjust_layer_point_sizes: function () {
       let layers = [];
       let style = mapbox_library_api.map.getStyle();
-      style.layers.forEach(layer => {
+      style.layers.forEach((layer) => {
         if (layer.id.startsWith('dt-maps-') && layer.id.endsWith('-layer')) {
           layers.push(layer);
         }
@@ -775,24 +1025,33 @@ jQuery(document).ready(function($) {
 
       // Proceed with layer point size adjustments, starting in reverse order.
       let counter = 0;
-      for (let i = (layers.length - 1); i >= 0; i--) {
+      for (let i = layers.length - 1; i >= 0; i--) {
         let size = counter * 4;
         counter++;
-        mapbox_library_api.map.setPaintProperty(layers[i].id, 'circle-translate', [size, 0]);
+        mapbox_library_api.map.setPaintProperty(
+          layers[i].id,
+          'circle-translate',
+          [size, 0],
+        );
       }
     },
     show_records_modal_add_mode: function () {
       let add_records_div = $('#add_records_div');
       $(add_records_div).fadeOut('fast', function () {
-
         // Reset metadata.
         $('#add_records_div_layer_id').val('');
 
         // Update modal title.
-        $('#add_records_div_title').text(window.lodash.escape(mapbox_library_api.obj.translations.add_records.title));
+        $('#add_records_div_title').text(
+          window.lodash.escape(
+            mapbox_library_api.obj.translations.add_records.title,
+          ),
+        );
 
         // Reset select widgets.
-        let add_records_div_content_post_type = $('#add_records_div_content_post_type');
+        let add_records_div_content_post_type = $(
+          '#add_records_div_content_post_type',
+        );
         $(add_records_div_content_post_type).val('contacts');
         $(add_records_div_content_post_type).trigger('change');
 
@@ -808,7 +1067,6 @@ jQuery(document).ready(function($) {
       if (id && settings) {
         let add_records_div = $('#add_records_div');
         $(add_records_div).fadeOut('fast', function () {
-
           // Reset metadata.
           $('#add_records_div_layer_id').val(id);
 
@@ -816,7 +1074,9 @@ jQuery(document).ready(function($) {
           $('#add_records_div_title').text(window.lodash.escape(title));
 
           // Reset select widgets, passing layer settings downstream.
-          let add_records_div_content_post_type = $('#add_records_div_content_post_type');
+          let add_records_div_content_post_type = $(
+            '#add_records_div_content_post_type',
+          );
           $(add_records_div_content_post_type).val('contacts');
           $(add_records_div_content_post_type).trigger('change', [settings]);
 
@@ -834,17 +1094,22 @@ jQuery(document).ready(function($) {
     },
     refresh_display_records_button_icon: function (layer_id) {
       if (layer_id) {
-        let layer_settings = mapbox_library_api.map_query_layer_payloads[layer_id];
+        let layer_settings =
+          mapbox_library_api.map_query_layer_payloads[layer_id];
 
         if (layer_settings) {
           let map_layers_tab = $('#map_layers_tab');
-          let map_layers_tab_button = $(map_layers_tab).find("button[data-query_id='"+ layer_id +"']");
+          let map_layers_tab_button = $(map_layers_tab).find(
+            "button[data-query_id='" + layer_id + "']",
+          );
           let display_records_button = $('#display_records_toggle');
 
-          if (layer_settings['displayed'] && layer_settings['displayed'] === true) {
+          if (
+            layer_settings['displayed'] &&
+            layer_settings['displayed'] === true
+          ) {
             $(display_records_button).addClass('selected-select-button');
             $(map_layers_tab_button).css('opacity', 1.0);
-
           } else {
             $(display_records_button).removeClass('selected-select-button');
             $(map_layers_tab_button).css('opacity', 0.3);
@@ -853,43 +1118,61 @@ jQuery(document).ready(function($) {
       }
     },
     add_records_build_post_type_field_select_options: function (post_type) {
-      let post_type_setting = mapbox_library_api.obj.settings.post_types[post_type];
+      let post_type_setting =
+        mapbox_library_api.obj.settings.post_types[post_type];
 
       let options_html = `<option value='query_all'>${window.lodash.escape(this.obj.translations.add_records.post_type_select_opt_group_record_types_query_all)}</option>`;
       if (post_type_setting && post_type_setting['fields']) {
         let field_setting = post_type_setting['fields'];
 
-        const unescapedOptions = Object.entries(field_setting)
-        .reduce((options, [key, setting]) => {
-          options[key] = setting.name
-          return options
-        }, {});
+        const unescapedOptions = Object.entries(field_setting).reduce(
+          (options, [key, setting]) => {
+            options[key] = setting.name;
+            return options;
+          },
+          {},
+        );
 
-        const postFieldOptions = window.SHAREDFUNCTIONS.escapeObject(unescapedOptions);
-        const sortedOptions = Object.entries(postFieldOptions).sort(([key1, value1], [key2, value2]) => {
-          if (value1 < value2) return -1
-          if (value1 === value2) return 0
-          if (value1 > value2) return 1
-        });
+        const postFieldOptions =
+          window.SHAREDFUNCTIONS.escapeObject(unescapedOptions);
+        const sortedOptions = Object.entries(postFieldOptions).sort(
+          ([key1, value1], [key2, value2]) => {
+            if (value1 < value2) return -1;
+            if (value1 === value2) return 0;
+            if (value1 > value2) return 1;
+          },
+        );
 
-        options_html += sortedOptions.map(([value, label]) => `
+        options_html += sortedOptions.map(
+          ([value, label]) => `
           <option value="${value}"> ${window.lodash.escape(label)} </option>
-      `);
+      `,
+        );
       }
 
       return options_html;
     },
-    add_records_refresh_post_type_field_value_entry_element: function (post_type, field_key, callback) {
-
+    add_records_refresh_post_type_field_value_entry_element: function (
+      post_type,
+      field_key,
+      callback,
+    ) {
       // Reset field value element by default.
       let entry_div = $('#add_records_div_content_post_type_field_values');
       $(entry_div).empty();
 
-      let post_type_setting = mapbox_library_api.obj.settings.post_types[post_type];
-      if (post_type_setting && post_type_setting['fields'][field_key] && post_type_setting['fields'][field_key]['type']) {
+      let post_type_setting =
+        mapbox_library_api.obj.settings.post_types[post_type];
+      if (
+        post_type_setting &&
+        post_type_setting['fields'][field_key] &&
+        post_type_setting['fields'][field_key]['type']
+      ) {
         let field_settings = post_type_setting['fields'][field_key];
         let field_type = field_settings['type'];
-        let field_default = field_settings['default'] ? field_settings['default'] : [];
+        let field_default = field_settings['default']
+          ? field_settings['default']
+          : [];
 
         // Generate entry element accordingly based on field type.
         $(entry_div).fadeOut('fast', function () {
@@ -921,16 +1204,23 @@ jQuery(document).ready(function($) {
     add_records_capture_state_snapshot_payload: function () {
       let post_type = $('#add_records_div_content_post_type').val();
       let field_key = $('#add_records_div_content_post_type_fields').val();
-      let field_values_div = $('#add_records_div_content_post_type_field_values');
-      let post_type_settings = mapbox_library_api.obj.settings.post_types[post_type];
+      let field_values_div = $(
+        '#add_records_div_content_post_type_field_values',
+      );
+      let post_type_settings =
+        mapbox_library_api.obj.settings.post_types[post_type];
 
       let payload = {
-        'post_type': post_type,
-        'field_key': field_key
+        post_type: post_type,
+        field_key: field_key,
       };
 
       // Ensure there are corresponding fields.
-      if (post_type_settings && post_type_settings['fields'] && post_type_settings['fields'][field_key]) {
+      if (
+        post_type_settings &&
+        post_type_settings['fields'] &&
+        post_type_settings['fields'][field_key]
+      ) {
         let field_settings = post_type_settings['fields'][field_key];
         let field_type = field_settings['type'];
 
@@ -941,20 +1231,29 @@ jQuery(document).ready(function($) {
         switch (field_type) {
           case 'key_select':
           case 'multi_select': {
-            $(field_values_div).find('.add-records-div-content-post-type-field-values-checkbox:checked').each(function () {
-              payload['field_values'].push($(this).val());
-            });
+            $(field_values_div)
+              .find(
+                '.add-records-div-content-post-type-field-values-checkbox:checked',
+              )
+              .each(function () {
+                payload['field_values'].push($(this).val());
+              });
             break;
           }
         }
       }
 
       // Generate unique id, based on payload shape.
-      payload['id'] = mapbox_library_api.add_records_generate_captured_state_snapshot_payload_id(payload);
+      payload['id'] =
+        mapbox_library_api.add_records_generate_captured_state_snapshot_payload_id(
+          payload,
+        );
 
       return payload;
     },
-    add_records_generate_captured_state_snapshot_payload_id: function (payload) {
+    add_records_generate_captured_state_snapshot_payload_id: function (
+      payload,
+    ) {
       let timestamp = new Date().getTime() / 1000;
       let seed = timestamp + payload.post_type + payload.field_key;
 
@@ -968,40 +1267,49 @@ jQuery(document).ready(function($) {
       let hash = 0;
       for (let i = 0; i < seed.length; i++) {
         let char = seed.charCodeAt(i);
-        hash = ((hash << 5) - hash) + char;
+        hash = (hash << 5) - hash + char;
         hash = hash & hash;
       }
 
       return '' + hash;
     },
     add_records_generate_hex_color: function () {
-      return '#' + (Math.random() * 0xFFFFFF << 0).toString(16).padStart(6, '0');
+      return (
+        '#' + ((Math.random() * 0xffffff) << 0).toString(16).padStart(6, '0')
+      );
     },
-    setup_map_type: function (){
+    setup_map_type: function () {
       // init map
       window.mapboxgl.accessToken = this.obj.settings.map_key;
-      if ( mapbox_library_api.map ){
-        mapbox_library_api.map.remove()
+      if (mapbox_library_api.map) {
+        mapbox_library_api.map.remove();
       }
       mapbox_library_api.map = new window.mapboxgl.Map({
         container: 'map',
         style: 'mapbox://styles/mapbox/light-v10',
         center: [2, 46],
         minZoom: 1,
-        zoom: 1.8
+        zoom: 1.8,
       });
       // SET BOUNDS
-      let map_bounds_token = this.obj.settings.post_type + this.obj.settings.menu_slug
-      let map_start = window.get_map_start( map_bounds_token )
-      if ( map_start ) {
-        mapbox_library_api.map.fitBounds( map_start, {duration: 0});
+      let map_bounds_token =
+        this.obj.settings.post_type + this.obj.settings.menu_slug;
+      let map_start = window.get_map_start(map_bounds_token);
+      if (map_start) {
+        mapbox_library_api.map.fitBounds(map_start, { duration: 0 });
       }
-      mapbox_library_api.map.on('zoomend', function() {
-        window.set_map_start( map_bounds_token, mapbox_library_api.map.getBounds() )
-      })
-      mapbox_library_api.map.on('dragend', function() {
-        window.set_map_start( map_bounds_token, mapbox_library_api.map.getBounds() )
-      })
+      mapbox_library_api.map.on('zoomend', function () {
+        window.set_map_start(
+          map_bounds_token,
+          mapbox_library_api.map.getBounds(),
+        );
+      });
+      mapbox_library_api.map.on('dragend', function () {
+        window.set_map_start(
+          map_bounds_token,
+          mapbox_library_api.map.getBounds(),
+        );
+      });
       // end set bounds
       // disable map rotation using right click + drag
       mapbox_library_api.map.dragRotate.disable();
@@ -1015,71 +1323,100 @@ jQuery(document).ready(function($) {
         });
       });
     },
-    load_map: function (map_type, query){
-
+    load_map: function (map_type, query) {
       let record_map_sources = [];
-      let style = mapbox_library_api.map.getStyle()
-      style.layers.forEach( layer=>{
-        if ( layer.id.startsWith("dt-maps-")){
-         let remove_layer = !( layer.metadata && layer.metadata.is_record_map && layer.metadata.is_record_map === true );
+      let style = mapbox_library_api.map.getStyle();
+      style.layers.forEach((layer) => {
+        if (layer.id.startsWith('dt-maps-')) {
+          let remove_layer = !(
+            layer.metadata &&
+            layer.metadata.is_record_map &&
+            layer.metadata.is_record_map === true
+          );
           if (remove_layer) {
             mapbox_library_api.map.removeLayer(layer.id);
           }
 
           // Ensure corresponding record map sources are not removed.
-          if ( layer.metadata && layer.metadata.is_record_map && layer.metadata.is_record_map === true ){
-            record_map_sources.push(`dt-maps-${layer.metadata.layer_id}-source`);
+          if (
+            layer.metadata &&
+            layer.metadata.is_record_map &&
+            layer.metadata.is_record_map === true
+          ) {
+            record_map_sources.push(
+              `dt-maps-${layer.metadata.layer_id}-source`,
+            );
           }
         }
-      } )
-      window.lodash.forOwn(style.sources, ( source, source_id)=>{
-        if ( source_id.startsWith("dt-maps-") && !window.lodash.includes(record_map_sources, source_id)){
+      });
+      window.lodash.forOwn(style.sources, (source, source_id) => {
+        if (
+          source_id.startsWith('dt-maps-') &&
+          !window.lodash.includes(record_map_sources, source_id)
+        ) {
           mapbox_library_api.map.removeSource(source_id);
         }
-      } )
-      mapbox_library_api.spinner.show()
-      mapbox_library_api.area_map.previous_grid_list = []
+      });
+      mapbox_library_api.spinner.show();
+      mapbox_library_api.area_map.previous_grid_list = [];
 
-      if ( mapbox_library_api.current_map_type === "cluster" ){
-        mapbox_library_api.cluster_map.default_setup()
-      } else if ( mapbox_library_api.current_map_type === "area" ){
-        mapbox_library_api.area_map.setup()
+      if (mapbox_library_api.current_map_type === 'cluster') {
+        mapbox_library_api.cluster_map.default_setup();
+      } else if (mapbox_library_api.current_map_type === 'area') {
+        mapbox_library_api.area_map.setup();
       } else {
-        mapbox_library_api.points_map.setup()
+        mapbox_library_api.points_map.setup();
       }
     },
-    get_level: function (){
-      let level = 'world'
-      if ( mapbox_library_api.map.getZoom() >= 4 ) {
-        level = 'admin1'
-      } if ( mapbox_library_api.map.getZoom() >= 6 ){
-        level = 'admin2'
+    get_level: function () {
+      let level = 'world';
+      if (mapbox_library_api.map.getZoom() >= 4) {
+        level = 'admin1';
+      }
+      if (mapbox_library_api.map.getZoom() >= 6) {
+        level = 'admin2';
       }
       return level;
     },
 
     points_map: {
       setup: async function () {
-        let points = await window.makeRequest('POST', mapbox_library_api.obj.settings.points_rest_url, {
-          post_type: mapbox_library_api.post_type,
-          query: mapbox_library_api.query_args || {}
-        }, mapbox_library_api.obj.settings.rest_base_url)
-        this.load_layer(points)
+        let points = await window.makeRequest(
+          'POST',
+          mapbox_library_api.obj.settings.points_rest_url,
+          {
+            post_type: mapbox_library_api.post_type,
+            query: mapbox_library_api.query_args || {},
+          },
+          mapbox_library_api.obj.settings.rest_base_url,
+        );
+        this.load_layer(points);
       },
-      load_layer: function ( points, layer_key = 'pointsLayer', color = '#11b4da', size = 6 ) {
-        layer_key = 'dt-maps-' + layer_key
+      load_layer: function (
+        points,
+        layer_key = 'pointsLayer',
+        color = '#11b4da',
+        size = 6,
+      ) {
+        layer_key = 'dt-maps-' + layer_key;
         let mapLayer = mapbox_library_api.map.getLayer(layer_key);
-        if (typeof mapLayer!=='undefined') {
-          mapbox_library_api.map.off('click', layer_key, mapbox_library_api.points_map.on_click);
-          mapbox_library_api.map.removeLayer(layer_key)
+        if (typeof mapLayer !== 'undefined') {
+          mapbox_library_api.map.off(
+            'click',
+            layer_key,
+            mapbox_library_api.points_map.on_click,
+          );
+          mapbox_library_api.map.removeLayer(layer_key);
         }
-        let mapSource = mapbox_library_api.map.getSource(`${layer_key}_pointsSource`);
-        if (typeof mapSource !=='undefined') {
-          mapbox_library_api.map.removeSource(`${layer_key}_pointsSource`)
+        let mapSource = mapbox_library_api.map.getSource(
+          `${layer_key}_pointsSource`,
+        );
+        if (typeof mapSource !== 'undefined') {
+          mapbox_library_api.map.removeSource(`${layer_key}_pointsSource`);
         }
         mapbox_library_api.map.addSource(`${layer_key}_pointsSource`, {
-          'type': 'geojson',
-          'data': points
+          type: 'geojson',
+          data: points,
         });
 
         mapbox_library_api.map.addLayer({
@@ -1090,11 +1427,15 @@ jQuery(document).ready(function($) {
             'circle-color': color,
             'circle-radius': size,
             'circle-stroke-width': 0.5,
-            'circle-stroke-color': '#fff'
-          }
+            'circle-stroke-color': '#fff',
+          },
         });
 
-        mapbox_library_api.map.on('click', layer_key, mapbox_library_api.points_map.on_click);
+        mapbox_library_api.map.on(
+          'click',
+          layer_key,
+          mapbox_library_api.points_map.on_click,
+        );
 
         mapbox_library_api.map.on('mouseenter', layer_key, function () {
           mapbox_library_api.map.getCanvas().style.cursor = 'pointer';
@@ -1103,105 +1444,128 @@ jQuery(document).ready(function($) {
           mapbox_library_api.map.getCanvas().style.cursor = '';
         });
 
-        mapbox_library_api.spinner.hide()
+        mapbox_library_api.spinner.hide();
       },
       on_click: function (e) {
         e.preventDefault();
 
-        let list = []
-        jQuery('#geocode-details').show()
+        let list = [];
+        jQuery('#geocode-details').show();
 
-        let content = jQuery('#geocode-details-content')
-        content.empty().html( mapbox_library_api.spinner )
+        let content = jQuery('#geocode-details-content');
+        content.empty().html(mapbox_library_api.spinner);
 
-        jQuery.each(e.features, function(i,v) {
-          if ( i > 20 ){ return }
+        jQuery.each(e.features, function (i, v) {
+          if (i > 20) {
+            return;
+          }
           let post_id = e.features[i].properties.post_id;
-          let post_type = e.features[i].properties.post_type
-          content.append(`<div class="grid-x" id="list-${window.lodash.escape( i )}"></div>`)
-          window.makeRequest('GET', window.lodash.escape( post_type ) +'/'+window.lodash.escape( post_id )+'/', null, 'dt-posts/v2/' )
-          .done(details=>{
-            list[i] = jQuery('#list-'+i)
+          let post_type = e.features[i].properties.post_type;
+          content.append(
+            `<div class="grid-x" id="list-${window.lodash.escape(i)}"></div>`,
+          );
+          window
+            .makeRequest(
+              'GET',
+              window.lodash.escape(post_type) +
+                '/' +
+                window.lodash.escape(post_id) +
+                '/',
+              null,
+              'dt-posts/v2/',
+            )
+            .done((details) => {
+              list[i] = jQuery('#list-' + i);
 
-            list[i].append(`
-              <div class="cell"><a  target="_blank" href="${window.lodash.escape(window.wpApiShare.site_url)}/${window.lodash.escape( post_type )}/${window.lodash.escape( details.ID )}">${window.lodash.escape( details.title )/*View Record*/}</a></div>
-            `)
+              list[i].append(`
+              <div class="cell"><a  target="_blank" href="${window.lodash.escape(window.wpApiShare.site_url)}/${window.lodash.escape(post_type)}/${window.lodash.escape(details.ID)}">${window.lodash.escape(details.title) /*View Record*/}</a></div>
+            `);
 
-            // Remove any duplicate links.
-            mapbox_library_api.remove_geocode_details_content_duplicates();
+              // Remove any duplicate links.
+              mapbox_library_api.remove_geocode_details_content_duplicates();
 
-            jQuery('.loading-spinner').hide()
-          })
-        })
-      }
+              jQuery('.loading-spinner').hide();
+            });
+        });
+      },
     },
     remove_geocode_details_content_duplicates: function () {
       let content = $('#geocode-details-content');
       let links = [];
-      $(content).find('a').each(function (idx, link) {
-        if (window.lodash.includes(links, $(link).attr('href'))) {
-          $(link).parent().remove();
-
-        } else {
-          links.push($(link).attr('href'));
-        }
-      });
+      $(content)
+        .find('a')
+        .each(function (idx, link) {
+          if (window.lodash.includes(links, $(link).attr('href'))) {
+            $(link).parent().remove();
+          } else {
+            links.push($(link).attr('href'));
+          }
+        });
     },
-    standardize_longitude: function (lng){
+    standardize_longitude: function (lng) {
       if (lng > 180) {
-        lng = lng - 180
-        lng = -Math.abs(lng)
+        lng = lng - 180;
+        lng = -Math.abs(lng);
       } else if (lng < -180) {
-        lng = lng + 180
-        lng = Math.abs(lng)
+        lng = lng + 180;
+        lng = Math.abs(lng);
       }
       return lng;
-    }
+    },
+  };
 
-  }
-
-  jQuery(document).on('click', '.close-details', function() {
-    jQuery('#geocode-details').hide()
-  })
+  jQuery(document).on('click', '.close-details', function () {
+    jQuery('#geocode-details').hide();
+  });
 
   jQuery(document).on('click', '.close-add-records-div', function () {
     jQuery('#add_records_div').hide();
   });
 
   let cluster_map = {
-    default_setup: async function (){
-      let geojson = await window.makeRequest( "POST", mapbox_library_api.obj.settings.rest_url, { post_type: mapbox_library_api.post_type, query: mapbox_library_api.query_args || {}} , mapbox_library_api.obj.settings.rest_base_url )
-      cluster_map.load_layer(geojson)
+    default_setup: async function () {
+      let geojson = await window.makeRequest(
+        'POST',
+        mapbox_library_api.obj.settings.rest_url,
+        {
+          post_type: mapbox_library_api.post_type,
+          query: mapbox_library_api.query_args || {},
+        },
+        mapbox_library_api.obj.settings.rest_base_url,
+      );
+      cluster_map.load_layer(geojson);
     },
-    load_layer: function ( geojson ) {
-
-      mapbox_library_api.map.on('click', 'dt-maps-clusters', function(e) {
-        let features =mapbox_library_api.map.queryRenderedFeatures(e.point, {
-          layers: ['dt-maps-clusters']
+    load_layer: function (geojson) {
+      mapbox_library_api.map.on('click', 'dt-maps-clusters', function (e) {
+        let features = mapbox_library_api.map.queryRenderedFeatures(e.point, {
+          layers: ['dt-maps-clusters'],
         });
 
         let clusterId = features[0].properties.cluster_id;
-        mapbox_library_api.map.getSource('dt-maps-clusterSource').getClusterExpansionZoom(
-          clusterId,
-          function(err, zoom) {
+        mapbox_library_api.map
+          .getSource('dt-maps-clusterSource')
+          .getClusterExpansionZoom(clusterId, function (err, zoom) {
             if (err) return;
 
             mapbox_library_api.map.easeTo({
               center: features[0].geometry.coordinates,
-              zoom: zoom
+              zoom: zoom,
             });
-          }
-        );
-      })
-      mapbox_library_api.map.on('click', 'dt-maps-unclustered-point', cluster_map.on_click );
-      mapbox_library_api.map.on('mouseenter', 'dt-maps-clusters', function() {
+          });
+      });
+      mapbox_library_api.map.on(
+        'click',
+        'dt-maps-unclustered-point',
+        cluster_map.on_click,
+      );
+      mapbox_library_api.map.on('mouseenter', 'dt-maps-clusters', function () {
         mapbox_library_api.map.getCanvas().style.cursor = 'pointer';
       });
-      mapbox_library_api.map.on('mouseleave', 'dt-maps-clusters', function() {
+      mapbox_library_api.map.on('mouseleave', 'dt-maps-clusters', function () {
         mapbox_library_api.map.getCanvas().style.cursor = '';
       });
       let mapSource = mapbox_library_api.map.getSource(`dt-maps-clusterSource`);
-      if (typeof mapSource!=='undefined') {
+      if (typeof mapSource !== 'undefined') {
         mapbox_library_api.map.removeSource(`dt-maps-clusterSource`);
       }
       mapbox_library_api.map.addSource('dt-maps-clusterSource', {
@@ -1209,7 +1573,7 @@ jQuery(document).ready(function($) {
         data: geojson,
         cluster: true,
         clusterMaxZoom: 14,
-        clusterRadius: 50
+        clusterRadius: 50,
       });
 
       mapbox_library_api.map.addLayer({
@@ -1225,7 +1589,7 @@ jQuery(document).ready(function($) {
             100,
             '#f1f075',
             750,
-            '#f28cb1'
+            '#f28cb1',
           ],
           'circle-radius': [
             'step',
@@ -1234,9 +1598,9 @@ jQuery(document).ready(function($) {
             100,
             30,
             750,
-            40
-          ]
-        }
+            40,
+          ],
+        },
       });
       mapbox_library_api.map.addLayer({
         id: 'dt-maps-cluster-count',
@@ -1246,8 +1610,8 @@ jQuery(document).ready(function($) {
         layout: {
           'text-field': '{point_count_abbreviated}',
           'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
-          'text-size': 12
-        }
+          'text-size': 12,
+        },
       });
       mapbox_library_api.map.addLayer({
         id: 'dt-maps-unclustered-point',
@@ -1256,283 +1620,403 @@ jQuery(document).ready(function($) {
         filter: ['!', ['has', 'point_count']],
         paint: {
           'circle-color': '#11b4da',
-          'circle-radius':12,
+          'circle-radius': 12,
           'circle-stroke-width': 1,
-          'circle-stroke-color': '#fff'
-        }
+          'circle-stroke-color': '#fff',
+        },
       });
 
-      mapbox_library_api.spinner.hide()
+      mapbox_library_api.spinner.hide();
     },
     on_click: function (e) {
-      let list = []
-      jQuery('#geocode-details').show()
+      let list = [];
+      jQuery('#geocode-details').show();
 
-      let content = jQuery('#geocode-details-content')
-      content.empty().html(spinner_html)
+      let content = jQuery('#geocode-details-content');
+      content.empty().html(spinner_html);
 
       jQuery.each(e.features, function (i, v) {
-        if ( i > 10 ){ return; }
+        if (i > 10) {
+          return;
+        }
         let post_id = e.features[i].properties.post_id;
-        let post_type = e.features[i].properties.post_type
-        content.append(`<div class="grid-x" id="list-${window.lodash.escape( i )}"></div>`)
-        window.makeRequest('GET', window.lodash.escape( post_type ) +'/'+window.lodash.escape( post_id )+'/', null, 'dt-posts/v2/' )
-        .done(details=>{
-          list[i] = jQuery('#list-'+i)
-          list[i].append(`
-              <div class="cell"><a target="_blank" href="${window.lodash.escape(window.wpApiShare.site_url)}/${window.lodash.escape( post_type )}/${window.lodash.escape( details.ID )}">${window.lodash.escape( details.title )/*View Record*/}</a></div>
-            `)
-          jQuery('.loading-spinner').hide()
-        })
-      })
+        let post_type = e.features[i].properties.post_type;
+        content.append(
+          `<div class="grid-x" id="list-${window.lodash.escape(i)}"></div>`,
+        );
+        window
+          .makeRequest(
+            'GET',
+            window.lodash.escape(post_type) +
+              '/' +
+              window.lodash.escape(post_id) +
+              '/',
+            null,
+            'dt-posts/v2/',
+          )
+          .done((details) => {
+            list[i] = jQuery('#list-' + i);
+            list[i].append(`
+              <div class="cell"><a target="_blank" href="${window.lodash.escape(window.wpApiShare.site_url)}/${window.lodash.escape(post_type)}/${window.lodash.escape(details.ID)}">${window.lodash.escape(details.title) /*View Record*/}</a></div>
+            `);
+            jQuery('.loading-spinner').hide();
+          });
+      });
     },
-  }
+  };
 
   let area_map = {
     grid_data: null,
-    previous_grid_list:[],
+    previous_grid_list: [],
     behind_layer: null,
-    setup: async function ( behind_layer = null ){
-      area_map.behind_layer = behind_layer
-      area_map.grid_data = await window.makeRequest( "POST", mapbox_library_api.obj.settings.totals_rest_url, { post_type: mapbox_library_api.obj.settings.post_type, query: mapbox_library_api.query_args || {}} , mapbox_library_api.obj.settings.rest_base_url )
-      await area_map.load_layer()
+    setup: async function (behind_layer = null) {
+      area_map.behind_layer = behind_layer;
+      area_map.grid_data = await window.makeRequest(
+        'POST',
+        mapbox_library_api.obj.settings.totals_rest_url,
+        {
+          post_type: mapbox_library_api.obj.settings.post_type,
+          query: mapbox_library_api.query_args || {},
+        },
+        mapbox_library_api.obj.settings.rest_base_url,
+      );
+      await area_map.load_layer();
       // load new layer on event
-      mapbox_library_api.map.on('zoomend', function() {
-        if ( mapbox_library_api.current_map_type !== 'area'){return;}
-        area_map.load_layer()
-      })
-      mapbox_library_api.map.on('dragend', function() {
-        if ( mapbox_library_api.current_map_type !== 'area'){return;}
-        area_map.load_layer()
-      })
-      mapbox_library_api.map.on('click', function( e ) {
-        if ( mapbox_library_api.current_map_type !== 'area'){return;}
+      mapbox_library_api.map.on('zoomend', function () {
+        if (mapbox_library_api.current_map_type !== 'area') {
+          return;
+        }
+        area_map.load_layer();
+      });
+      mapbox_library_api.map.on('dragend', function () {
+        if (mapbox_library_api.current_map_type !== 'area') {
+          return;
+        }
+        area_map.load_layer();
+      });
+      mapbox_library_api.map.on('click', function (e) {
+        if (mapbox_library_api.current_map_type !== 'area') {
+          return;
+        }
         // this section increments up the result on level because
         // it corresponds better to the viewable user intent for details
-        let level = mapbox_library_api.get_level()
-        area_map.load_detail_panel( e.lngLat.lng, e.lngLat.lat, level )
-      })
+        let level = mapbox_library_api.get_level();
+        area_map.load_detail_panel(e.lngLat.lng, e.lngLat.lat, level);
+      });
     },
-    load_layer: async function ( level = null){
-      mapbox_library_api.spinner.show()
+    load_layer: async function (level = null) {
+      mapbox_library_api.spinner.show();
       // set geocode level, default to auto
-      if ( !level ){
-        level = mapbox_library_api.get_level()
+      if (!level) {
+        level = mapbox_library_api.get_level();
       }
 
-      let bbox =mapbox_library_api.map.getBounds()
+      let bbox = mapbox_library_api.map.getBounds();
 
-      let data = [{ grid_id:'1', parent_id:'1'}]
-      if ( level !== "world" ){
-        data = await window.makeRequest('GET', `${mapbox_library_api.obj.settings.geocoder_url}dt-mapping/location-grid-list-api.php`,
+      let data = [{ grid_id: '1', parent_id: '1' }];
+      if (level !== 'world') {
+        data = await window.makeRequest(
+          'GET',
+          `${mapbox_library_api.obj.settings.geocoder_url}dt-mapping/location-grid-list-api.php`,
           {
             type: 'match_within_bbox',
             north_latitude: bbox._ne.lat,
             south_latitude: bbox._sw.lat,
-            west_longitude: window.mapbox_library_api.standardize_longitude(bbox._sw.lng),
-            east_longitude: window.mapbox_library_api.standardize_longitude(bbox._ne.lng),
+            west_longitude: window.mapbox_library_api.standardize_longitude(
+              bbox._sw.lng,
+            ),
+            east_longitude: window.mapbox_library_api.standardize_longitude(
+              bbox._ne.lng,
+            ),
             level: level,
             nonce: mapbox_library_api.obj.settings.geocoder_nonce,
-            query: mapbox_library_api.query_args || {}
-          }
-        )
+            query: mapbox_library_api.query_args || {},
+          },
+        );
       }
 
       // default layer to world
-      if ( level === 'world' ) {
-        data = [{ grid_id:'1', parent_id:'1'}]
+      if (level === 'world') {
+        data = [{ grid_id: '1', parent_id: '1' }];
       }
 
-      let status404 = window.SHAREDFUNCTIONS.get_json_cookie('geojson_failed', [] )
+      let status404 = window.SHAREDFUNCTIONS.get_json_cookie(
+        'geojson_failed',
+        [],
+      );
 
-      let done = []
-      data.forEach( res=>{
-        let grid_id = res.grid_id
-        let parent_id = res.parent_id
-        let layer_id = 'dt-maps-' + parent_id.toString()
+      let done = [];
+      data.forEach((res) => {
+        let grid_id = res.grid_id;
+        let parent_id = res.parent_id;
+        let layer_id = 'dt-maps-' + parent_id.toString();
         // is new test
-        if ( !window.lodash.find(area_map.previous_grid_list, {parent_id:parent_id}) && !status404.includes(parent_id) && !done.includes(parent_id) ) {
+        if (
+          !window.lodash.find(area_map.previous_grid_list, {
+            parent_id: parent_id,
+          }) &&
+          !status404.includes(parent_id) &&
+          !done.includes(parent_id)
+        ) {
           // is defined test
           let mapLayer = mapbox_library_api.map.getLayer(layer_id);
-          if(typeof mapLayer === 'undefined') {
-
+          if (typeof mapLayer === 'undefined') {
             done.push(parent_id);
             // get geojson collection
-            jQuery.get( mapbox_library_api.obj.settings.map_mirror + 'collection/' + parent_id + '.geojson', null, null, 'json')
-            .done(function (geojson) {
-              // add data to geojson properties
-              let highest_value = 1
-              jQuery.each(geojson.features, function (i, v) {
-                if (area_map.grid_data[geojson.features[i].properties.grid_id]) {
-                  geojson.features[i].properties.value = parseInt(area_map.grid_data[geojson.features[i].properties.grid_id].count)
-                } else {
-                  geojson.features[i].properties.value = 0
-                }
-                highest_value = Math.max(highest_value,  geojson.features[i].properties.value)
-              })
-              // add source
-              let mapSource = mapbox_library_api.map.getSource(layer_id);
-              if (typeof mapSource==='undefined') {
-                mapbox_library_api.map.addSource(layer_id, {
-                  'type': 'geojson',
-                  'data': geojson
+            jQuery
+              .get(
+                mapbox_library_api.obj.settings.map_mirror +
+                  'collection/' +
+                  parent_id +
+                  '.geojson',
+                null,
+                null,
+                'json',
+              )
+              .done(function (geojson) {
+                // add data to geojson properties
+                let highest_value = 1;
+                jQuery.each(geojson.features, function (i, v) {
+                  if (
+                    area_map.grid_data[geojson.features[i].properties.grid_id]
+                  ) {
+                    geojson.features[i].properties.value = parseInt(
+                      area_map.grid_data[geojson.features[i].properties.grid_id]
+                        .count,
+                    );
+                  } else {
+                    geojson.features[i].properties.value = 0;
+                  }
+                  highest_value = Math.max(
+                    highest_value,
+                    geojson.features[i].properties.value,
+                  );
                 });
-              }
-
-              // add fill layer
-              mapbox_library_api.map.addLayer({
-                'id': layer_id,
-                'type': 'fill',
-                'source': layer_id,
-                'paint': {
-                  'fill-color': {
-                    property: 'value',
-                    stops: [[0, 'rgba(0, 0, 0, 0)'], [1, 'rgb(155, 200, 254)'], [highest_value, 'rgb(37, 82, 154)']]
-                  },
-                  'fill-opacity': 0.75,
-                  'fill-outline-color': '#707070',
+                // add source
+                let mapSource = mapbox_library_api.map.getSource(layer_id);
+                if (typeof mapSource === 'undefined') {
+                  mapbox_library_api.map.addSource(layer_id, {
+                    type: 'geojson',
+                    data: geojson,
+                  });
                 }
-              }, area_map.behind_layer);
-            }).catch(()=>{
-              status404.push(parent_id)
-              window.SHAREDFUNCTIONS.save_json_cookie( 'geojson_failed', status404, 'metrics' )
-            })// end get geojson collection
+
+                // add fill layer
+                mapbox_library_api.map.addLayer(
+                  {
+                    id: layer_id,
+                    type: 'fill',
+                    source: layer_id,
+                    paint: {
+                      'fill-color': {
+                        property: 'value',
+                        stops: [
+                          [0, 'rgba(0, 0, 0, 0)'],
+                          [1, 'rgb(155, 200, 254)'],
+                          [highest_value, 'rgb(37, 82, 154)'],
+                        ],
+                      },
+                      'fill-opacity': 0.75,
+                      'fill-outline-color': '#707070',
+                    },
+                  },
+                  area_map.behind_layer,
+                );
+              })
+              .catch(() => {
+                status404.push(parent_id);
+                window.SHAREDFUNCTIONS.save_json_cookie(
+                  'geojson_failed',
+                  status404,
+                  'metrics',
+                );
+              }); // end get geojson collection
           }
         } // end load new layer
-      })
-      area_map.previous_grid_list.forEach(grid_item=>{
-        let layer_id = 'dt-maps-' + grid_item.parent_id
-        let mapLayer =mapbox_library_api.map.getLayer(layer_id);
-        if(typeof mapLayer !== 'undefined' && !window.lodash.find(data, {parent_id:grid_item.parent_id})) {
-          mapbox_library_api.map.removeLayer( layer_id )
-          mapbox_library_api.map.removeSource( layer_id )
-        }
-      })
-      area_map.previous_grid_list = data
-      mapbox_library_api.spinner.hide()
-    },
-    load_detail_panel: function (lng, lat, level){
-      lng = window.mapbox_library_api.standardize_longitude( lng )
-      if ( level === 'world' ) {
-        level = 'admin0'
-      }
-
-      let content = jQuery('#geocode-details-content')
-      content.empty().html( spinner_html )
-
-      jQuery('#geocode-details').show()
-
-      // geocode
-      window.makeRequest('GET', mapbox_library_api.obj.settings.geocoder_url + 'dt-mapping/location-grid-list-api.php',
-        {
-          type:'geocode',
-          longitude:lng,
-          latitude:lat,
-          level:level,
-          nonce:mapbox_library_api.obj.settings.geocoder_nonce,
-          query: mapbox_library_api.query_args || {}
-        }).done(details=>{
-
-        /* hierarchy list*/
-        content.empty().append(`<ul id="hierarchy-list" class="accordion" data-accordion></ul>`)
-        let list = jQuery('#hierarchy-list')
-        if ( details.admin0_grid_id ) {
-          list.append( `
-            <li id="admin0_wrapper" class="accordion-item" data-accordion-item>
-             <a href="#" class="accordion-title">${window.lodash.escape( details.admin0_name )} :  <span id="admin0_count">0</span></a>
-              <div class="accordion-content grid-x" data-tab-content><div id="admin0_list" class="grid-x"></div></div>
-            </li>
-          `)
-          if ( details.admin0_grid_id in area_map.grid_data ) {
-            jQuery('#admin0_count').html(area_map.grid_data[details.admin0_grid_id].count)
-          }
-
-        }
-        if ( details.admin1_grid_id ) {
-          list.append( `
-            <li id="admin1_wrapper" class="accordion-item" data-accordion-item >
-              <a href="#" class="accordion-title">${window.lodash.escape( details.admin1_name )} : <span id="admin1_count">0</span></a>
-              <div class="accordion-content" data-tab-content><div id="admin1_list" class="grid-x"></div></div>
-            </li>
-          `)
-
-          if ( details.admin1_grid_id in area_map.grid_data ) {
-            jQuery('#admin1_count').html(area_map.grid_data[details.admin1_grid_id].count)
-          }
-
-        }
-        if ( details.admin2_grid_id ) {
-          list.append( `
-            <li id="admin2_wrapper" class="accordion-item" data-accordion-item>
-              <a href="#" class="accordion-title">${window.lodash.escape( details.admin2_name )} : <span id="admin2_count">0</span></a>
-              <div class="accordion-content" data-tab-content><div id="admin2_list" class="grid-x"></div></div>
-            </li>
-          `)
-
-          if ( details.admin2_grid_id in area_map.grid_data ) {
-            jQuery('#admin2_count').html(area_map.grid_data[details.admin2_grid_id].count)
-          }
-        }
-
-        jQuery('.accordion-item').last().addClass('is-active')
-        list.foundation()
-        /* end hierarchy list */
-
-        if ( details.admin2_grid_id !== null ) {
-          jQuery('#admin2_list').html( spinner_html )
-          window.makeRequest( "POST", mapbox_library_api.obj.settings.list_by_grid_rest_url, { grid_id: details.admin2_grid_id, post_type: mapbox_library_api.post_type,
-            query: mapbox_library_api.query_args || {} } , mapbox_library_api.obj.settings.rest_base_url )
-          .done(list_by_grid=>{
-            if ( list_by_grid.length > 0 ) {
-              write_list( 'admin2_list', list_by_grid )
-            } else {
-              jQuery('#admin2_list').html( '' )
-            }
-          })
-        } else if ( details.admin1_grid_id !== null ) {
-          jQuery('#admin1_list').html( spinner_html )
-          window.makeRequest( "POST", mapbox_library_api.obj.settings.list_by_grid_rest_url, { grid_id: details.admin1_grid_id, post_type: mapbox_library_api.post_type,
-            query: mapbox_library_api.query_args || {} } , mapbox_library_api.obj.settings.rest_base_url )
-          .done(list_by_grid=>{
-            if ( list_by_grid.length > 0 ) {
-              write_list( 'admin1_list', list_by_grid )
-            } else {
-              jQuery('#admin1_list').html( '' )
-            }
-          })
-        } else if ( details.admin0_grid_id !== null ) {
-          jQuery('#admin0_list').html( spinner_html )
-          window.makeRequest( "POST", mapbox_library_api.obj.settings.list_by_grid_rest_url, { grid_id: details.admin0_grid_id, post_type: mapbox_library_api.post_type,
-            query: mapbox_library_api.query_args || {} } , mapbox_library_api.obj.settings.rest_base_url )
-          .done(list_by_grid=>{
-            if ( list_by_grid.length > 0 ) {
-              write_list( 'admin0_list', list_by_grid )
-            } else {
-              jQuery('#admin0_list').html( '' )
-            }
-          })
-        }
-
-        function write_list( level, list_by_grid ) {
-          let level_list = jQuery('#'+level)
-          level_list.empty()
-          jQuery.each(list_by_grid, function(i,v) {
-            if ( i > 20 ){ return }
-            level_list.append(`<div class="cell"><a target="_blank" href="${window.lodash.escape(window.wpApiShare.site_url)}/${window.lodash.escape( mapbox_library_api.post_type )}/${window.lodash.escape( v.post_id )}">${window.lodash.escape( v.post_title ) }</a></div>`)
-          })
-          if ( list_by_grid.length > 20 ){
-            level_list.append(`<div class="cell">...</div>`)
-          }
+      });
+      area_map.previous_grid_list.forEach((grid_item) => {
+        let layer_id = 'dt-maps-' + grid_item.parent_id;
+        let mapLayer = mapbox_library_api.map.getLayer(layer_id);
+        if (
+          typeof mapLayer !== 'undefined' &&
+          !window.lodash.find(data, { parent_id: grid_item.parent_id })
+        ) {
+          mapbox_library_api.map.removeLayer(layer_id);
+          mapbox_library_api.map.removeSource(layer_id);
         }
       });
-    }
-  }
+      area_map.previous_grid_list = data;
+      mapbox_library_api.spinner.hide();
+    },
+    load_detail_panel: function (lng, lat, level) {
+      lng = window.mapbox_library_api.standardize_longitude(lng);
+      if (level === 'world') {
+        level = 'admin0';
+      }
 
-  mapbox_library_api.cluster_map = cluster_map
-  mapbox_library_api.area_map = area_map
+      let content = jQuery('#geocode-details-content');
+      content.empty().html(spinner_html);
+
+      jQuery('#geocode-details').show();
+
+      // geocode
+      window
+        .makeRequest(
+          'GET',
+          mapbox_library_api.obj.settings.geocoder_url +
+            'dt-mapping/location-grid-list-api.php',
+          {
+            type: 'geocode',
+            longitude: lng,
+            latitude: lat,
+            level: level,
+            nonce: mapbox_library_api.obj.settings.geocoder_nonce,
+            query: mapbox_library_api.query_args || {},
+          },
+        )
+        .done((details) => {
+          /* hierarchy list*/
+          content
+            .empty()
+            .append(
+              `<ul id="hierarchy-list" class="accordion" data-accordion></ul>`,
+            );
+          let list = jQuery('#hierarchy-list');
+          if (details.admin0_grid_id) {
+            list.append(`
+            <li id="admin0_wrapper" class="accordion-item" data-accordion-item>
+             <a href="#" class="accordion-title">${window.lodash.escape(details.admin0_name)} :  <span id="admin0_count">0</span></a>
+              <div class="accordion-content grid-x" data-tab-content><div id="admin0_list" class="grid-x"></div></div>
+            </li>
+          `);
+            if (details.admin0_grid_id in area_map.grid_data) {
+              jQuery('#admin0_count').html(
+                area_map.grid_data[details.admin0_grid_id].count,
+              );
+            }
+          }
+          if (details.admin1_grid_id) {
+            list.append(`
+            <li id="admin1_wrapper" class="accordion-item" data-accordion-item >
+              <a href="#" class="accordion-title">${window.lodash.escape(details.admin1_name)} : <span id="admin1_count">0</span></a>
+              <div class="accordion-content" data-tab-content><div id="admin1_list" class="grid-x"></div></div>
+            </li>
+          `);
+
+            if (details.admin1_grid_id in area_map.grid_data) {
+              jQuery('#admin1_count').html(
+                area_map.grid_data[details.admin1_grid_id].count,
+              );
+            }
+          }
+          if (details.admin2_grid_id) {
+            list.append(`
+            <li id="admin2_wrapper" class="accordion-item" data-accordion-item>
+              <a href="#" class="accordion-title">${window.lodash.escape(details.admin2_name)} : <span id="admin2_count">0</span></a>
+              <div class="accordion-content" data-tab-content><div id="admin2_list" class="grid-x"></div></div>
+            </li>
+          `);
+
+            if (details.admin2_grid_id in area_map.grid_data) {
+              jQuery('#admin2_count').html(
+                area_map.grid_data[details.admin2_grid_id].count,
+              );
+            }
+          }
+
+          jQuery('.accordion-item').last().addClass('is-active');
+          list.foundation();
+          /* end hierarchy list */
+
+          if (details.admin2_grid_id !== null) {
+            jQuery('#admin2_list').html(spinner_html);
+            window
+              .makeRequest(
+                'POST',
+                mapbox_library_api.obj.settings.list_by_grid_rest_url,
+                {
+                  grid_id: details.admin2_grid_id,
+                  post_type: mapbox_library_api.post_type,
+                  query: mapbox_library_api.query_args || {},
+                },
+                mapbox_library_api.obj.settings.rest_base_url,
+              )
+              .done((list_by_grid) => {
+                if (list_by_grid.length > 0) {
+                  write_list('admin2_list', list_by_grid);
+                } else {
+                  jQuery('#admin2_list').html('');
+                }
+              });
+          } else if (details.admin1_grid_id !== null) {
+            jQuery('#admin1_list').html(spinner_html);
+            window
+              .makeRequest(
+                'POST',
+                mapbox_library_api.obj.settings.list_by_grid_rest_url,
+                {
+                  grid_id: details.admin1_grid_id,
+                  post_type: mapbox_library_api.post_type,
+                  query: mapbox_library_api.query_args || {},
+                },
+                mapbox_library_api.obj.settings.rest_base_url,
+              )
+              .done((list_by_grid) => {
+                if (list_by_grid.length > 0) {
+                  write_list('admin1_list', list_by_grid);
+                } else {
+                  jQuery('#admin1_list').html('');
+                }
+              });
+          } else if (details.admin0_grid_id !== null) {
+            jQuery('#admin0_list').html(spinner_html);
+            window
+              .makeRequest(
+                'POST',
+                mapbox_library_api.obj.settings.list_by_grid_rest_url,
+                {
+                  grid_id: details.admin0_grid_id,
+                  post_type: mapbox_library_api.post_type,
+                  query: mapbox_library_api.query_args || {},
+                },
+                mapbox_library_api.obj.settings.rest_base_url,
+              )
+              .done((list_by_grid) => {
+                if (list_by_grid.length > 0) {
+                  write_list('admin0_list', list_by_grid);
+                } else {
+                  jQuery('#admin0_list').html('');
+                }
+              });
+          }
+
+          function write_list(level, list_by_grid) {
+            let level_list = jQuery('#' + level);
+            level_list.empty();
+            jQuery.each(list_by_grid, function (i, v) {
+              if (i > 20) {
+                return;
+              }
+              level_list.append(
+                `<div class="cell"><a target="_blank" href="${window.lodash.escape(window.wpApiShare.site_url)}/${window.lodash.escape(mapbox_library_api.post_type)}/${window.lodash.escape(v.post_id)}">${window.lodash.escape(v.post_title)}</a></div>`,
+              );
+            });
+            if (list_by_grid.length > 20) {
+              level_list.append(`<div class="cell">...</div>`);
+            }
+          }
+        });
+    },
+  };
+
+  mapbox_library_api.cluster_map = cluster_map;
+  mapbox_library_api.area_map = area_map;
   window.mapbox_library_api = mapbox_library_api;
 
   window.mapbox_library_api.setup_container();
-  let obj = window.dt_mapbox_metrics
-  jQuery('#metrics-sidemenu').foundation('down', jQuery(`#${obj.settings.menu_slug}-menu`));
-})
+  let obj = window.dt_mapbox_metrics;
+  jQuery('#metrics-sidemenu').foundation(
+    'down',
+    jQuery(`#${obj.settings.menu_slug}-menu`),
+  );
+});

--- a/dt-metrics/records/genmap.js
+++ b/dt-metrics/records/genmap.js
@@ -1,18 +1,18 @@
-jQuery(document).ready(function($) {
+jQuery(document).ready(function ($) {
   if (window.wpApiShare.url_path.startsWith('metrics/records/genmap')) {
     project_records_genmap();
   }
 
   let orgchart_container = null;
   function project_records_genmap() {
-    "use strict";
-    let chart = jQuery('#chart')
-    let spinner = ' <span class="loading-spinner active"></span> '
+    'use strict';
+    let chart = jQuery('#chart');
+    let spinner = ' <span class="loading-spinner active"></span> ';
 
-    chart.empty().html(spinner)
+    chart.empty().html(spinner);
     jQuery('#metrics-sidemenu').foundation('down', jQuery('#records-menu'));
 
-    let translations = window.dtMetricsProject.translations
+    let translations = window.dtMetricsProject.translations;
 
     chart.empty().html(`
           <div class="grid-x grid-padding-x">
@@ -53,19 +53,23 @@ jQuery(document).ready(function($) {
           </div>
 
           <div id="modal" class="reveal" data-reveal></div>
-       `)
+       `);
 
-    window.load_genmap = ( focus_id = null ) => {
+    window.load_genmap = (focus_id = null) => {
       jQuery('#infinite_loops_grid_div').fadeOut('fast');
       jQuery('#genmap-details').empty();
       let select_post_type_fields = jQuery('#select_post_type_fields');
 
       let selected_post_type = jQuery('#select_post_types').val();
       let payload = {
-        'p2p_type': jQuery(select_post_type_fields).find('option:selected').data('p2p_key'),
-        'p2p_direction': jQuery(select_post_type_fields).find('option:selected').data('p2p_direction'),
-        'post_type': selected_post_type,
-        'gen_depth_limit': 100,
+        p2p_type: jQuery(select_post_type_fields)
+          .find('option:selected')
+          .data('p2p_key'),
+        p2p_direction: jQuery(select_post_type_fields)
+          .find('option:selected')
+          .data('p2p_direction'),
+        post_type: selected_post_type,
+        gen_depth_limit: 100,
       };
 
       // Dynamically update URL parameters.
@@ -77,123 +81,147 @@ jQuery(document).ready(function($) {
         payload['focus_id'] = focus_id;
         url.searchParams.set('focus_id', focus_id);
       } else {
-          url.searchParams.delete('focus_id');
+        url.searchParams.delete('focus_id');
       }
 
       window.history.pushState(null, document.title, url.search);
 
       // Fetch generational map chart.
-      window.makeRequest('POST', 'metrics/records/genmap', payload )
-      .promise()
-      .then(response => {
-        let container = jQuery('#genmap')
-        container.empty()
+      window
+        .makeRequest('POST', 'metrics/records/genmap', payload)
+        .promise()
+        .then((response) => {
+          let container = jQuery('#genmap');
+          container.empty();
 
-        let loops = identify_infinite_loops( response, [] );
-        if ( loops.length > 0 ) {
-          display_infinite_loops( loops );
-        }
+          let loops = identify_infinite_loops(response, []);
+          if (loops.length > 0) {
+            display_infinite_loops(loops);
+          }
 
-        var nodeTemplate = function(data) {
-          return `
+          var nodeTemplate = function (data) {
+            return `
             <div class="title" data-item-id="${window.lodash.escape(data.id)}">${window.lodash.escape(data.name)}</div>
             <div class="content">${window.lodash.escape(data.content)}</div>
           `;
-        };
+          };
 
-        // Ensure no result responses are reshaped accordingly.
-        if ( response && (typeof response === 'string') && response.includes('No Results') ) {
-          response = {};
-        }
+          // Ensure no result responses are reshaped accordingly.
+          if (
+            response &&
+            typeof response === 'string' &&
+            response.includes('No Results')
+          ) {
+            response = {};
+          }
 
-        orgchart_container = container.orgchart({
-          'data': response,
-          'nodeContent': 'content',
-          'direction': 'l2r',
-          'nodeTemplate': nodeTemplate,
-        });
+          orgchart_container = container.orgchart({
+            data: response,
+            nodeContent: 'content',
+            direction: 'l2r',
+            nodeTemplate: nodeTemplate,
+          });
 
-        let container_height = window.innerHeight - 200 // because it is rotated
-        container.height(container_height)
+          let container_height = window.innerHeight - 200; // because it is rotated
+          container.height(container_height);
 
-        container.off('click', '.node' )
-        container.on('click', '.node', function () {
-          let node = jQuery(this)
-          let node_id = node.attr('id')
-          let node_parent_id = node.data('parent')
+          container.off('click', '.node');
+          container.on('click', '.node', function () {
+            let node = jQuery(this);
+            let node_id = node.attr('id');
+            let node_parent_id = node.data('parent');
 
-          open_modal_details(node_id, node_parent_id, selected_post_type)
+            open_modal_details(node_id, node_parent_id, selected_post_type);
+          });
         })
-      })
-      .catch(error => {
-        let msg = ( (error.responseJSON !== undefined) && error.responseJSON['message'] ) ? error.responseJSON['message'] : error.statusText;
-        alert(window.lodash.escape(msg));
-      });
-    }
+        .catch((error) => {
+          let msg =
+            error.responseJSON !== undefined && error.responseJSON['message']
+              ? error.responseJSON['message']
+              : error.statusText;
+          alert(window.lodash.escape(msg));
+        });
+    };
 
     // Set initial states and default to any specified url parameters.
     refresh_post_type_select_list(function () {
-
       const request_params = fetch_url_search_params();
 
       // Ensure required parts are present, in order to proceed.
-      if ( request_params && request_params.record_type ) {
+      if (request_params && request_params.record_type) {
         jQuery('#select_post_types').val(request_params.record_type);
       }
 
-      refresh_post_type_field_select_list( function() {
-        if ( request_params && request_params.field ) {
+      refresh_post_type_field_select_list(function () {
+        if (request_params && request_params.field) {
           jQuery('#select_post_type_fields').val(request_params.field);
-          window.load_genmap((request_params.focus_id) ? request_params.focus_id : null);
-
+          window.load_genmap(
+            request_params.focus_id ? request_params.focus_id : null,
+          );
         } else {
           window.load_genmap();
         }
       });
-
     });
 
-    jQuery('#select_post_types').on('change', function(e) {
-        refresh_post_type_field_select_list(window.load_genmap);
+    jQuery('#select_post_types').on('change', function (e) {
+      refresh_post_type_field_select_list(window.load_genmap);
     });
 
-    jQuery('#select_post_type_fields').on('change', function(e) {
+    jQuery('#select_post_type_fields').on('change', function (e) {
       window.load_genmap();
     });
 
-    jQuery(document).on('click', '.genmap-details-add-child', function(e) {
+    jQuery(document).on('click', '.genmap-details-add-child', function (e) {
       let control = jQuery(e.currentTarget);
-      display_add_child_modal(jQuery(control).data('post_type'), jQuery(control).data('post_id'), jQuery(control).data('post_name'));
+      display_add_child_modal(
+        jQuery(control).data('post_type'),
+        jQuery(control).data('post_id'),
+        jQuery(control).data('post_name'),
+      );
     });
 
-    jQuery(document).on('click', '.genmap-details-add-focus', function(e) {
-        let control = jQuery(e.currentTarget);
-        let post_type = jQuery(control).data('post_type');
-        let post_id = jQuery(control).data('post_id');
-        let p2p_key = jQuery('#select_post_type_fields').find('option:selected').data('p2p_key');
+    jQuery(document).on('click', '.genmap-details-add-focus', function (e) {
+      let control = jQuery(e.currentTarget);
+      let post_type = jQuery(control).data('post_type');
+      let post_id = jQuery(control).data('post_id');
+      let p2p_key = jQuery('#select_post_type_fields')
+        .find('option:selected')
+        .data('p2p_key');
 
-        handle_focus(post_type, post_id, p2p_key);
+      handle_focus(post_type, post_id, p2p_key);
     });
 
-    jQuery(document).on('click', '.genmap-details-toggle-child-display', function(e) {
-      toggle_child_display(jQuery(e.currentTarget).data('post_id'), jQuery(e.currentTarget).data('parent_id'));
-    });
+    jQuery(document).on(
+      'click',
+      '.genmap-details-toggle-child-display',
+      function (e) {
+        toggle_child_display(
+          jQuery(e.currentTarget).data('post_id'),
+          jQuery(e.currentTarget).data('parent_id'),
+        );
+      },
+    );
 
     jQuery(document).on('click', '#gen_tree_add_child_but', function (e) {
       handle_add_child();
     });
   }
 
-  function identify_infinite_loops( data, loops ) {
-    if ( data?.['children'] ) {
+  function identify_infinite_loops(data, loops) {
+    if (data?.['children']) {
       data['children'].forEach(function (item) {
         if (item['has_infinite_loop']) {
           loops.push({
-            'id': item['id'],
-            'name': item['name'],
-            'loop': extract_infinite_loop(item['id'], item['children'], [], false)
+            id: item['id'],
+            name: item['name'],
+            loop: extract_infinite_loop(
+              item['id'],
+              item['children'],
+              [],
+              false,
+            ),
           });
-
         } else if (item?.['children'].length > 0) {
           loops = identify_infinite_loops(item, loops);
         }
@@ -203,21 +231,25 @@ jQuery(document).ready(function($) {
     return loops;
   }
 
-  function extract_infinite_loop( parent_id, children, loop, loop_closed ) {
-    children.forEach(function ( item ) {
-      if ( parent_id === item['id'] ) {
+  function extract_infinite_loop(parent_id, children, loop, loop_closed) {
+    children.forEach(function (item) {
+      if (parent_id === item['id']) {
         loop_closed = true;
-
-      } else if ( !loop_closed ) {
+      } else if (!loop_closed) {
         loop.push(item);
-        loop = extract_infinite_loop( parent_id, item['children'], loop, loop_closed );
+        loop = extract_infinite_loop(
+          parent_id,
+          item['children'],
+          loop,
+          loop_closed,
+        );
       }
     });
 
     return loop;
   }
 
-  function display_infinite_loops( loops ) {
+  function display_infinite_loops(loops) {
     let loops_grid_div = jQuery('#infinite_loops_grid_div');
     let loops_div = jQuery('#infinite_loops_div');
     let selected_post_type = jQuery('#select_post_types').val();
@@ -227,18 +259,17 @@ jQuery(document).ready(function($) {
 
       // Ensure duplicate loops are removed.
       let processed_loop_ids = [];
-      let filtered_loops = loops.filter( loop => {
-        if ( !processed_loop_ids.includes( loop['id'] ) ) {
-          processed_loop_ids.push( loop['id'] );
+      let filtered_loops = loops.filter((loop) => {
+        if (!processed_loop_ids.includes(loop['id'])) {
+          processed_loop_ids.push(loop['id']);
           return true;
-
         } else {
           return false;
         }
       });
 
       // Proceed with filtered loops display
-      filtered_loops.forEach(function ( item ) {
+      filtered_loops.forEach(function (item) {
         let html = `
         <table>
             <thead>
@@ -254,7 +285,7 @@ jQuery(document).ready(function($) {
             <tbody>
               ${(function func(loop, post_type) {
                 let tbody_html = ``;
-                loop.forEach(function ( child ) {
+                loop.forEach(function (child) {
                   tbody_html += `
                   <tr>
                     <td>
@@ -279,16 +310,16 @@ jQuery(document).ready(function($) {
   }
 
   function fetch_url_search_params() {
-      const url_search_params = new URLSearchParams(window.location.search);
+    const url_search_params = new URLSearchParams(window.location.search);
 
-      let request_params = {};
-      for ( const param of url_search_params ) {
-          if ( Array.isArray( param ) && param.length === 2 ) {
-              request_params[ param[0] ] = param[1];
-          }
+    let request_params = {};
+    for (const param of url_search_params) {
+      if (Array.isArray(param) && param.length === 2) {
+        request_params[param[0]] = param[1];
       }
+    }
 
-      return request_params;
+    return request_params;
   }
 
   function display_add_child_modal(post_type, post_id, post_name) {
@@ -304,21 +335,29 @@ jQuery(document).ready(function($) {
 
     let modal = jQuery('#template_metrics_modal');
     let modal_buttons = jQuery('#template_metrics_modal_buttons');
-    let title = window.dtMetricsProject.translations.modal.add_child_title + ` [ ${window.lodash.escape(post_name)} ]`;
+    let title =
+      window.dtMetricsProject.translations.modal.add_child_title +
+      ` [ ${window.lodash.escape(post_name)} ]`;
     let content = jQuery('#template_metrics_modal_content');
 
     jQuery(modal_buttons).empty().html(buttons_html);
 
-    jQuery('#template_metrics_modal_title').empty().html(window.lodash.escape(title));
+    jQuery('#template_metrics_modal_title')
+      .empty()
+      .html(window.lodash.escape(title));
     jQuery(content).css('max-height', '300px');
     jQuery(content).css('overflow', 'auto');
     jQuery(content).empty().html(list_html);
     jQuery(modal).foundation('open');
   }
 
-  $(document).on('open.zf.reveal', '#template_metrics_modal[data-reveal]', function () {
-    jQuery('#gen_tree_add_child_name').focus();
-  });
+  $(document).on(
+    'open.zf.reveal',
+    '#template_metrics_modal[data-reveal]',
+    function () {
+      jQuery('#gen_tree_add_child_name').focus();
+    },
+  );
 
   function handle_add_child() {
     let post_type = jQuery('#gen_tree_add_child_post_type').val();
@@ -328,92 +367,108 @@ jQuery(document).ready(function($) {
 
     if (post_type && parent_id && child_title && field_id) {
       window.API.create_post(post_type, {
-        'title': child_title,
-        'additional_meta': {
-          'created_from': parent_id,
-          'add_connection': field_id
-        }
-      }).then(new_post => {
+        title: child_title,
+        additional_meta: {
+          created_from: parent_id,
+          add_connection: field_id,
+        },
+      })
+        .then((new_post) => {
+          // Close modal and refresh generation tree, accordingly, based on focussed state.
+          jQuery('#template_metrics_modal').foundation('close');
 
-        // Close modal and refresh generation tree, accordingly, based on focussed state.
-        jQuery('#template_metrics_modal').foundation('close');
-
-        // Ensure to respect any existing focussed selections.
-        const request_params = fetch_url_search_params();
-        window.load_genmap( ( request_params && request_params.focus_id ) ? request_params.focus_id : null );
-
-      }).catch(function (error) {
-        console.error(error);
-      });
+          // Ensure to respect any existing focussed selections.
+          const request_params = fetch_url_search_params();
+          window.load_genmap(
+            request_params && request_params.focus_id
+              ? request_params.focus_id
+              : null,
+          );
+        })
+        .catch(function (error) {
+          console.error(error);
+        });
     }
   }
 
   function handle_focus(post_type, post_id, p2p_key) {
-    if ( post_id ) {
-      window.load_genmap( post_id );
+    if (post_id) {
+      window.load_genmap(post_id);
     }
   }
 
   function toggle_child_display(post_id, parent_id) {
-      if (post_id && orgchart_container) {
-          let query = (parent_id === 0 ? `#${post_id}.node` : `#${post_id}.node[data-parent='${parent_id}']`);
-          let node = jQuery('#genmap').find(query);
-          if (node) {
-              let children = orgchart_container.getNodeState(node, 'children');
-              if (children.exist === true) {
-                if ( children.visible === true ) {
-                    orgchart_container.hideChildren(node);
-                } else {
-                    toggle_child_display_show_children(node);
-                }
-              }
+    if (post_id && orgchart_container) {
+      let query =
+        parent_id === 0
+          ? `#${post_id}.node`
+          : `#${post_id}.node[data-parent='${parent_id}']`;
+      let node = jQuery('#genmap').find(query);
+      if (node) {
+        let children = orgchart_container.getNodeState(node, 'children');
+        if (children.exist === true) {
+          if (children.visible === true) {
+            orgchart_container.hideChildren(node);
+          } else {
+            toggle_child_display_show_children(node);
           }
+        }
       }
+    }
   }
 
-    function toggle_child_display_show_children(node) {
-        if (node && orgchart_container) {
-            orgchart_container.showChildren(node);
+  function toggle_child_display_show_children(node) {
+    if (node && orgchart_container) {
+      orgchart_container.showChildren(node);
 
-            // Recursively display nested children.
-            let children = orgchart_container.getChildren(node);
-            if ( ( children !== undefined ) && children.length > 0 ) {
-                children.each(function (idx, child) {
-                    toggle_child_display_show_children(jQuery(child));
-                });
-            }
-        }
+      // Recursively display nested children.
+      let children = orgchart_container.getChildren(node);
+      if (children !== undefined && children.length > 0) {
+        children.each(function (idx, child) {
+          toggle_child_display_show_children(jQuery(child));
+        });
+      }
     }
+  }
 
   function refresh_post_type_select_list(callback = null) {
     let post_types = window.dtMetricsProject.post_types;
-    if ( post_types ) {
+    if (post_types) {
       let post_type_select = jQuery('#select_post_types');
       jQuery(post_type_select).empty();
 
       // Only focus on post types with valid connection types.
       let filtered_post_types = [];
-      jQuery.each( post_types, function ( post_type, post_type_obj ) {
-        if ( post_type_obj && post_type_obj.connection_types && Array.isArray( post_type_obj.connection_types ) && filter_post_type_connection_fields( post_type ).length > 0 ) {
+      jQuery.each(post_types, function (post_type, post_type_obj) {
+        if (
+          post_type_obj &&
+          post_type_obj.connection_types &&
+          Array.isArray(post_type_obj.connection_types) &&
+          filter_post_type_connection_fields(post_type).length > 0
+        ) {
           filtered_post_types.push({
             value: post_type,
-            text: post_type_obj.label_plural
+            text: post_type_obj.label_plural,
           });
         }
       });
 
-      let sorted_post_types = window.lodash.sortBy(filtered_post_types, [function (o) {
-        return o.text;
-      }]);
-      jQuery.each( sorted_post_types, function ( idx, option ) {
-        jQuery(post_type_select).append(jQuery('<option>', {
-          value: option.value,
-          text: option.text
-        }));
+      let sorted_post_types = window.lodash.sortBy(filtered_post_types, [
+        function (o) {
+          return o.text;
+        },
+      ]);
+      jQuery.each(sorted_post_types, function (idx, option) {
+        jQuery(post_type_select).append(
+          jQuery('<option>', {
+            value: option.value,
+            text: option.text,
+          }),
+        );
       });
     }
 
-    if ( callback ) {
+    if (callback) {
       callback();
     }
   }
@@ -427,50 +482,75 @@ jQuery(document).ready(function($) {
       jQuery(post_type_fields_select).empty();
 
       // Capture related connection type fields.
-      let filtered_post_type_fields = filter_post_type_connection_fields( selected_post_type );
+      let filtered_post_type_fields =
+        filter_post_type_connection_fields(selected_post_type);
 
-      let uniq_post_type_fields = window.lodash.uniqWith(filtered_post_type_fields, function (a, b) {
-        return (a.p2p_key === b.p2p_key) && (a.p2p_direction === b.p2p_direction);
-      });
+      let uniq_post_type_fields = window.lodash.uniqWith(
+        filtered_post_type_fields,
+        function (a, b) {
+          return a.p2p_key === b.p2p_key && a.p2p_direction === b.p2p_direction;
+        },
+      );
 
-      let sorted_post_type_fields = window.lodash.sortBy(uniq_post_type_fields, [function (o) {
-        return o.text;
-      }]);
+      let sorted_post_type_fields = window.lodash.sortBy(
+        uniq_post_type_fields,
+        [
+          function (o) {
+            return o.text;
+          },
+        ],
+      );
 
-      jQuery.each( sorted_post_type_fields, function ( idx, option ) {
-        jQuery('<option>').val(option.value).text(option.text).attr('data-p2p_key', option.p2p_key).attr('data-p2p_direction', option.p2p_direction).appendTo(post_type_fields_select);
+      jQuery.each(sorted_post_type_fields, function (idx, option) {
+        jQuery('<option>')
+          .val(option.value)
+          .text(option.text)
+          .attr('data-p2p_key', option.p2p_key)
+          .attr('data-p2p_direction', option.p2p_direction)
+          .appendTo(post_type_fields_select);
       });
     }
 
-    if ( callback ) {
+    if (callback) {
       callback();
     }
   }
 
-  function filter_post_type_connection_fields( post_type ) {
+  function filter_post_type_connection_fields(post_type) {
     const post_types = window.dtMetricsProject.post_types;
     let filtered_post_type_fields = [];
-    if (post_types && post_type && post_types[post_type] && post_types[post_type].connection_types) {
-
+    if (
+      post_types &&
+      post_type &&
+      post_types[post_type] &&
+      post_types[post_type].connection_types
+    ) {
       // Only capture related connection type fields.
-      post_types[post_type].connection_types.forEach( ( field_id, idx ) => {
-        if ( post_types[post_type]['fields'][field_id] && post_types[post_type]['fields'][field_id]['post_type'] && post_types[post_type]['fields'][field_id]['post_type'] === post_type ) {
-
+      post_types[post_type].connection_types.forEach((field_id, idx) => {
+        if (
+          post_types[post_type]['fields'][field_id] &&
+          post_types[post_type]['fields'][field_id]['post_type'] &&
+          post_types[post_type]['fields'][field_id]['post_type'] === post_type
+        ) {
           // Hard filter some specific fields.
           let to_be_filtered = true;
-          if ( ( post_type === 'contacts' ) && [ 'baptized_by', 'coached_by', 'subassigned' ].includes( field_id ) ) {
+          if (
+            post_type === 'contacts' &&
+            ['baptized_by', 'coached_by', 'subassigned'].includes(field_id)
+          ) {
             to_be_filtered = false;
           }
-          if ( ( post_type === 'groups' ) && [ 'parent_groups' ].includes( field_id ) ) {
+          if (post_type === 'groups' && ['parent_groups'].includes(field_id)) {
             to_be_filtered = false;
           }
 
-          if ( to_be_filtered ) {
+          if (to_be_filtered) {
             filtered_post_type_fields.push({
               value: field_id,
               text: post_types[post_type]['fields'][field_id]['name'],
               p2p_key: post_types[post_type]['fields'][field_id]['p2p_key'],
-              p2p_direction: post_types[post_type]['fields'][field_id]['p2p_direction']
+              p2p_direction:
+                post_types[post_type]['fields'][field_id]['p2p_direction'],
             });
           }
         }
@@ -480,68 +560,83 @@ jQuery(document).ready(function($) {
     return filtered_post_type_fields;
   }
 
-  function open_modal_details( id, parent_id, post_type ) {
-    if ( id ) {
-      let spinner = ' <span class="loading-spinner active"></span> '
-      jQuery('#genmap-details').html(spinner)
+  function open_modal_details(id, parent_id, post_type) {
+    if (id) {
+      let spinner = ' <span class="loading-spinner active"></span> ';
+      jQuery('#genmap-details').html(spinner);
 
-      window.makeRequest('GET', post_type + '/' + id, null, 'dt-posts/v2/')
-      .promise()
-      .then(data => {
-        let container = jQuery('#genmap-details')
-        container.empty()
-        if (data) {
-          container.html(window.detail_template(parent_id, post_type, data))
-        }
-      })
-      .catch(error => {
-        jQuery('#genmap-details').html('');
-      });
+      window
+        .makeRequest('GET', post_type + '/' + id, null, 'dt-posts/v2/')
+        .promise()
+        .then((data) => {
+          let container = jQuery('#genmap-details');
+          container.empty();
+          if (data) {
+            container.html(window.detail_template(parent_id, post_type, data));
+          }
+        })
+        .catch((error) => {
+          jQuery('#genmap-details').html('');
+        });
     }
   }
 
-  window.detail_template = ( parent_id, post_type, data ) => {
-    let escaped_translations = window.SHAREDFUNCTIONS.escapeObject( window.dtMetricsProject.translations );
+  window.detail_template = (parent_id, post_type, data) => {
+    let escaped_translations = window.SHAREDFUNCTIONS.escapeObject(
+      window.dtMetricsProject.translations,
+    );
 
     // Determine orgchart node state.
     let orgchart_node_state = {};
     if (data.ID && orgchart_container) {
       let orgchart_node = jQuery('#genmap').find(`#${data.ID}.node`);
-      let orgchart_node_children = orgchart_container.getNodeState(orgchart_node, 'children');
+      let orgchart_node_children = orgchart_container.getNodeState(
+        orgchart_node,
+        'children',
+      );
 
       // Capture associated children state.
-      orgchart_node_state['children_exist'] = (orgchart_node_children.exist) ? orgchart_node_children.exist : false;
-      orgchart_node_state['children_visible'] = (orgchart_node_children.visible) ? orgchart_node_children.visible : false;
+      orgchart_node_state['children_exist'] = orgchart_node_children.exist
+        ? orgchart_node_children.exist
+        : false;
+      orgchart_node_state['children_visible'] = orgchart_node_children.visible
+        ? orgchart_node_children.visible
+        : false;
     }
-    let toggle_child_displayed_but_state = ((orgchart_node_state['children_exist'] !== undefined) && orgchart_node_state['children_exist'] === false) ? 'disabled' : '';
+    let toggle_child_displayed_but_state =
+      orgchart_node_state['children_exist'] !== undefined &&
+      orgchart_node_state['children_exist'] === false
+        ? 'disabled'
+        : '';
 
-    let template = ''
+    let template = '';
 
-    if ( post_type === 'contacts' ) {
-
-      let assign_to = ''
-      if ( typeof data.assigned_to !== 'undefined' ) {
-        assign_to = data.assigned_to.display
+    if (post_type === 'contacts') {
+      let assign_to = '';
+      if (typeof data.assigned_to !== 'undefined') {
+        assign_to = data.assigned_to.display;
       }
-      let coach_list = ''
-      if ( typeof data.coached_by !== 'undefined' ) {
-        coach_list = '<ul>'
-        jQuery.each( data.coached_by, function( index, value ) {
-          coach_list += '<li>' + window.lodash.escape(value['post_title']) + '</li>'
-        })
-        coach_list += '</ul>'
+      let coach_list = '';
+      if (typeof data.coached_by !== 'undefined') {
+        coach_list = '<ul>';
+        jQuery.each(data.coached_by, function (index, value) {
+          coach_list +=
+            '<li>' + window.lodash.escape(value['post_title']) + '</li>';
+        });
+        coach_list += '</ul>';
       }
-      let group_list = ''
-      if ( typeof data.groups !== 'undefined' ) {
-        group_list = '<ul>'
-        jQuery.each( data.groups, function( index, value ) {
-          group_list += '<li>' + window.lodash.escape(value['post_title']) + '</li>'
-        })
-        group_list += '</ul>'
+      let group_list = '';
+      if (typeof data.groups !== 'undefined') {
+        group_list = '<ul>';
+        jQuery.each(data.groups, function (index, value) {
+          group_list +=
+            '<li>' + window.lodash.escape(value['post_title']) + '</li>';
+        });
+        group_list += '</ul>';
       }
-      let status = ''
-      if ( typeof data.overall_status !== 'undefined' ) {
-        status = data.overall_status['label']
+      let status = '';
+      if (typeof data.overall_status !== 'undefined') {
+        status = data.overall_status['label'];
       }
       template = `
         <div class="grid-x grid-padding-x">
@@ -565,40 +660,41 @@ jQuery(document).ready(function($) {
           </div>
         </div>
       `;
-    } else if ( post_type === 'groups' ) {
+    } else if (post_type === 'groups') {
+      let members_count = 0;
+      if (typeof data.member_count !== 'undefined') {
+        members_count = data.member_count;
+      }
+      let assign_to = '';
+      if (typeof data.assigned_to !== 'undefined') {
+        assign_to = data.assigned_to.display;
+      }
 
-      let members_count = 0
-      if ( typeof data.member_count !== 'undefined' ) {
-        members_count = data.member_count
+      let member_list = '';
+      if (typeof data.members !== 'undefined') {
+        member_list = '<ul>';
+        jQuery.each(data.members, function (index, value) {
+          member_list +=
+            '<li>' + window.lodash.escape(value['post_title']) + '</li>';
+        });
+        member_list += '</ul>';
       }
-      let assign_to = ''
-      if ( typeof data.assigned_to !== 'undefined' ) {
-        assign_to = data.assigned_to.display
+      let coach_list = '';
+      if (typeof data.coached_by !== 'undefined') {
+        coach_list = '<ul>';
+        jQuery.each(data.coached_by, function (index, value) {
+          coach_list +=
+            '<li>' + window.lodash.escape(value['post_title']) + '</li>';
+        });
+        coach_list += '</ul>';
       }
-
-      let member_list = ''
-      if ( typeof data.members !== 'undefined' ) {
-        member_list = '<ul>'
-        jQuery.each( data.members, function( index, value ) {
-          member_list += '<li>' + window.lodash.escape(value['post_title']) + '</li>'
-        })
-        member_list += '</ul>'
+      let status = '';
+      if (typeof data.group_status !== 'undefined') {
+        status = data.group_status['label'];
       }
-      let coach_list = ''
-      if ( typeof data.coached_by !== 'undefined' ) {
-        coach_list = '<ul>'
-        jQuery.each( data.coached_by, function( index, value ) {
-          coach_list += '<li>' + window.lodash.escape(value['post_title']) + '</li>'
-        })
-        coach_list += '</ul>'
-      }
-      let status = ''
-      if ( typeof data.group_status !== 'undefined' ) {
-        status = data.group_status['label']
-      }
-      let type = ''
-      if ( typeof data.group_type !== 'undefined' ) {
-        type = data.group_type['label']
+      let type = '';
+      if (typeof data.group_type !== 'undefined') {
+        type = data.group_type['label'];
       }
       template = `
         <div class="grid-x grid-padding-x">
@@ -627,7 +723,7 @@ jQuery(document).ready(function($) {
             ${coach_list}
           </div>
         </div>
-      `
+      `;
     } else {
       template = `
         <div class="grid-x grid-padding-x">
@@ -654,7 +750,7 @@ jQuery(document).ready(function($) {
               <i class="mdi mdi-bullseye-arrow gen-node-control-focus" style="font-size: 20px;"></i>
               <span style="display: flex">${escaped_translations.details.focus}</span>
           </a>
-          <a href="#" class="button genmap-details-toggle-child-display" data-post_type="${window.lodash.escape(data.post_type)}" data-post_id="${window.lodash.escape(data.ID)}" data-post_name="${window.lodash.escape(data.title)}" data-parent_id="${window.lodash.escape( ((parent_id !== undefined) ? parent_id : 0) )}" ${ toggle_child_displayed_but_state }>
+          <a href="#" class="button genmap-details-toggle-child-display" data-post_type="${window.lodash.escape(data.post_type)}" data-post_id="${window.lodash.escape(data.ID)}" data-post_name="${window.lodash.escape(data.title)}" data-parent_id="${window.lodash.escape(parent_id !== undefined ? parent_id : 0)}" ${toggle_child_displayed_but_state}>
               <i class="mdi mdi-file-tree" style="font-size: 20px;"></i>
               <span style="display: flex">${escaped_translations.details.hide}</span>
           </a>
@@ -662,9 +758,8 @@ jQuery(document).ready(function($) {
       </div>
       `;
     return template;
-  }
-
-})
+  };
+});
 // {
 //   'icons': {
 //   'theme': 'oci',

--- a/dt-people-groups/people-groups.js
+++ b/dt-people-groups/people-groups.js
@@ -1,69 +1,95 @@
 jQuery(document).ready(function () {
-    "use strict";
+  'use strict';
 
-    jQuery('#edit-slug-box').hide();
-
-
+  jQuery('#edit-slug-box').hide();
 });
 
 function group_search() {
-    let sval = jQuery('#group-search').val();
-    let data = { "s": sval }
-    let search_button = jQuery('#search_button')
-    search_button.append(' <img style="height:1em;" src="' + window.dtPeopleGroupsAPI.images_uri + 'spinner.svg" />');
+  let sval = jQuery('#group-search').val();
+  let data = { s: sval };
+  let search_button = jQuery('#search_button');
+  search_button.append(
+    ' <img style="height:1em;" src="' +
+      window.dtPeopleGroupsAPI.images_uri +
+      'spinner.svg" />',
+  );
 
-    jQuery.ajax({
-        type: "POST",
-        data: JSON.stringify(data),
-        contentType: "application/json; charset=utf-8",
-        dataType: "json",
-        url: window.dtPeopleGroupsAPI.root + 'dt/v1/people-groups/search_csv',
-        beforeSend: function(xhr) {
-            xhr.setRequestHeader('X-WP-Nonce', window.dtPeopleGroupsAPI.nonce);
-        },
+  jQuery
+    .ajax({
+      type: 'POST',
+      data: JSON.stringify(data),
+      contentType: 'application/json; charset=utf-8',
+      dataType: 'json',
+      url: window.dtPeopleGroupsAPI.root + 'dt/v1/people-groups/search_csv',
+      beforeSend: function (xhr) {
+        xhr.setRequestHeader('X-WP-Nonce', window.dtPeopleGroupsAPI.nonce);
+      },
     })
-        .done(function (data) {
-          let div = jQuery('#results')
-          div.empty();
-          search_button.empty().text('Get List')
+    .done(function (data) {
+      let div = jQuery('#results');
+      div.empty();
+      search_button.empty().text('Get List');
 
-          div.append(`<dl><dt><strong>` + sval + `</strong></dt>`)
+      div.append(`<dl><dt><strong>` + sval + `</strong></dt>`);
 
-          jQuery.each(data, function (i, v) {
-            div.append(`
-                <dd>` + v[4] + ` ( ` + v[1] + ` | ` + v[3] + ` ) <button onclick="add_single_people_group('` + v[3] + `','` + String(v[1]).replace(/'/g, "\\'") + `','` + v[33] + `')" id="button-` + v[3] + `">add</button> <span id="message-` + v[3] + `"></span></dd>
-                `)
+      jQuery.each(data, function (i, v) {
+        div.append(
+          `
+                <dd>` +
+            v[4] +
+            ` ( ` +
+            v[1] +
+            ` | ` +
+            v[3] +
+            ` ) <button onclick="add_single_people_group('` +
+            v[3] +
+            `','` +
+            String(v[1]).replace(/'/g, "\\'") +
+            `','` +
+            v[33] +
+            `')" id="button-` +
+            v[3] +
+            `">add</button> <span id="message-` +
+            v[3] +
+            `"></span></dd>
+                `,
+        );
 
-            // Check last element for duplicate flag to determine if group has already been installed.
-            if (v[v.length - 1]) {
-              let button = jQuery('#button-' + v[3]);
-              if (button) {
-                jQuery(button).text('installed');
-                jQuery(button).attr('disabled', 'disabled');
-              }
-            }
-          })
-          div.append(`</dl>`)
+        // Check last element for duplicate flag to determine if group has already been installed.
+        if (v[v.length - 1]) {
+          let button = jQuery('#button-' + v[3]);
+          if (button) {
+            jQuery(button).text('installed');
+            jQuery(button).attr('disabled', 'disabled');
+          }
+        }
+      });
+      div.append(`</dl>`);
 
-          // Add listener for select all button, ensuring to delete all stale click listeners.
-          jQuery('#add_all_groups').show().off('click').on('click', function () {
-            div.prepend('<span><strong>DO NOT NAVIGATE AWAY FROM THIS PAGE UNTIL INSTALL IS COMPLETE!</strong></span><br>')
-            jQuery.each(jQuery('#results button'), function (i, v) {
-              setTimeout(function () {
-                console.log(v.id);
-                jQuery('#' + v.id).click()
-              }, 700 * i);
-            })
-          })
-        })
-        .fail(function (err) {
-          console.log("error");
-          console.log(err);
-        })
+      // Add listener for select all button, ensuring to delete all stale click listeners.
+      jQuery('#add_all_groups')
+        .show()
+        .off('click')
+        .on('click', function () {
+          div.prepend(
+            '<span><strong>DO NOT NAVIGATE AWAY FROM THIS PAGE UNTIL INSTALL IS COMPLETE!</strong></span><br>',
+          );
+          jQuery.each(jQuery('#results button'), function (i, v) {
+            setTimeout(function () {
+              console.log(v.id);
+              jQuery('#' + v.id).click();
+            }, 700 * i);
+          });
+        });
+    })
+    .fail(function (err) {
+      console.log('error');
+      console.log(err);
+    });
 }
 
 function import_all_people_groups() {
-  if (confirm("Import all country people groups?")) {
+  if (confirm('Import all country people groups?')) {
     let group_search_select = jQuery('#group-search');
     let search_button = jQuery('#search_button');
     let import_all_button = jQuery('#import_all_button');
@@ -72,56 +98,83 @@ function import_all_people_groups() {
     group_search_select.attr('disabled', 'disabled');
     search_button.attr('disabled', 'disabled');
     import_all_button.attr('disabled', 'disabled');
-    import_all_button.empty().text('Import All Country People Groups').append(' <img style="height:1em;" src="' + window.dtPeopleGroupsAPI.images_uri + 'spinner.svg" />');
+    import_all_button
+      .empty()
+      .text('Import All Country People Groups')
+      .append(
+        ' <img style="height:1em;" src="' +
+          window.dtPeopleGroupsAPI.images_uri +
+          'spinner.svg" />',
+      );
     add_all_groups.hide();
     results_div.empty();
 
     // First, fetch bulk people groups import batches to be processed.
-    jQuery.ajax({
-      type: "GET",
-      data: JSON.stringify({}),
-      contentType: "application/json; charset=utf-8",
-      dataType: "json",
-      url: window.dtPeopleGroupsAPI.root + 'dt/v1/people-groups/get_bulk_people_groups_import_batches',
-      beforeSend: function (xhr) {
-        xhr.setRequestHeader('X-WP-Nonce', window.dtPeopleGroupsAPI.nonce);
-      }
+    jQuery
+      .ajax({
+        type: 'GET',
+        data: JSON.stringify({}),
+        contentType: 'application/json; charset=utf-8',
+        dataType: 'json',
+        url:
+          window.dtPeopleGroupsAPI.root +
+          'dt/v1/people-groups/get_bulk_people_groups_import_batches',
+        beforeSend: function (xhr) {
+          xhr.setRequestHeader('X-WP-Nonce', window.dtPeopleGroupsAPI.nonce);
+        },
+      })
+      .done(function (data) {
+        console.log(data);
 
-    }).done(function (data) {
-      console.log(data);
+        // Ensure user is doubly sure they wish to proceed with import.
+        if (
+          data['total_batches'] &&
+          data['total_records'] &&
+          data['batches'] &&
+          confirm(
+            'Are you sure you wish to import ' +
+              data['total_records'] +
+              ' records, across ' +
+              data['total_batches'] +
+              ' batches?',
+          )
+        ) {
+          // Iterate through each item and sequentially call the ajax function.
+          let looper = jQuery.Deferred().resolve();
+          jQuery.when
+            .apply(
+              jQuery,
+              jQuery.map(data['batches'], function (batch, country) {
+                looper = looper.then(function () {
+                  console.log(country);
+                  console.log(batch);
 
-      // Ensure user is doubly sure they wish to proceed with import.
-      if (data['total_batches'] && data['total_records'] && data['batches'] && confirm("Are you sure you wish to import " + data['total_records'] + " records, across " + data['total_batches'] + " batches?")) {
-
-        // Iterate through each item and sequentially call the ajax function.
-        let looper = jQuery.Deferred().resolve();
-        jQuery.when.apply(jQuery, jQuery.map(data['batches'], function (batch, country) {
-          looper = looper.then(function () {
-            console.log(country);
-            console.log(batch);
-
-            // Trigger ajax call with batch data;
-            return add_bulk_people_groups(country, batch);
-          });
-          return looper;
-
-        })).then(function () {
-          // Once all batches have been processed, re-enable buttons and dropdowns.
+                  // Trigger ajax call with batch data;
+                  return add_bulk_people_groups(country, batch);
+                });
+                return looper;
+              }),
+            )
+            .then(function () {
+              // Once all batches have been processed, re-enable buttons and dropdowns.
+              import_all_button.prop('disabled', false);
+              import_all_button
+                .empty()
+                .text('Import All Country People Groups');
+              group_search_select.prop('disabled', false);
+              search_button.prop('disabled', false);
+            });
+        } else {
           import_all_button.prop('disabled', false);
           import_all_button.empty().text('Import All Country People Groups');
           group_search_select.prop('disabled', false);
           search_button.prop('disabled', false);
-        });
-      } else {
-        import_all_button.prop('disabled', false);
-        import_all_button.empty().text('Import All Country People Groups');
-        group_search_select.prop('disabled', false);
-        search_button.prop('disabled', false);
-      }
-    }).fail(function (err) {
-      console.log("error");
-      console.log(err);
-    });
+        }
+      })
+      .fail(function (err) {
+        console.log('error');
+        console.log(err);
+      });
   }
 }
 
@@ -129,11 +182,13 @@ function add_bulk_people_groups(country, people_groups) {
   let deferred = jQuery.Deferred();
 
   jQuery.ajax({
-    type: "POST",
-    data: JSON.stringify({'groups': people_groups}),
-    contentType: "application/json; charset=utf-8",
-    dataType: "json",
-    url: window.dtPeopleGroupsAPI.root + 'dt/v1/people-groups/add_bulk_people_groups',
+    type: 'POST',
+    data: JSON.stringify({ groups: people_groups }),
+    contentType: 'application/json; charset=utf-8',
+    dataType: 'json',
+    url:
+      window.dtPeopleGroupsAPI.root +
+      'dt/v1/people-groups/add_bulk_people_groups',
     beforeSend: function (xhr) {
       xhr.setRequestHeader('X-WP-Nonce', window.dtPeopleGroupsAPI.nonce);
     },
@@ -142,187 +197,251 @@ function add_bulk_people_groups(country, people_groups) {
       deferred.resolve(data);
 
       // Update table with batch import results.
-      let html = `<tr><td>${country}: Processed ${(data['total_groups_insert_success'] + data['total_groups_insert_updates'])} of ${data['total_groups_count']}</td></tr>`;
+      let html = `<tr><td>${country}: Processed ${data['total_groups_insert_success'] + data['total_groups_insert_updates']} of ${data['total_groups_count']}</td></tr>`;
       jQuery('#import_people_group_table').find('tbody > tr').eq(0).after(html);
-
     },
     error: function (error) {
       deferred.reject(error);
-    }
+    },
   });
 
   return deferred.promise();
 }
 
-function add_single_people_group( rop3, country, location_grid ) {
-    let data = { "rop3": rop3, "country": country, "location_grid": location_grid }
-    let button = jQuery( '#button-' + rop3 )
-    let message = jQuery('#message-' + rop3 )
+function add_single_people_group(rop3, country, location_grid) {
+  let data = { rop3: rop3, country: country, location_grid: location_grid };
+  let button = jQuery('#button-' + rop3);
+  let message = jQuery('#message-' + rop3);
 
+  button
+    .attr('disabled', 'disabled')
+    .append(
+      ' <img style="height:1em;" src="' +
+        window.dtPeopleGroupsAPI.images_uri +
+        'spinner.svg" />',
+    );
 
-    button.attr('disabled', 'disabled').append(' <img style="height:1em;" src="'+ window.dtPeopleGroupsAPI.images_uri +'spinner.svg" />')
-
-    jQuery.ajax({
-        type: "POST",
-        data: JSON.stringify(data),
-        contentType: "application/json; charset=utf-8",
-        dataType: "json",
-        url: window.dtPeopleGroupsAPI.root + 'dt/v1/people-groups/add_single_people_group',
-        beforeSend: function(xhr) {
-            xhr.setRequestHeader('X-WP-Nonce', window.dtPeopleGroupsAPI.nonce);
-        },
+  jQuery
+    .ajax({
+      type: 'POST',
+      data: JSON.stringify(data),
+      contentType: 'application/json; charset=utf-8',
+      dataType: 'json',
+      url:
+        window.dtPeopleGroupsAPI.root +
+        'dt/v1/people-groups/add_single_people_group',
+      beforeSend: function (xhr) {
+        xhr.setRequestHeader('X-WP-Nonce', window.dtPeopleGroupsAPI.nonce);
+      },
     })
-        .done(function (data) {
-            if ( data.status === 'Success' ) {
-                button.text('installed')
-            }
-            if ( data.status === 'Duplicate' ) {
-                button.text('duplicate')
-            }
+    .done(function (data) {
+      if (data.status === 'Success') {
+        button.text('installed');
+      }
+      if (data.status === 'Duplicate') {
+        button.text('duplicate');
+      }
 
-            console.log(data)
-        })
-        .fail(function (err) {
-            console.log("error");
-            console.log(err);
-        })
+      console.log(data);
+    })
+    .fail(function (err) {
+      console.log('error');
+      console.log(err);
+    });
 }
 
 function link_search() {
-    let country = jQuery('#country').val()
-    let rop3 = jQuery('#rop3').val()
-    let post_id = jQuery('#post_id').val()
-    let search_button = jQuery('#search_button')
-    search_button.append(' <img style="height:1em;" src="'+ window.dtPeopleGroupsAPI.images_uri +'spinner.svg" />')
+  let country = jQuery('#country').val();
+  let rop3 = jQuery('#rop3').val();
+  let post_id = jQuery('#post_id').val();
+  let search_button = jQuery('#search_button');
+  search_button.append(
+    ' <img style="height:1em;" src="' +
+      window.dtPeopleGroupsAPI.images_uri +
+      'spinner.svg" />',
+  );
 
-    if( country ) {
-        let data = { "s": country }
-        jQuery.ajax({
-            type: "POST",
-            data: JSON.stringify(data),
-            contentType: "application/json; charset=utf-8",
-            dataType: "json",
-            url: window.dtPeopleGroupsAPI.root + 'dt/v1/people-groups/search_csv',
-            beforeSend: function(xhr) {
-                xhr.setRequestHeader('X-WP-Nonce', window.dtPeopleGroupsAPI.nonce);
-            },
-        })
-            .done(function (data) {
-                let div = jQuery('#results')
-                div.empty()
-                search_button.empty().text('Search')
+  if (country) {
+    let data = { s: country };
+    jQuery
+      .ajax({
+        type: 'POST',
+        data: JSON.stringify(data),
+        contentType: 'application/json; charset=utf-8',
+        dataType: 'json',
+        url: window.dtPeopleGroupsAPI.root + 'dt/v1/people-groups/search_csv',
+        beforeSend: function (xhr) {
+          xhr.setRequestHeader('X-WP-Nonce', window.dtPeopleGroupsAPI.nonce);
+        },
+      })
+      .done(function (data) {
+        let div = jQuery('#results');
+        div.empty();
+        search_button.empty().text('Search');
 
-                div.append(`<dl><dt><strong>`+country+`</strong></dt>`)
+        div.append(`<dl><dt><strong>` + country + `</strong></dt>`);
 
-                jQuery.each(data, function(i, v) {
-                    div.append(`
-                <dd>`+ v[4] +` ( `+ v[1] + ` | ` + v[3] +` ) <button type="button" onclick="link_or_update('`+v[3]+`','`+v[1]+`','`+post_id+`')" id="button-`+v[3]+`">link</button> <span id="message-`+v[3]+`"></span></dd>
-                `)
-                })
+        jQuery.each(data, function (i, v) {
+          div.append(
+            `
+                <dd>` +
+              v[4] +
+              ` ( ` +
+              v[1] +
+              ` | ` +
+              v[3] +
+              ` ) <button type="button" onclick="link_or_update('` +
+              v[3] +
+              `','` +
+              v[1] +
+              `','` +
+              post_id +
+              `')" id="button-` +
+              v[3] +
+              `">link</button> <span id="message-` +
+              v[3] +
+              `"></span></dd>
+                `,
+          );
+        });
 
-                div.append(`</dl>`)
-            })
-            .fail(function (err) {
-                console.log("error");
-                console.log(err);
-            })
-    } else {
-        let data = { "rop3": rop3 }
-        let div = jQuery('#results')
-        jQuery.ajax({
-            type: "POST",
-            data: JSON.stringify(data),
-            contentType: "application/json; charset=utf-8",
-            dataType: "json",
-            url: window.dtPeopleGroupsAPI.root + 'dt/v1/people-groups/search_csv_by_rop3',
-            beforeSend: function(xhr) {
-                xhr.setRequestHeader('X-WP-Nonce', window.dtPeopleGroupsAPI.nonce);
-            },
-        })
-            .done(function (data) {
+        div.append(`</dl>`);
+      })
+      .fail(function (err) {
+        console.log('error');
+        console.log(err);
+      });
+  } else {
+    let data = { rop3: rop3 };
+    let div = jQuery('#results');
+    jQuery
+      .ajax({
+        type: 'POST',
+        data: JSON.stringify(data),
+        contentType: 'application/json; charset=utf-8',
+        dataType: 'json',
+        url:
+          window.dtPeopleGroupsAPI.root +
+          'dt/v1/people-groups/search_csv_by_rop3',
+        beforeSend: function (xhr) {
+          xhr.setRequestHeader('X-WP-Nonce', window.dtPeopleGroupsAPI.nonce);
+        },
+      })
+      .done(function (data) {
+        div.empty();
+        search_button.empty().text('Search');
 
-                div.empty()
-                search_button.empty().text('Search')
+        div.append(`<dl><dt><strong>Matches for ` + rop3 + `</strong></dt>`);
 
-                div.append(`<dl><dt><strong>Matches for `+rop3+`</strong></dt>`)
+        jQuery.each(data, function (i, v) {
+          let str = v[1];
+          str = str.replace(/\s+/g, '-').toLowerCase();
 
-                jQuery.each(data, function(i, v) {
-                    let str = v[1]
-                    str = str.replace(/\s+/g, '-').toLowerCase()
+          div.append(
+            `
+                <dd>` +
+              v[4] +
+              ` ( ` +
+              v[1] +
+              ` | ` +
+              v[3] +
+              ` ) <button type="button" onclick="link_or_update_by_rop3('` +
+              v[3] +
+              `','` +
+              v[1] +
+              `','` +
+              post_id +
+              `')" id="button-` +
+              str +
+              `">link</button> <span id="message-` +
+              str +
+              `"></span></dd>
+                `,
+          );
+        });
 
-                    div.append(`
-                <dd>`+ v[4] +` ( `+ v[1] + ` | ` + v[3] +` ) <button type="button" onclick="link_or_update_by_rop3('`+v[3]+`','`+v[1]+`','`+post_id+`')" id="button-`+str+`">link</button> <span id="message-`+str+`"></span></dd>
-                `)
-                })
+        div.append(`</dl>`);
+      })
+      .fail(function (err) {
+        div.empty().text('No match found.');
 
-                div.append(`</dl>`)
-            })
-            .fail(function (err) {
-                div.empty().text('No match found.')
-
-                console.log("error");
-                console.log(err);
-            })
-    }
+        console.log('error');
+        console.log(err);
+      });
+  }
 }
 
-function link_or_update( rop3, country, post_id ) {
-    let button = jQuery( '#button-' + rop3 )
-    let message = jQuery('#message-' + rop3 )
-    button.attr('disabled', 'disabled').append(' <img style="height:1em;" src="'+ window.dtPeopleGroupsAPI.images_uri +'spinner.svg" />')
+function link_or_update(rop3, country, post_id) {
+  let button = jQuery('#button-' + rop3);
+  let message = jQuery('#message-' + rop3);
+  button
+    .attr('disabled', 'disabled')
+    .append(
+      ' <img style="height:1em;" src="' +
+        window.dtPeopleGroupsAPI.images_uri +
+        'spinner.svg" />',
+    );
 
-    let data = { "country": country, "rop3": rop3, "post_id": post_id }
-    jQuery.ajax({
-        type: "POST",
-        data: JSON.stringify(data),
-        contentType: "application/json; charset=utf-8",
-        dataType: "json",
-        url: window.dtPeopleGroupsAPI.root + 'dt/v1/people-groups/link_or_update',
-        beforeSend: function(xhr) {
-            xhr.setRequestHeader('X-WP-Nonce', window.dtPeopleGroupsAPI.nonce);
-        },
+  let data = { country: country, rop3: rop3, post_id: post_id };
+  jQuery
+    .ajax({
+      type: 'POST',
+      data: JSON.stringify(data),
+      contentType: 'application/json; charset=utf-8',
+      dataType: 'json',
+      url: window.dtPeopleGroupsAPI.root + 'dt/v1/people-groups/link_or_update',
+      beforeSend: function (xhr) {
+        xhr.setRequestHeader('X-WP-Nonce', window.dtPeopleGroupsAPI.nonce);
+      },
     })
-        .done(function (data) {
-            if ( data.status === 'Success' ) {
-                button.text('installed')
-            }
+    .done(function (data) {
+      if (data.status === 'Success') {
+        button.text('installed');
+      }
 
-            console.log(data)
-        })
-        .fail(function (err) {
-            console.log("error");
-            console.log(err);
-        })
+      console.log(data);
+    })
+    .fail(function (err) {
+      console.log('error');
+      console.log(err);
+    });
 }
 
-function link_or_update_by_rop3( rop3, country, post_id ) {
-    let str = country
-    str = str.replace(/\s+/g, '-').toLowerCase()
+function link_or_update_by_rop3(rop3, country, post_id) {
+  let str = country;
+  str = str.replace(/\s+/g, '-').toLowerCase();
 
-    let button = jQuery( '#button-' + str )
-    let message = jQuery('#message-' + str )
-    button.attr('disabled', 'disabled').append(' <img style="height:1em;" src="'+ window.dtPeopleGroupsAPI.images_uri +'spinner.svg" />')
+  let button = jQuery('#button-' + str);
+  let message = jQuery('#message-' + str);
+  button
+    .attr('disabled', 'disabled')
+    .append(
+      ' <img style="height:1em;" src="' +
+        window.dtPeopleGroupsAPI.images_uri +
+        'spinner.svg" />',
+    );
 
-    let data = { "country": country, "rop3": rop3, "post_id": post_id }
-    jQuery.ajax({
-        type: "POST",
-        data: JSON.stringify(data),
-        contentType: "application/json; charset=utf-8",
-        dataType: "json",
-        url: window.dtPeopleGroupsAPI.root + 'dt/v1/people-groups/link_or_update',
-        beforeSend: function(xhr) {
-            xhr.setRequestHeader('X-WP-Nonce', window.dtPeopleGroupsAPI.nonce);
-        },
+  let data = { country: country, rop3: rop3, post_id: post_id };
+  jQuery
+    .ajax({
+      type: 'POST',
+      data: JSON.stringify(data),
+      contentType: 'application/json; charset=utf-8',
+      dataType: 'json',
+      url: window.dtPeopleGroupsAPI.root + 'dt/v1/people-groups/link_or_update',
+      beforeSend: function (xhr) {
+        xhr.setRequestHeader('X-WP-Nonce', window.dtPeopleGroupsAPI.nonce);
+      },
     })
-        .done(function (data) {
-            if ( data.status === 'Success' ) {
-                button.text('installed')
-            }
+    .done(function (data) {
+      if (data.status === 'Success') {
+        button.text('installed');
+      }
 
-            console.log(data)
-        })
-        .fail(function (err) {
-            console.log("error");
-            console.log(err);
-        })
+      console.log(data);
+    })
+    .fail(function (err) {
+      console.log('error');
+      console.log(err);
+    });
 }

--- a/dt-users/hover-coverage-map.js
+++ b/dt-users/hover-coverage-map.js
@@ -1,11 +1,11 @@
-"use strict";
+'use strict';
 
-jQuery(document).ready(function() {
-  let chartDiv = jQuery('#chart')
+jQuery(document).ready(function () {
+  let chartDiv = jQuery('#chart');
   chartDiv.empty().html(`
-    <span class="section-header" title="Cumulative simple map of user coverage">${window.SHAREDFUNCTIONS.escapeHTML( window.wp_js_object.translations.title )}</span>
+    <span class="section-header" title="Cumulative simple map of user coverage">${window.SHAREDFUNCTIONS.escapeHTML(window.wp_js_object.translations.title)}</span>
     <div id="mapping_chart"></div>
-  `)
+  `);
 
-  window.page_mapping_view(window.wp_js_object.rest_endpoints_base)
-})
+  window.page_mapping_view(window.wp_js_object.rest_endpoints_base);
+});

--- a/dt-users/mapbox-coverage-map.js
+++ b/dt-users/mapbox-coverage-map.js
@@ -1,81 +1,102 @@
-window.mapbox_library_api.current_map_type = "area"
-jQuery(document).ready(function($) {
-  let user_list = []
+window.mapbox_library_api.current_map_type = 'area';
+jQuery(document).ready(function ($) {
+  let user_list = [];
 
-  window.makeRequest( "POST", `get_user_list`, null , 'user-management/v1/')
-  .done(response=>{
-    user_list = response
-  }).catch((e)=>{
-    console.log( 'error in activity')
-    console.log( e)
-  })
+  window
+    .makeRequest('POST', `get_user_list`, null, 'user-management/v1/')
+    .done((response) => {
+      user_list = response;
+    })
+    .catch((e) => {
+      console.log('error in activity');
+      console.log(e);
+    });
 
-  $('#map-type').hide()
-  let field_key = "user_status_options"
+  $('#map-type').hide();
+  let field_key = 'user_status_options';
   let options_html = `<button class="button small selected-select-button" data-key="all">
     ${window.SHAREDFUNCTIONS.escapeHTML(window.dt_mapbox_metrics.translations.all)}
-  </button>`
-  window.lodash.forOwn(window.dt_mapbox_metrics.settings.user_status_options, (option, option_key)=>{
-    options_html += `<button class="button small empty-select-button" data-key="${window.SHAREDFUNCTIONS.escapeHTML(option_key)}" style="">
+  </button>`;
+  window.lodash.forOwn(
+    window.dt_mapbox_metrics.settings.user_status_options,
+    (option, option_key) => {
+      options_html += `<button class="button small empty-select-button" data-key="${window.SHAREDFUNCTIONS.escapeHTML(option_key)}" style="">
       ${window.SHAREDFUNCTIONS.escapeHTML(option.label)}
-    </button>`
-  })
+    </button>`;
+    },
+  );
   let split_by_html = `
       <div id="${field_key}" class="border-left map-option-buttons">
         ${window.SHAREDFUNCTIONS.escapeHTML(window.dt_mapbox_metrics.translations.user_status)}:
         ${options_html}
       </div>
-    `
-  $('#legend-bar').append(split_by_html)
-  $(`#${field_key} button`).on('click', function (e){
-    let buttons = $(`#${field_key} button`)
-    buttons.removeClass("selected-select-button")
-    buttons.addClass("empty-select-button")
-    $(this).addClass("selected-select-button")
+    `;
+  $('#legend-bar').append(split_by_html);
+  $(`#${field_key} button`).on('click', function (e) {
+    let buttons = $(`#${field_key} button`);
+    buttons.removeClass('selected-select-button');
+    buttons.addClass('empty-select-button');
+    $(this).addClass('selected-select-button');
 
-    window. mapbox_library_api.query_args = { status: $(this).data('key') }
-    window. mapbox_library_api.setup_map_type()
-  })
+    window.mapbox_library_api.query_args = { status: $(this).data('key') };
+    window.mapbox_library_api.setup_map_type();
+  });
 
-  window.mapbox_library_api.area_map.load_detail_panel =  function ( lng, lat, level ) {
-
-    lng = window.mapbox_library_api.standardize_longitude( lng )
-    if ( level === 'world' ) {
-      level = 'admin0'
+  window.mapbox_library_api.area_map.load_detail_panel = function (
+    lng,
+    lat,
+    level,
+  ) {
+    lng = window.mapbox_library_api.standardize_longitude(lng);
+    if (level === 'world') {
+      level = 'admin0';
     }
 
-    let content = jQuery('#geocode-details-content')
-    content.empty().html(`<span class="loading-spinner users-spinner active"></span>`)
+    let content = jQuery('#geocode-details-content');
+    content
+      .empty()
+      .html(`<span class="loading-spinner users-spinner active"></span>`);
 
-    jQuery('#geocode-details').show()
+    jQuery('#geocode-details').show();
 
     // geocode
-    window.makeRequest('GET', window.wpApiShare.template_dir + '/dt-mapping/location-grid-list-api.php',
-      {
-        type:'geocode',
-        longitude:lng,
-        latitude:lat,
-        level:level,
-        nonce: window.mapbox_library_api.obj.settings.geocoder_nonce,
-        query: window.mapbox_library_api.query_args || {}
-      } )
-    .done(details=>{
-      /* hierarchy list*/
-      content.empty().append(`<ul id="hierarchy-list" class="accordion" data-accordion></ul>`)
-      let list = jQuery('#hierarchy-list')
+    window
+      .makeRequest(
+        'GET',
+        window.wpApiShare.template_dir +
+          '/dt-mapping/location-grid-list-api.php',
+        {
+          type: 'geocode',
+          longitude: lng,
+          latitude: lat,
+          level: level,
+          nonce: window.mapbox_library_api.obj.settings.geocoder_nonce,
+          query: window.mapbox_library_api.query_args || {},
+        },
+      )
+      .done((details) => {
+        /* hierarchy list*/
+        content
+          .empty()
+          .append(
+            `<ul id="hierarchy-list" class="accordion" data-accordion></ul>`,
+          );
+        let list = jQuery('#hierarchy-list');
 
-      if ( details.admin0_grid_id ) {
-        list.append( `
+        if (details.admin0_grid_id) {
+          list.append(`
           <li id="admin0_wrapper" class="accordion-item" data-accordion-item>
             <a href="#" class="accordion-title">${window.SHAREDFUNCTIONS.escapeHTML(details.admin0_name)} :  <span id="admin0_count">0</span></a>
             <div class="accordion-content grid-x" data-tab-content><div id="admin0_list" class="grid-x"></div></div>
           </li>
-        `)
-        let level_list = jQuery('#admin0_list')
-        if ( details.admin0_grid_id in user_list ) {
-          jQuery('#admin0_count').html(user_list[details.admin0_grid_id].length)
-          jQuery.each(user_list[details.admin0_grid_id], function(i,v) {
-            level_list.append(`
+        `);
+          let level_list = jQuery('#admin0_list');
+          if (details.admin0_grid_id in user_list) {
+            jQuery('#admin0_count').html(
+              user_list[details.admin0_grid_id].length,
+            );
+            jQuery.each(user_list[details.admin0_grid_id], function (i, v) {
+              level_list.append(`
               <div class="cell small-10 align-self-middle" data-id="${window.SHAREDFUNCTIONS.escapeHTML(v.grid_meta_id)}">
                 <a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/user-management/user/${window.SHAREDFUNCTIONS.escapeHTML(v.user_id)}">
                   ${window.SHAREDFUNCTIONS.escapeHTML(v.name)}
@@ -85,27 +106,28 @@ jQuery(document).ready(function($) {
                 <a class="button clear delete-button mapbox-delete-button small float-right" data-user_id="${window.SHAREDFUNCTIONS.escapeHTML(v.user_id)}" data-id="${window.SHAREDFUNCTIONS.escapeHTML(v.grid_meta_id)}" data-level="admin0" data-location="${window.SHAREDFUNCTIONS.escapeHTML(details.admin0_grid_id)}">
                   <img src="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.template_dir)}/dt-assets/images/invalid.svg" alt="delete">
                 </a>
-              </div>`)
-          })
-        }
-        level_list.append(`<div class="cell add-user-button"><button class="add-user small expanded button hollow" data-level="admin0" data-location="${window.SHAREDFUNCTIONS.escapeHTML(details.admin0_grid_id)}">
+              </div>`);
+            });
+          }
+          level_list.append(`<div class="cell add-user-button"><button class="add-user small expanded button hollow" data-level="admin0" data-location="${window.SHAREDFUNCTIONS.escapeHTML(details.admin0_grid_id)}">
           ${window.SHAREDFUNCTIONS.escapeHTML(window.dt_mapbox_metrics.translations.add_user_to.replace('%s', details.admin0_name))}
-        </button></div>`)
-
-      }
-      if ( details.admin1_grid_id ) {
-        list.append( `
+        </button></div>`);
+        }
+        if (details.admin1_grid_id) {
+          list.append(`
           <li id="admin1_wrapper" class="accordion-item" data-accordion-item >
             <a href="#" class="accordion-title">${window.SHAREDFUNCTIONS.escapeHTML(details.admin1_name)} : <span id="admin1_count">0</span></a>
             <div class="accordion-content" data-tab-content><div id="admin1_list" class="grid-x"></div></div>
           </li>
-        `)
+        `);
 
-        let level_list = jQuery('#admin1_list')
-        if ( details.admin1_grid_id in user_list ) {
-          jQuery('#admin1_count').html(user_list[details.admin1_grid_id].length)
-          jQuery.each(user_list[details.admin1_grid_id], function(i,v) {
-            level_list.append(`
+          let level_list = jQuery('#admin1_list');
+          if (details.admin1_grid_id in user_list) {
+            jQuery('#admin1_count').html(
+              user_list[details.admin1_grid_id].length,
+            );
+            jQuery.each(user_list[details.admin1_grid_id], function (i, v) {
+              level_list.append(`
               <div class="cell small-10 align-self-middle" data-id="${window.SHAREDFUNCTIONS.escapeHTML(v.grid_meta_id)}">
                 <a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/user-management/user/${window.SHAREDFUNCTIONS.escapeHTML(v.user_id)}">
                   ${window.SHAREDFUNCTIONS.escapeHTML(v.name)}
@@ -115,26 +137,28 @@ jQuery(document).ready(function($) {
                 <a class="button clear delete-button mapbox-delete-button small float-right" data-user_id="${window.SHAREDFUNCTIONS.escapeHTML(v.user_id)}" data-id="${window.SHAREDFUNCTIONS.escapeHTML(v.grid_meta_id)}" data-level="admin1" data-location="${window.SHAREDFUNCTIONS.escapeHTML(details.admin1_grid_id)}">
                   <img src="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.template_dir)}/dt-assets/images/invalid.svg" alt="delete">
                 </a>
-              </div>`)
-          })
-        }
-        level_list.append(`<div class="cell add-user-button"><button class="add-user small expanded button hollow" data-level="admin1" data-location="${window.SHAREDFUNCTIONS.escapeHTML(details.admin1_grid_id)}">
+              </div>`);
+            });
+          }
+          level_list.append(`<div class="cell add-user-button"><button class="add-user small expanded button hollow" data-level="admin1" data-location="${window.SHAREDFUNCTIONS.escapeHTML(details.admin1_grid_id)}">
           ${window.SHAREDFUNCTIONS.escapeHTML(window.dt_mapbox_metrics.translations.add_user_to.replace('%s', details.admin1_name))}
-        </button></div>`)
-      }
-      if ( details.admin2_grid_id ) {
-        list.append( `
+        </button></div>`);
+        }
+        if (details.admin2_grid_id) {
+          list.append(`
           <li id="admin2_wrapper" class="accordion-item" data-accordion-item>
             <a href="#" class="accordion-title">${window.SHAREDFUNCTIONS.escapeHTML(details.admin2_name)} : <span id="admin2_count">0</span></a>
             <div class="accordion-content" data-tab-content><div id="admin2_list"  class="grid-x"></div></div>
           </li>
-        `)
+        `);
 
-        let level_list = jQuery('#admin2_list')
-        if ( details.admin2_grid_id in user_list ) {
-          jQuery('#admin2_count').html(user_list[details.admin2_grid_id].length)
-          jQuery.each(user_list[details.admin2_grid_id], function(i,v) {
-            level_list.append(`
+          let level_list = jQuery('#admin2_list');
+          if (details.admin2_grid_id in user_list) {
+            jQuery('#admin2_count').html(
+              user_list[details.admin2_grid_id].length,
+            );
+            jQuery.each(user_list[details.admin2_grid_id], function (i, v) {
+              level_list.append(`
               <div class="cell small-10 align-self-middle" data-id="${window.SHAREDFUNCTIONS.escapeHTML(v.grid_meta_id)}">
                 <a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/user-management/user/${window.SHAREDFUNCTIONS.escapeHTML(v.user_id)}">
                   ${window.SHAREDFUNCTIONS.escapeHTML(v.name)}
@@ -144,25 +168,25 @@ jQuery(document).ready(function($) {
                 <a class="button clear delete-button mapbox-delete-button small float-right" data-user_id="${window.SHAREDFUNCTIONS.escapeHTML(v.user_id)}" data-id="${window.SHAREDFUNCTIONS.escapeHTML(v.grid_meta_id)}" data-level="admin2"  data-location="${window.SHAREDFUNCTIONS.escapeHTML(details.admin2_grid_id)}">
                   <img src="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.template_dir)}/dt-assets/images/invalid.svg" alt="delete">
                 </a>
-              </div>`)
-          })
-        }
-        level_list.append(`<div class="cell add-user-button"><button class="add-user expanded small button hollow" data-level="admin2" data-location="${window.SHAREDFUNCTIONS.escapeHTML(details.admin2_grid_id)}">
+              </div>`);
+            });
+          }
+          level_list.append(`<div class="cell add-user-button"><button class="add-user expanded small button hollow" data-level="admin2" data-location="${window.SHAREDFUNCTIONS.escapeHTML(details.admin2_grid_id)}">
           ${window.SHAREDFUNCTIONS.escapeHTML(window.dt_mapbox_metrics.translations.add_user_to.replace('%s', details.admin2_name))}
-        </button></div>`)
-      }
+        </button></div>`);
+        }
 
-      jQuery('.accordion-item').last().addClass('is-active')
-      list.foundation()
-      /* end hierarchy list */
+        jQuery('.accordion-item').last().addClass('is-active');
+        list.foundation();
+        /* end hierarchy list */
 
-      /* build click function to add user to location */
-      jQuery('.add-user').on('click', function() {
-        jQuery('#add-user-wrapper').remove()
-        let selected_location = jQuery(this).data('location')
-        let list_level = jQuery(this).data('level')
+        /* build click function to add user to location */
+        jQuery('.add-user').on('click', function () {
+          jQuery('#add-user-wrapper').remove();
+          let selected_location = jQuery(this).data('location');
+          let list_level = jQuery(this).data('level');
 
-        jQuery(this).parent().append(`
+          jQuery(this).parent().append(`
           <div id="add-user-wrapper">
             <var id="add-user-location-result-container" class="result-container add-user-location-result-container"></var>
             <div id="assigned_to_t" name="form-assigned_to">
@@ -182,64 +206,84 @@ jQuery(document).ready(function($) {
               </div>
             </div>
           </div>
-          `)
-        jQuery.typeahead({
-          input: '.js-typeahead-add-user',
-          minLength: 0,
-          accent: true,
-          searchOnFocus: true,
-          source: window.TYPEAHEADS.typeaheadUserSource(),
-          templateValue: "{{name}}",
-          template: function (query, item) {
-            return `<div class="assigned-to-row" dir="auto">
+          `);
+          jQuery.typeahead({
+            input: '.js-typeahead-add-user',
+            minLength: 0,
+            accent: true,
+            searchOnFocus: true,
+            source: window.TYPEAHEADS.typeaheadUserSource(),
+            templateValue: '{{name}}',
+            template: function (query, item) {
+              return `<div class="assigned-to-row" dir="auto">
               <span>
                   <span class="avatar"><img style="vertical-align: text-bottom" src="{{avatar}}"/></span>
-                  ${window.SHAREDFUNCTIONS.escapeHTML( item.name )}
+                  ${window.SHAREDFUNCTIONS.escapeHTML(item.name)}
               </span>
-              ${ window.SHAREDFUNCTIONS.escapeHTML(item.status_color) ? `<span class="status-square" style="background-color: ${window.SHAREDFUNCTIONS.escapeHTML(item.status_color)};">&nbsp;</span>` : '' }
-              ${ item.update_needed ? `<span>
-                <img style="height: 12px;" src="${window.SHAREDFUNCTIONS.escapeHTML( window.wpApiShare.template_dir )}/dt-assets/images/broken.svg"/>
+              ${window.SHAREDFUNCTIONS.escapeHTML(item.status_color) ? `<span class="status-square" style="background-color: ${window.SHAREDFUNCTIONS.escapeHTML(item.status_color)};">&nbsp;</span>` : ''}
+              ${
+                item.update_needed
+                  ? `<span>
+                <img style="height: 12px;" src="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.template_dir)}/dt-assets/images/broken.svg"/>
                 <span style="font-size: 14px">${window.SHAREDFUNCTIONS.escapeHTML(item.update_needed)}</span>
-              </span>` : '' }
-            </div>`
-          },
-          dynamic: true,
-          hint: true,
-          emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.no_records_found),
-          callback: {
-            onClick: function(node, a, item){
-              let data = {
-                user_id: item.ID,
-                user_location: {
-                  location_grid_meta: [
-                    {
-                      grid_id: selected_location
-                    }
-                  ]
-                }
+              </span>`
+                  : ''
               }
-              window.makeRequest( "POST", `users/user_location`, data )
-              .then(function (response) {
-                window.makeRequest( "POST", `get_user_list`, null , 'user-management/v1/')
-                .done(response=>{
-                  user_list = response
-                  if ( selected_location in user_list ) {
-                    jQuery('#'+list_level+'_count').html(user_list[selected_location].length)
-                  }
-                }).catch((e)=>{
-                  console.log( 'error in get_user_list')
-                  console.log( e)
-                })
+            </div>`;
+            },
+            dynamic: true,
+            hint: true,
+            emptyTemplate: window.SHAREDFUNCTIONS.escapeHTML(
+              window.wpApiShare.translations.no_records_found,
+            ),
+            callback: {
+              onClick: function (node, a, item) {
+                let data = {
+                  user_id: item.ID,
+                  user_location: {
+                    location_grid_meta: [
+                      {
+                        grid_id: selected_location,
+                      },
+                    ],
+                  },
+                };
+                window
+                  .makeRequest('POST', `users/user_location`, data)
+                  .then(function (response) {
+                    window
+                      .makeRequest(
+                        'POST',
+                        `get_user_list`,
+                        null,
+                        'user-management/v1/',
+                      )
+                      .done((response) => {
+                        user_list = response;
+                        if (selected_location in user_list) {
+                          jQuery('#' + list_level + '_count').html(
+                            user_list[selected_location].length,
+                          );
+                        }
+                      })
+                      .catch((e) => {
+                        console.log('error in get_user_list');
+                        console.log(e);
+                      });
 
-                window.mapbox_library_api.load_map()
+                    window.mapbox_library_api.load_map();
 
-                // remove user add input
-                jQuery('#add-user-wrapper').remove()
+                    // remove user add input
+                    jQuery('#add-user-wrapper').remove();
 
-                // add new user to list
-                jQuery.each(response.user_location.location_grid_meta, function(i,v) {
-                  if ( v.grid_id.toString() === selected_location.toString() ) {
-                    jQuery('#'+list_level+'_list').prepend(`
+                    // add new user to list
+                    jQuery.each(
+                      response.user_location.location_grid_meta,
+                      function (i, v) {
+                        if (
+                          v.grid_id.toString() === selected_location.toString()
+                        ) {
+                          jQuery('#' + list_level + '_list').prepend(`
                       <div class="cell small-10 align-self-middle" data-id="${window.SHAREDFUNCTIONS.escapeHTML(v.grid_meta_id)}">
                         <a  href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/user-management/user/${window.SHAREDFUNCTIONS.escapeHTML(response.user_id)}">
                           ${window.SHAREDFUNCTIONS.escapeHTML(response.user_title)}
@@ -249,45 +293,45 @@ jQuery(document).ready(function($) {
                         <a class="button clear delete-button mapbox-delete-button small float-right" data-user_id="${window.SHAREDFUNCTIONS.escapeHTML(response.user_id)}" data-id="${window.SHAREDFUNCTIONS.escapeHTML(v.grid_meta_id)}">
                           <img src="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.template_dir)}/dt-assets/images/invalid.svg" alt="delete">
                         </a>
-                      </div>`)
-                  }
-                })
+                      </div>`);
+                        }
+                      },
+                    );
 
-                window.mapbox_library_api.area_map.delete_user_action()
-
-
-              }).catch(err => { console.error(err) })
+                    window.mapbox_library_api.area_map.delete_user_action();
+                  })
+                  .catch((err) => {
+                    console.error(err);
+                  });
+              },
+              onResult: function (node, query, result, resultCount) {
+                let text = window.TYPEAHEADS.typeaheadHelpText(
+                  resultCount,
+                  query,
+                  result,
+                );
+                $('#add-user-location-result-container').html(text);
+              },
+              onHideLayout: function () {
+                $('.add-user-location-result-container').html('');
+              },
+              onReady: function () {},
             },
-            onResult: function (node, query, result, resultCount) {
-              let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
-              $('#add-user-location-result-container').html(text);
-            },
-            onHideLayout: function () {
-              $('.add-user-location-result-container').html("");
-            },
-            onReady: function () {
-
-            }
-          },
+          });
         });
+        /* end click add function */
 
-      })
-      /* end click add function */
-
-      window.mapbox_library_api.area_map.delete_user_action()
-
-    }); // end geocode
-  }
+        window.mapbox_library_api.area_map.delete_user_action();
+      }); // end geocode
+  };
 
   window.mapbox_library_api.area_map.delete_user_action = function () {
-    jQuery( '.mapbox-delete-button' ).on( "click", function(e) {
+    jQuery('.mapbox-delete-button').on('click', function (e) {
+      let selected_location = jQuery(this).data('location');
+      let list_level = jQuery(this).data('level');
 
-      let selected_location = jQuery(this).data('location')
-      let list_level = jQuery(this).data('level')
-
-      let level_count = jQuery('#'+list_level+'_count')
-      level_count.html( (parseInt( level_count.html()) ) - 1)
-
+      let level_count = jQuery('#' + list_level + '_count');
+      level_count.html(parseInt(level_count.html()) - 1);
 
       let data = {
         user_id: e.currentTarget.dataset.user_id,
@@ -295,34 +339,38 @@ jQuery(document).ready(function($) {
           location_grid_meta: [
             {
               grid_meta_id: e.currentTarget.dataset.id,
-            }
-          ]
-        }
-      }
+            },
+          ],
+        },
+      };
 
       // let post_id = e.currentTarget.dataset.user_id
-      window.makeRequest( "DELETE", `users/user_location`, data )
-      .then(function (response) {
+      window
+        .makeRequest('DELETE', `users/user_location`, data)
+        .then(function (response) {
+          jQuery('div[data-id=' + e.currentTarget.dataset.id + ']').remove();
 
-        jQuery('div[data-id=' + e.currentTarget.dataset.id + ']').remove()
+          window
+            .makeRequest('POST', `get_user_list`, null, 'user-management/v1/')
+            .done((response) => {
+              user_list = response;
 
-        window.makeRequest( "POST", `get_user_list`, null , 'user-management/v1/')
-        .done(response=>{
-          user_list = response
-
-          if ( selected_location in user_list ) {
-            jQuery('#'+list_level+'_count').html(user_list[selected_location].length)
-          }
-        }).catch((e)=>{
-          console.log( 'error in get_user_list')
-          console.log( e)
+              if (selected_location in user_list) {
+                jQuery('#' + list_level + '_count').html(
+                  user_list[selected_location].length,
+                );
+              }
+            })
+            .catch((e) => {
+              console.log('error in get_user_list');
+              console.log(e);
+            });
+          //reload the map
+          window.mapbox_library_api.load_map();
         })
-        //reload the map
-        window.mapbox_library_api.load_map()
-      }).catch(err => { console.error(err) })
-
+        .catch((err) => {
+          console.error(err);
+        });
     });
-  }
-
-})
-
+  };
+});

--- a/dt-users/table/users-table.js
+++ b/dt-users/table/users-table.js
@@ -2,7 +2,7 @@
  * Users table in LitElement
  */
 
-jQuery(document).ready(function($) {
+jQuery(document).ready(function ($) {
   $('#chart').empty().html(`
     <style>
         users-table {
@@ -11,86 +11,97 @@ jQuery(document).ready(function($) {
             --sort-asc: url(${window.wpApiShare.template_dir + '/dt-assets/images/sort_asc.png'});
         }
     </style>
-    <users-table></users-table>`)
-})
+    <users-table></users-table>`);
+});
 
-import {html, css, LitElement} from 'https://cdn.jsdelivr.net/gh/lit/dist@2/core/lit-core.min.js';
+import {
+  html,
+  css,
+  LitElement,
+} from 'https://cdn.jsdelivr.net/gh/lit/dist@2/core/lit-core.min.js';
 
 export class UsersTable extends LitElement {
   static properties = {
-    users: {type: Array, state:true},
-    search: {type: String, state:true},
-    sort: {type: String, state:true},
-    loading : {type: Boolean, state:true},
-    total_users : {type: Number, state:true}
-  }
+    users: { type: Array, state: true },
+    search: { type: String, state: true },
+    sort: { type: String, state: true },
+    loading: { type: Boolean, state: true },
+    total_users: { type: Number, state: true },
+  };
 
   constructor() {
     super();
 
-    this.users = [{name:'loading...'}]
+    this.users = [{ name: 'loading...' }];
     this.getUsers();
 
-    this.translations = window.SHAREDFUNCTIONS.escapeObject( window.dt_users_table.translations );
+    this.translations = window.SHAREDFUNCTIONS.escapeObject(
+      window.dt_users_table.translations,
+    );
   }
 
-  async getUsers( search = '', sort = '', filter ) {
+  async getUsers(search = '', sort = '', filter) {
     this.loading = true;
-    let users =  await fetch(window.dt_users_table.rest_endpoint + `get-users`, {
+    let users = await fetch(window.dt_users_table.rest_endpoint + `get-users`, {
       method: 'POST',
       body: JSON.stringify({
         limit: 500,
         search,
         sort,
-        filter
+        filter,
       }),
       headers: {
-        "Content-Type": "application/json",
-        'X-WP-Nonce': window.wpApiShare.nonce
-      }
-    }).then(res => res.json());
+        'Content-Type': 'application/json',
+        'X-WP-Nonce': window.wpApiShare.nonce,
+      },
+    }).then((res) => res.json());
     this.loading = false;
     this.users = users.users;
     this.total_users = users.total_users;
-
   }
 
-  open_edit_modal(user_id){
-    window.open_user_modal( user_id )
+  open_edit_modal(user_id) {
+    window.open_user_modal(user_id);
   }
 
-  search_text(){
+  search_text() {
     this.search = this.shadowRoot.querySelector('#search-users').value;
-    this.getUsers( this.search )
+    this.getUsers(this.search);
   }
 
-  clear_search(){
+  clear_search() {
     this.search = '';
-    this.getUsers( this.search )
+    this.getUsers(this.search);
   }
 
-  sort_column(e){
+  sort_column(e) {
     let id = e.target.id;
     let sort = e.target.id;
-    if ( this.sort === sort ) {
-      sort = sort.includes('-') ? sort.replace('-', '') : '-' + sort
+    if (this.sort === sort) {
+      sort = sort.includes('-') ? sort.replace('-', '') : '-' + sort;
     }
-    this.getUsers( this.search, sort )
+    this.getUsers(this.search, sort);
 
     //add sort_asc or sort_desc class to column
-    this.shadowRoot.querySelectorAll('th').forEach(th=> th.classList.remove('sorting_asc', 'sorting_desc'));
-    this.shadowRoot.querySelector('#' + id).classList.add(sort.includes('-') ? 'sorting_desc' : 'sorting_asc');
+    this.shadowRoot
+      .querySelectorAll('th')
+      .forEach((th) => th.classList.remove('sorting_asc', 'sorting_desc'));
+    this.shadowRoot
+      .querySelector('#' + id)
+      .classList.add(sort.includes('-') ? 'sorting_desc' : 'sorting_asc');
 
     this.sort = sort;
   }
 
-  filter_column(column, value, e){
+  filter_column(column, value, e) {
     let filter = {};
     filter[column] = value;
-    this.getUsers( this.search, this.sort, filter )
+    this.getUsers(this.search, this.sort, filter);
 
     //set all filter selects to empty
-    this.shadowRoot.querySelectorAll('.filter-select').forEach(select=> select.value = '');
+    this.shadowRoot
+      .querySelectorAll('.filter-select')
+      .forEach((select) => (select.value = ''));
     e.target.value = value;
   }
 
@@ -98,7 +109,7 @@ export class UsersTable extends LitElement {
     return html`
         <div id="title-row">
             <div>
-                <h2>${this.translations.users} ${this.loading ? html`<img style="height:1em;" src="${window.wpApiShare.template_dir}/spinner.svg" alt="spinner" />` : html`<span style="font-size: 14px;font-weight: normal">${this.translations.showing_x_of_y.replace('%1$s', this.users.length).replace('%2$s', this.total_users)}`}</span></h2>
+                <h2>${this.translations.users} ${this.loading ? html`<img style="height:1em;" src="${window.wpApiShare.template_dir}/spinner.svg" alt="spinner" />` : html`<span style="font-size: 14px;font-weight: normal">${this.translations.showing_x_of_y.replace('%1$s', this.users.length).replace('%2$s', this.total_users)}</span>`}</span></h2>
             </div>
             <div class="search-section">
                 <input id="search-users" type="search" placeholder="${this.translations.search}" @search="${this.search_text}">
@@ -110,69 +121,118 @@ export class UsersTable extends LitElement {
         <div class="user-table-div" style="overflow: auto;">
           <table class="sortable">
               <tr class="filter-row">
-                  ${Object.keys(window.dt_users_table.fields).map(k=>{
-                    if ( window.dt_users_table.fields[k].hidden === true  ) return;
-                    if ( window.dt_users_table.fields[k].options  ) {
+                  ${Object.keys(window.dt_users_table.fields).map((k) => {
+                    if (window.dt_users_table.fields[k].hidden === true) return;
+                    if (window.dt_users_table.fields[k].options) {
                       let options = window.dt_users_table.fields[k].options;
-                      return html`<td data-field="${k}" data-type="${window.dt_users_table.fields[k].type}">
-                          <select class="filter-select" @change="${e=>this.filter_column(k,e.target.value, e)}">
-                              <option value=""></option>
-                              ${Object.keys(options).map(o=> html`<option value="${o}">${options[o].label}</option>`)}
-                          </select>
-                      </td>`
+                      return html`<td
+                        data-field="${k}"
+                        data-type="${window.dt_users_table.fields[k].type}"
+                      >
+                        <select
+                          class="filter-select"
+                          @change="${(e) =>
+                            this.filter_column(k, e.target.value, e)}"
+                        >
+                          <option value=""></option>
+                          ${Object.keys(options).map(
+                            (o) =>
+                              html`<option value="${o}">
+                                ${options[o].label}
+                              </option>`,
+                          )}
+                        </select>
+                      </td>`;
                     } else {
-                      return html`<td data-field="${k}" data-type="${window.dt_users_table.fields[k].type}"></td>`
+                      return html`<td
+                        data-field="${k}"
+                        data-type="${window.dt_users_table.fields[k].type}"
+                      ></td>`;
                     }
                   })}
               </tr>
               <tr>
-                  ${Object.keys(window.dt_users_table.fields).map(k=>{
-                    if ( window.dt_users_table.fields[k].hidden === true  ) return;
-                    return html`<th id="${k}" data-field="${k}" @click="${this.sort_column}" data-type="${window.dt_users_table.fields[k].type}">
-                        ${window.dt_users_table.fields[k].label}
-                    </th>`
+                  ${Object.keys(window.dt_users_table.fields).map((k) => {
+                    if (window.dt_users_table.fields[k].hidden === true) return;
+                    return html`<th
+                      id="${k}"
+                      data-field="${k}"
+                      @click="${this.sort_column}"
+                      data-type="${window.dt_users_table.fields[k].type}"
+                    >
+                      ${window.dt_users_table.fields[k].label}
+                    </th>`;
                   })}
               </tr>
 
-              ${this.users.length ? this.users.map(user => html`
-                  <tr class="user_row" data-user="${user.ID}" @click="${e=>this.open_edit_modal(user.ID)}">
-                      ${Object.keys(window.dt_users_table.fields).map(k=>{
-                        if ( window.dt_users_table.fields[k].hidden === true  ) return;
-                        let field = window.dt_users_table.fields[k];
+              ${
+                this.users.length
+                  ? this.users.map(
+                      (user) => html`
+                        <tr
+                          class="user_row"
+                          data-user="${user.ID}"
+                          @click="${(e) => this.open_edit_modal(user.ID)}"
+                        >
+                          ${Object.keys(window.dt_users_table.fields).map(
+                            (k) => {
+                              if (
+                                window.dt_users_table.fields[k].hidden === true
+                              )
+                                return;
+                              let field = window.dt_users_table.fields[k];
 
-                        if ( field.type === 'text' || field.type === 'number' ){
-                          return html`<td>${user[k]}</td>`
-                        } else
-                        //date fields
-                        if ( field.type === 'date' ){
-                          return html`<td>${user[k] ? window.SHAREDFUNCTIONS.formatDate(user[k]):''}</td>`
-                        } else
-                        //array fields
-                        if ( ['array', 'array_keys'].includes(field.type) ){
-                          let labels = '';
-                          if ( (user[k] || []).map !== undefined ) {
-                              labels = (user[k] || []).map(v=>{
-
-                              return field.options[v]?.label || null
-                            }).filter(a=>a).join(', ');
-                          }
-                          return html`<td>${labels}</td>`
-                        } else
-                        //key select fields
-                        if ( ['key_select'].includes(field.type)){
-                          return html`<td>${field.options[user[k]]?.label || user[k]}</td>`
-                        } else
-                        //location grid fields
-                        if ( ['location_grid'].includes(field.type) ){
-                          let labels = (user[k] || []).map(v=>{
-                            return v.label || v
-                          }).join(', ')
-                          return html`<td>${labels}</td>`
-                        }
-                      })}
-                  </tr>
-              `
-              ) : html`` }
+                              if (
+                                field.type === 'text' ||
+                                field.type === 'number'
+                              ) {
+                                return html`<td>${user[k]}</td>`;
+                              }
+                              //date fields
+                              else if (field.type === 'date') {
+                                return html`<td>
+                                  ${user[k]
+                                    ? window.SHAREDFUNCTIONS.formatDate(user[k])
+                                    : ''}
+                                </td>`;
+                              }
+                              //array fields
+                              else if (
+                                ['array', 'array_keys'].includes(field.type)
+                              ) {
+                                let labels = '';
+                                if ((user[k] || []).map !== undefined) {
+                                  labels = (user[k] || [])
+                                    .map((v) => {
+                                      return field.options[v]?.label || null;
+                                    })
+                                    .filter((a) => a)
+                                    .join(', ');
+                                }
+                                return html`<td>${labels}</td>`;
+                              }
+                              //key select fields
+                              else if (['key_select'].includes(field.type)) {
+                                return html`<td>
+                                  ${field.options[user[k]]?.label || user[k]}
+                                </td>`;
+                              }
+                              //location grid fields
+                              else if (['location_grid'].includes(field.type)) {
+                                let labels = (user[k] || [])
+                                  .map((v) => {
+                                    return v.label || v;
+                                  })
+                                  .join(', ');
+                                return html`<td>${labels}</td>`;
+                              }
+                            },
+                          )}
+                        </tr>
+                      `,
+                    )
+                  : html``
+              }
           </table>
         </div>
     `;
@@ -186,16 +246,19 @@ export class UsersTable extends LitElement {
           table-layout: fixed;
         }
 
-        td, th {
+        td,
+        th {
           border: 1px solid #dddddd;
           text-align: left;
           padding: 8px;
           //min-width: 75px;
         }
-        th[data-type="number"],td[data-type="number"] {
+        th[data-type='number'],
+        td[data-type='number'] {
           width: 75px;
         }
-        th[data-field="ID"],td[data-field="ID"] {
+        th[data-field='ID'],
+        td[data-field='ID'] {
           width: 50px;
         }
 
@@ -205,7 +268,7 @@ export class UsersTable extends LitElement {
         .sortable th {
           background-repeat: no-repeat;
           background-position: center right;
-          padding-right:1.5rem;
+          padding-right: 1.5rem;
           background-image: var(--sort-both);
         }
         .sortable .sorting_desc {
@@ -254,7 +317,9 @@ export class UsersTable extends LitElement {
           min-height: 30px;
           max-width: 25rem;
           -webkit-appearance: none;
-          background: #fff url(data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2220%22%20height%3D%2220%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M5%206l5%205%205-5%202%201-7%207-7-7%202-1z%22%20fill%3D%22%23555%22%2F%3E%3C%2Fsvg%3E) no-repeat right 5px top 55%;
+          background: #fff
+            url(data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2220%22%20height%3D%2220%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M5%206l5%205%205-5%202%201-7%207-7-7%202-1z%22%20fill%3D%22%23555%22%2F%3E%3C%2Fsvg%3E)
+            no-repeat right 5px top 55%;
           background-size: 16px 16px;
           cursor: pointer;
           vertical-align: middle;
@@ -279,8 +344,8 @@ export class UsersTable extends LitElement {
           background-color: #fff;
           color: #2c3338;
         }
-      `
-    ]
+      `,
+    ];
   }
 }
 

--- a/dt-users/user-management.js
+++ b/dt-users/user-management.js
@@ -1,9 +1,10 @@
 /* global dt_user_management_localized:false */
-jQuery(document).ready(function($) {
-  let escaped_translations = window.SHAREDFUNCTIONS.escapeObject(window.dt_user_management_localized.translations)
+jQuery(document).ready(function ($) {
+  let escaped_translations = window.SHAREDFUNCTIONS.escapeObject(
+    window.dt_user_management_localized.translations,
+  );
 
-  window.open_user_modal = ( user_id )=>{
-
+  window.open_user_modal = (user_id) => {
     // Reset email password button.
     let button_icon = $('#reset_user_pwd_email_icon');
     button_icon.removeClass('active');
@@ -17,426 +18,592 @@ jQuery(document).ready(function($) {
     /**
      * Set availability dates
      */
-    let unavailable_dates_picker = $('#date_range')
-    unavailable_dates_picker.daterangepicker({
-      parentEl: "#user_modal",
-      "singleDatePicker": false,
-      autoUpdateInput: false,
-      "locale": {
-        "format": "YYYY/MM/DD",
-        "separator": " - ",
-        "daysOfWeek": window.SHAREDFUNCTIONS.get_days_of_the_week_initials(),
-        "monthNames": window.SHAREDFUNCTIONS.get_months_labels(),
-      },
-      "firstDay": 1,
-      "opens": "center",
-      "drops": "down"
-    }).on('apply.daterangepicker', function (ev, picker) {
-      $(this).val(picker.startDate.format('YYYY/MM/DD') + ' - ' + picker.endDate.format('YYYY/MM/DD'));
-      let start_date = picker.startDate.format('YYYY/MM/DD')
-      let end_date = picker.endDate.format('YYYY/MM/DD')
-      $('#add_unavailable_dates_spinner').addClass('active')
-      update_user( window.current_user_lookup, 'add_unavailability', {start_date, end_date}).then((resp)=>{
-        $('#add_unavailable_dates_spinner').removeClass('active')
-        unavailable_dates_picker.val('');
-        display_dates_unavailable(resp)
+    let unavailable_dates_picker = $('#date_range');
+    unavailable_dates_picker
+      .daterangepicker({
+        parentEl: '#user_modal',
+        singleDatePicker: false,
+        autoUpdateInput: false,
+        locale: {
+          format: 'YYYY/MM/DD',
+          separator: ' - ',
+          daysOfWeek: window.SHAREDFUNCTIONS.get_days_of_the_week_initials(),
+          monthNames: window.SHAREDFUNCTIONS.get_months_labels(),
+        },
+        firstDay: 1,
+        opens: 'center',
+        drops: 'down',
       })
-    })
+      .on('apply.daterangepicker', function (ev, picker) {
+        $(this).val(
+          picker.startDate.format('YYYY/MM/DD') +
+            ' - ' +
+            picker.endDate.format('YYYY/MM/DD'),
+        );
+        let start_date = picker.startDate.format('YYYY/MM/DD');
+        let end_date = picker.endDate.format('YYYY/MM/DD');
+        $('#add_unavailable_dates_spinner').addClass('active');
+        update_user(window.current_user_lookup, 'add_unavailability', {
+          start_date,
+          end_date,
+        }).then((resp) => {
+          $('#add_unavailable_dates_spinner').removeClass('active');
+          unavailable_dates_picker.val('');
+          display_dates_unavailable(resp);
+        });
+      });
 
-    window.current_user_lookup = user_id
+    window.current_user_lookup = user_id;
 
-    $('#user-id-reveal').html(window.current_user_lookup)
+    $('#user-id-reveal').html(window.current_user_lookup);
 
-    $('.users-spinner').addClass("active")
+    $('.users-spinner').addClass('active');
 
-    $('#languages_multi_select .dt_multi_select').addClass('empty-select-button').removeClass('selected-select-button');
+    $('#languages_multi_select .dt_multi_select')
+      .addClass('empty-select-button')
+      .removeClass('selected-select-button');
 
     // load spinners
-    let spinner = ' <span class="loading-spinner users-spinner active"></span> '
-    $("#user_name").html(spinner)
-    $('#update_needed_count').html(spinner)
-    $('#needs_accepted_count').html(spinner)
-    $('#active_contacts').html(spinner)
-    $('#unread_notifications').html(spinner)
-    $('#assigned_this_month').html(spinner)
-    $('#assigned_last_month').html(spinner)
-    $('#assigned_this_year').html(spinner)
-    $('#assigned_all_time').html(spinner)
-    $('#unaccepted_contacts').html(spinner)
-    $('#contact_accepts').html(spinner)
-    $('#avg_contact_accept').html(spinner)
-    $('#unattempted_contacts').html(spinner)
-    $('#contact_attempts').html(spinner)
-    $('#avg_contact_attempt').html(spinner)
-    $('#update_needed_list').html(spinner)
-    $('#status_chart_div').html(spinner)
-    $('#activity').html(spinner)
-    $('#day_activity_chart').html(spinner)
-    $('#mapbox-wrapper').html(spinner)
-    $('#location-grid-meta-results').html(spinner)
-    $('#profile_loading').addClass("active")
+    let spinner =
+      ' <span class="loading-spinner users-spinner active"></span> ';
+    $('#user_name').html(spinner);
+    $('#update_needed_count').html(spinner);
+    $('#needs_accepted_count').html(spinner);
+    $('#active_contacts').html(spinner);
+    $('#unread_notifications').html(spinner);
+    $('#assigned_this_month').html(spinner);
+    $('#assigned_last_month').html(spinner);
+    $('#assigned_this_year').html(spinner);
+    $('#assigned_all_time').html(spinner);
+    $('#unaccepted_contacts').html(spinner);
+    $('#contact_accepts').html(spinner);
+    $('#avg_contact_accept').html(spinner);
+    $('#unattempted_contacts').html(spinner);
+    $('#contact_attempts').html(spinner);
+    $('#avg_contact_attempt').html(spinner);
+    $('#update_needed_list').html(spinner);
+    $('#status_chart_div').html(spinner);
+    $('#activity').html(spinner);
+    $('#day_activity_chart').html(spinner);
+    $('#mapbox-wrapper').html(spinner);
+    $('#location-grid-meta-results').html(spinner);
+    $('#profile_loading').addClass('active');
 
-    $('#status-select').val('')
-    $('#workload-select').val('')
+    $('#status-select').val('');
+    $('#workload-select').val('');
 
     //clear the locations typeahead of previous values when the modal is opened
-    let typeahead = window.Typeahead['.js-typeahead-location_grid']
+    let typeahead = window.Typeahead['.js-typeahead-location_grid'];
     if (typeahead) {
       typeahead.items = [];
-      typeahead.comparedItems =[];
+      typeahead.comparedItems = [];
       typeahead.label.container.empty();
-      typeahead.adjustInputSize()
+      typeahead.adjustInputSize();
     }
 
     /* details */
-    window.makeRequest( "get", `user?user=${user_id}&section=details`, null , 'user-management/v1/')
-    .done(details=>{
-      if ( window.current_user_lookup === user_id ) {
-        $('#profile_loading').removeClass("active")
-        user_details = details
-        $("#user_name").html(window.SHAREDFUNCTIONS.escapeHTML(details.display_name))
-        $("#update_display_name").val(details.display_name);
-        $("#user_email").html(details.user_email);
-        (details.languages || []).forEach(l=>{
-          $(`#${l}`).addClass('selected-select-button').removeClass('empty-select-button')
-        })
+    window
+      .makeRequest(
+        'get',
+        `user?user=${user_id}&section=details`,
+        null,
+        'user-management/v1/',
+      )
+      .done((details) => {
+        if (window.current_user_lookup === user_id) {
+          $('#profile_loading').removeClass('active');
+          user_details = details;
+          $('#user_name').html(
+            window.SHAREDFUNCTIONS.escapeHTML(details.display_name),
+          );
+          $('#update_display_name').val(details.display_name);
+          $('#user_email').html(details.user_email);
+          (details.languages || []).forEach((l) => {
+            $(`#${l}`)
+              .addClass('selected-select-button')
+              .removeClass('empty-select-button');
+          });
 
-        $('#gender').val(details.gender)
-        $('#description').val(details.description)
-        details.user_fields.forEach(field=>{
-          $(`#${field.key}`).val(field.value)
-        })
+          $('#gender').val(details.gender);
+          $('#description').val(details.description);
+          details.user_fields.forEach((field) => {
+            $(`#${field.key}`).val(field.value);
+          });
 
-        $('#user_status').val(window.SHAREDFUNCTIONS.escapeHTML(details.user_status))
-        if ( details.user_status !== "0" ){
-        }
-        $('#workload_status').val(window.SHAREDFUNCTIONS.escapeHTML(details.workload_status))
+          $('#user_status').val(
+            window.SHAREDFUNCTIONS.escapeHTML(details.user_status),
+          );
+          if (details.user_status !== '0') {
+          }
+          $('#workload_status').val(
+            window.SHAREDFUNCTIONS.escapeHTML(details.workload_status),
+          );
 
+          setup_user_roles(details);
 
-        setup_user_roles( details );
+          //availability
+          if (details.dates_unavailable) {
+            display_dates_unavailable(details.dates_unavailable);
+          }
 
-        //availability
-        if ( details.dates_unavailable ) {
-          display_dates_unavailable( details.dates_unavailable )
-        }
-
-        let update_needed_list_html = ``;
-        (details.update_needed.contacts||[]).forEach(contact => {
-          update_needed_list_html += `<li>
+          let update_needed_list_html = ``;
+          (details.update_needed.contacts || []).forEach((contact) => {
+            update_needed_list_html += `<li>
             <a href="${window.wpApiShare.site_url}/contacts/${window.SHAREDFUNCTIONS.escapeHTML(contact.ID)}" target="_blank">
                 ${window.SHAREDFUNCTIONS.escapeHTML(contact.post_title)}:  ${window.SHAREDFUNCTIONS.escapeHTML(contact.last_modified_msg)}
             </a>
-          </li>`
-        })
-        $('#update_needed_list').html(update_needed_list_html)
-
-
-        //locations
-        if ( typeof window.dtMapbox !== "undefined" ) {
-          window.dtMapbox.post_type = 'users'
-          window.dtMapbox.user_id = user_id
-          window.dtMapbox.user_location = details.user_location
-          window.write_results_box()
-
-          $( '#new-mapbox-search' ).on( "click", function() {
-            window.dtMapbox.post_type = 'users'
-            window.dtMapbox.user_id = user_id
-            window.dtMapbox.user_location = details.user_location
-            window.write_input_widget()
+          </li>`;
           });
-        } else {
+          $('#update_needed_list').html(update_needed_list_html);
+
           //locations
-          if (typeahead) {
-            typeahead.items = [];
-            typeahead.comparedItems =[];
-            typeahead.label.container.empty();
-            typeahead.adjustInputSize()
+          if (typeof window.dtMapbox !== 'undefined') {
+            window.dtMapbox.post_type = 'users';
+            window.dtMapbox.user_id = user_id;
+            window.dtMapbox.user_location = details.user_location;
+            window.write_results_box();
+
+            $('#new-mapbox-search').on('click', function () {
+              window.dtMapbox.post_type = 'users';
+              window.dtMapbox.user_id = user_id;
+              window.dtMapbox.user_location = details.user_location;
+              window.write_input_widget();
+            });
+          } else {
+            //locations
+            if (typeahead) {
+              typeahead.items = [];
+              typeahead.comparedItems = [];
+              typeahead.label.container.empty();
+              typeahead.adjustInputSize();
+            }
+            (details.user_location.location_grid || []).forEach((location) => {
+              typeahead.addMultiselectItemLayout({
+                ID: location.id.toString(),
+                name: location.label,
+              });
+            });
           }
-          (details.user_location.location_grid || []).forEach(location => {
-            typeahead.addMultiselectItemLayout({ID: location.id.toString(), name: location.label})
-          })
         }
-      }
-    }).catch((e)=>{
-      console.log( 'error in details')
-      console.log( e)
-    })
+      })
+      .catch((e) => {
+        console.log('error in details');
+        console.log(e);
+      });
 
     let loaded_dmm_tab_once = false;
-    $('#dmm-label').on( "click", function (){
-      if ( !loaded_dmm_tab_once ) {
+    $('#dmm-label').on('click', function () {
+      if (!loaded_dmm_tab_once) {
         /* locations */
-        window.makeRequest("get", `user?user=${user_id}&section=stats`, null, 'user-management/v1/')
-        .done(details => {
-          if (window.current_user_lookup===user_id) {
-            //stats
-            $('#update_needed_count').html(window.SHAREDFUNCTIONS.escapeHTML(details.update_needed["total"]))
-            $('#needs_accepted_count').html(window.SHAREDFUNCTIONS.escapeHTML(details.needs_accepted["total"]))
-            $('#active_contacts').html(window.SHAREDFUNCTIONS.escapeHTML(details.active_contacts))
-            $('#unread_notifications').html(window.SHAREDFUNCTIONS.escapeHTML(details.unread_notifications))
-            $('#assigned_this_month').text(window.SHAREDFUNCTIONS.escapeHTML(details.assigned_counts.this_month))
-            $('#assigned_last_month').text(window.SHAREDFUNCTIONS.escapeHTML(details.assigned_counts.last_month))
-            $('#assigned_this_year').text(window.SHAREDFUNCTIONS.escapeHTML(details.assigned_counts.this_year))
-            $('#assigned_all_time').text(window.SHAREDFUNCTIONS.escapeHTML(details.assigned_counts.all_time))
+        window
+          .makeRequest(
+            'get',
+            `user?user=${user_id}&section=stats`,
+            null,
+            'user-management/v1/',
+          )
+          .done((details) => {
+            if (window.current_user_lookup === user_id) {
+              //stats
+              $('#update_needed_count').html(
+                window.SHAREDFUNCTIONS.escapeHTML(
+                  details.update_needed['total'],
+                ),
+              );
+              $('#needs_accepted_count').html(
+                window.SHAREDFUNCTIONS.escapeHTML(
+                  details.needs_accepted['total'],
+                ),
+              );
+              $('#active_contacts').html(
+                window.SHAREDFUNCTIONS.escapeHTML(details.active_contacts),
+              );
+              $('#unread_notifications').html(
+                window.SHAREDFUNCTIONS.escapeHTML(details.unread_notifications),
+              );
+              $('#assigned_this_month').text(
+                window.SHAREDFUNCTIONS.escapeHTML(
+                  details.assigned_counts.this_month,
+                ),
+              );
+              $('#assigned_last_month').text(
+                window.SHAREDFUNCTIONS.escapeHTML(
+                  details.assigned_counts.last_month,
+                ),
+              );
+              $('#assigned_this_year').text(
+                window.SHAREDFUNCTIONS.escapeHTML(
+                  details.assigned_counts.this_year,
+                ),
+              );
+              $('#assigned_all_time').text(
+                window.SHAREDFUNCTIONS.escapeHTML(
+                  details.assigned_counts.all_time,
+                ),
+              );
 
-            status_pie_chart(details.contact_statuses)
-          }
-
-        }).catch((e) => {
-          console.log('error in locations')
-          console.log(e)
-        })
+              status_pie_chart(details.contact_statuses);
+            }
+          })
+          .catch((e) => {
+            console.log('error in locations');
+            console.log(e);
+          });
         /* unaccepted_contacts */
-        window.makeRequest("get", `user?user=${user_id}&section=unaccepted_contacts`, null, 'user-management/v1/')
-        .done(response => {
-
-          if (window.current_user_lookup===user_id && response.unaccepted_contacts.length > 0) {
-            let unaccepted_contacts_html = ``
-            response.unaccepted_contacts.forEach(contact => {
-              let days = contact.time / 60 / 60 / 24;
-              unaccepted_contacts_html += `<li>
+        window
+          .makeRequest(
+            'get',
+            `user?user=${user_id}&section=unaccepted_contacts`,
+            null,
+            'user-management/v1/',
+          )
+          .done((response) => {
+            if (
+              window.current_user_lookup === user_id &&
+              response.unaccepted_contacts.length > 0
+            ) {
+              let unaccepted_contacts_html = ``;
+              response.unaccepted_contacts.forEach((contact) => {
+                let days = contact.time / 60 / 60 / 24;
+                unaccepted_contacts_html += `<li>
           <a href="${window.wpApiShare.site_url}/contacts/${window.SHAREDFUNCTIONS.escapeHTML(contact.ID)}" target="_blank">
               ${window.SHAREDFUNCTIONS.escapeHTML(contact.name)} has be waiting to be accepted for ${days.toFixed(1)} days
-              </a> </li>`
-            })
-            $('#unaccepted_contacts').html(unaccepted_contacts_html)
-          } else {
-            $('#unaccepted_contacts').html('')
-          }
-
-        }).catch((e) => {
-          console.log('error in unaccepted_contacts')
-          console.log(e)
-        })
+              </a> </li>`;
+              });
+              $('#unaccepted_contacts').html(unaccepted_contacts_html);
+            } else {
+              $('#unaccepted_contacts').html('');
+            }
+          })
+          .catch((e) => {
+            console.log('error in unaccepted_contacts');
+            console.log(e);
+          });
 
         /* contact_accepts */
-        window.makeRequest("get", `user?user=${user_id}&section=contact_accepts`, null, 'user-management/v1/')
-        .done(response => {
-
-          if (window.current_user_lookup===user_id && response.contact_accepts.length > 0) {
-            // assigned to contact accept
-            let accepted_contacts_html = ``
-            let avg_contact_accept = 0
-            response.contact_accepts.forEach(contact => {
-              let days = contact.time / 60 / 60 / 24;
-              avg_contact_accept += days
-              let accept_line = escaped_translations.accept_time
-              .replace('%1$s', contact.name)
-              .replace('%2$s', window.moment.unix(contact.date_accepted).format("MMM Do"))
-              .replace('%3$s', days.toFixed(1))
-              accepted_contacts_html += `<li>
+        window
+          .makeRequest(
+            'get',
+            `user?user=${user_id}&section=contact_accepts`,
+            null,
+            'user-management/v1/',
+          )
+          .done((response) => {
+            if (
+              window.current_user_lookup === user_id &&
+              response.contact_accepts.length > 0
+            ) {
+              // assigned to contact accept
+              let accepted_contacts_html = ``;
+              let avg_contact_accept = 0;
+              response.contact_accepts.forEach((contact) => {
+                let days = contact.time / 60 / 60 / 24;
+                avg_contact_accept += days;
+                let accept_line = escaped_translations.accept_time
+                  .replace('%1$s', contact.name)
+                  .replace(
+                    '%2$s',
+                    window.moment.unix(contact.date_accepted).format('MMM Do'),
+                  )
+                  .replace('%3$s', days.toFixed(1));
+                accepted_contacts_html += `<li>
           <a href="${window.wpApiShare.site_url}/contacts/${window.SHAREDFUNCTIONS.escapeHTML(contact.ID)}" target="_blank">
               ${window.SHAREDFUNCTIONS.escapeHTML(accept_line)}
-          </a> </li>`
-            })
-            $('#contact_accepts').html(accepted_contacts_html)
-            $('#avg_contact_accept').html(avg_contact_accept===0 ? '-':(avg_contact_accept / response.contact_accepts.length).toFixed(1))
-          } else {
-            $('#contact_accepts').html('')
-            $('#avg_contact_accept').html('')
-          }
-
-        }).catch((e) => {
-          console.log('error in contact_accepts')
-          console.log(e)
-        })
+          </a> </li>`;
+              });
+              $('#contact_accepts').html(accepted_contacts_html);
+              $('#avg_contact_accept').html(
+                avg_contact_accept === 0
+                  ? '-'
+                  : (
+                      avg_contact_accept / response.contact_accepts.length
+                    ).toFixed(1),
+              );
+            } else {
+              $('#contact_accepts').html('');
+              $('#avg_contact_accept').html('');
+            }
+          })
+          .catch((e) => {
+            console.log('error in contact_accepts');
+            console.log(e);
+          });
 
         /* unattempted_contacts */
-        window.makeRequest("get", `user?user=${user_id}&section=unattempted_contacts`, null, 'user-management/v1/')
-        .done(response => {
-
-          if (window.current_user_lookup===user_id && response.unattempted_contacts.length > 0) {
-            //contacts assigned with no contact attempt
-            let unattemped_contacts_html = ``
-            response.unattempted_contacts.forEach(contact => {
-              let days = contact.time / 60 / 60 / 24;
-              let line = escaped_translations.no_contact_attempt_time
-              .replace('%1$s', window.SHAREDFUNCTIONS.escapeHTML(contact.name))
-              .replace('%2$s', days.toFixed(1))
-              unattemped_contacts_html += `<li>
+        window
+          .makeRequest(
+            'get',
+            `user?user=${user_id}&section=unattempted_contacts`,
+            null,
+            'user-management/v1/',
+          )
+          .done((response) => {
+            if (
+              window.current_user_lookup === user_id &&
+              response.unattempted_contacts.length > 0
+            ) {
+              //contacts assigned with no contact attempt
+              let unattemped_contacts_html = ``;
+              response.unattempted_contacts.forEach((contact) => {
+                let days = contact.time / 60 / 60 / 24;
+                let line = escaped_translations.no_contact_attempt_time
+                  .replace(
+                    '%1$s',
+                    window.SHAREDFUNCTIONS.escapeHTML(contact.name),
+                  )
+                  .replace('%2$s', days.toFixed(1));
+                unattemped_contacts_html += `<li>
           <a href="${window.wpApiShare.site_url}/contacts/${window.SHAREDFUNCTIONS.escapeHTML(contact.ID)}" target="_blank">
               ${window.SHAREDFUNCTIONS.escapeHTML(line)}
-          </a> </li>`
-            })
-            $('#unattempted_contacts').html(unattemped_contacts_html)
-          } else {
-            $('#unattempted_contacts').html('')
-          }
-
-        }).catch((e) => {
-          console.log('error in unattempted_contacts')
-          console.log(e)
-        })
+          </a> </li>`;
+              });
+              $('#unattempted_contacts').html(unattemped_contacts_html);
+            } else {
+              $('#unattempted_contacts').html('');
+            }
+          })
+          .catch((e) => {
+            console.log('error in unattempted_contacts');
+            console.log(e);
+          });
 
         /* contact_attempts */
-        window.makeRequest("get", `user?user=${user_id}&section=contact_attempts`, null, 'user-management/v1/')
-        .done(response => {
-
-          if (window.current_user_lookup===user_id && response.contact_attempts.length > 0) {
-            //contact assigned to contact attempt
-            let attempted_contacts_html = ``
-            let avg_contact_attempt = 0
-            response.contact_attempts.forEach(contact => {
-              let days = contact.time / 60 / 60 / 24;
-              avg_contact_attempt += days
-              let line = escaped_translations.contact_attempt_time
-              .replace('%1$s', window.SHAREDFUNCTIONS.escapeHTML(contact.name))
-              .replace('%2$s', window.moment.unix(contact.date_attempted).format("MMM Do"))
-              .replace('%3$s', days.toFixed(1))
-              attempted_contacts_html += `<li>
+        window
+          .makeRequest(
+            'get',
+            `user?user=${user_id}&section=contact_attempts`,
+            null,
+            'user-management/v1/',
+          )
+          .done((response) => {
+            if (
+              window.current_user_lookup === user_id &&
+              response.contact_attempts.length > 0
+            ) {
+              //contact assigned to contact attempt
+              let attempted_contacts_html = ``;
+              let avg_contact_attempt = 0;
+              response.contact_attempts.forEach((contact) => {
+                let days = contact.time / 60 / 60 / 24;
+                avg_contact_attempt += days;
+                let line = escaped_translations.contact_attempt_time
+                  .replace(
+                    '%1$s',
+                    window.SHAREDFUNCTIONS.escapeHTML(contact.name),
+                  )
+                  .replace(
+                    '%2$s',
+                    window.moment.unix(contact.date_attempted).format('MMM Do'),
+                  )
+                  .replace('%3$s', days.toFixed(1));
+                attempted_contacts_html += `<li>
           <a href="${window.wpApiShare.site_url}/contacts/${window.SHAREDFUNCTIONS.escapeHTML(contact.ID)}" target="_blank">
               ${window.SHAREDFUNCTIONS.escapeHTML(line)}
-          </a> </li>`
-            })
-            $('#contact_attempts').html(attempted_contacts_html)
-            $('#avg_contact_attempt').html(avg_contact_attempt===0 ? '-':(avg_contact_attempt / response.contact_attempts.length).toFixed(1))
-          } else {
-            $('#contact_attempts').html('')
-            $('#avg_contact_attempt').html('')
-          }
-
-        }).catch((e) => {
-          console.log('error in contact_attempts')
-          console.log(e)
-        })
+          </a> </li>`;
+              });
+              $('#contact_attempts').html(attempted_contacts_html);
+              $('#avg_contact_attempt').html(
+                avg_contact_attempt === 0
+                  ? '-'
+                  : (
+                      avg_contact_attempt / response.contact_attempts.length
+                    ).toFixed(1),
+              );
+            } else {
+              $('#contact_attempts').html('');
+              $('#avg_contact_attempt').html('');
+            }
+          })
+          .catch((e) => {
+            console.log('error in contact_attempts');
+            console.log(e);
+          });
       }
-    })
+    });
 
     /* activity */
-    window.makeRequest( "get", `user?user=${user_id}&section=activity`, null , 'user-management/v1/')
-    .done(activity=>{
-      if ( window.current_user_lookup === user_id ) {
-        let activity_div = $('#activity')
-        let activity_html = window.dtActivityLogs.makeActivityList(activity.user_activity, escaped_translations)
-        activity_div.html(activity_html)
-      }
-    }).catch((e)=>{
-      console.log( 'error in activity')
-      console.log( e)
-    })
+    window
+      .makeRequest(
+        'get',
+        `user?user=${user_id}&section=activity`,
+        null,
+        'user-management/v1/',
+      )
+      .done((activity) => {
+        if (window.current_user_lookup === user_id) {
+          let activity_div = $('#activity');
+          let activity_html = window.dtActivityLogs.makeActivityList(
+            activity.user_activity,
+            escaped_translations,
+          );
+          activity_div.html(activity_html);
+        }
+      })
+      .catch((e) => {
+        console.log('error in activity');
+        console.log(e);
+      });
 
     /* days active */
-    window.makeRequest( "get", `user?user=${user_id}&section=days_active`, null , 'user-management/v1/')
-    .done(days=>{
-      if ( window.current_user_lookup === user_id ) {
-        let days_of_the_week = window.SHAREDFUNCTIONS.get_days_of_the_week_initials('short')
-        const daysActiveTranslated = days.days_active.map((day) => {
-          // translations start week with Sun, php gmdate starts week with Monday
-          const weekNumber = parseInt(day.weekday_number) === 7 ? 0 : parseInt(day.weekday_number)
-          const translatedWeekDay = days_of_the_week[weekNumber]
-          return {
-            ...day,
-            weekday: translatedWeekDay ? translatedWeekDay : day.weekday
-          }
-        })
-        day_activity_chart(daysActiveTranslated)
-      }
-    }).catch((e)=>{
-      console.log( 'error in days active')
-      console.log( e)
-    })
+    window
+      .makeRequest(
+        'get',
+        `user?user=${user_id}&section=days_active`,
+        null,
+        'user-management/v1/',
+      )
+      .done((days) => {
+        if (window.current_user_lookup === user_id) {
+          let days_of_the_week =
+            window.SHAREDFUNCTIONS.get_days_of_the_week_initials('short');
+          const daysActiveTranslated = days.days_active.map((day) => {
+            // translations start week with Sun, php gmdate starts week with Monday
+            const weekNumber =
+              parseInt(day.weekday_number) === 7
+                ? 0
+                : parseInt(day.weekday_number);
+            const translatedWeekDay = days_of_the_week[weekNumber];
+            return {
+              ...day,
+              weekday: translatedWeekDay ? translatedWeekDay : day.weekday,
+            };
+          });
+          day_activity_chart(daysActiveTranslated);
+        }
+      })
+      .catch((e) => {
+        console.log('error in days active');
+        console.log(e);
+      });
+  };
+
+  if (window.wpApiShare.url_path.includes('user-management/users')) {
+  } else if (window.wpApiShare.url_path.includes('user-management/user/')) {
+    window.open_user_modal(
+      window.wpApiShare.url_path
+        .replace('user-management/user', '')
+        .replace('/', ''),
+    );
+  }
+  if (window.wpApiShare.url_path.includes('user-management/add-user')) {
+    write_add_user();
   }
 
-  if( window.wpApiShare.url_path.includes('user-management/users') ) {
-  } else if ( window.wpApiShare.url_path.includes('user-management/user/')){
-    window.open_user_modal( window.wpApiShare.url_path.replace( 'user-management/user','').replace('/','') )
-  }
-  if( window.wpApiShare.url_path.includes('user-management/add-user') ) {
-    write_add_user()
-  }
-
-  let update_user = ( user_id, key, value )=>{
-    let data =  {
-      [key]: value
-    }
-    return window.makeRequest( "POST", `user?user=${user_id}`, data , 'user-management/v1/' )
-  }
+  let update_user = (user_id, key, value) => {
+    let data = {
+      [key]: value,
+    };
+    return window.makeRequest(
+      'POST',
+      `user?user=${user_id}`,
+      data,
+      'user-management/v1/',
+    );
+  };
 
   let user_details = [];
 
-  function setup_user_roles(user_data){
+  function setup_user_roles(user_data) {
     $('#user_roles_list input').prop('checked', false);
-    if ( user_data.roles ){
-      window.lodash.forOwn( user_data.roles, role=>{
-        $(`#user_roles_list [value="${role}"]`).prop('checked', true)
-        if ( role === "partner" || role === "marketer" ){
-          $(`#allowed_sources_options`).show()
+    if (user_data.roles) {
+      window.lodash.forOwn(user_data.roles, (role) => {
+        $(`#user_roles_list [value="${role}"]`).prop('checked', true);
+        if (role === 'partner' || role === 'marketer') {
+          $(`#allowed_sources_options`).show();
           $('#allowed_sources_options input').prop('checked', false);
-          user_data.allowed_sources.forEach(source=>{
-            $(`#allowed_sources_options [value="${source}"]`).prop('checked', true)
-          })
-          if ( user_data.allowed_sources.length === 0 ){
-            $(`#allowed_sources_options [value="all"]`).prop('checked', true)
+          user_data.allowed_sources.forEach((source) => {
+            $(`#allowed_sources_options [value="${source}"]`).prop(
+              'checked',
+              true,
+            );
+          });
+          if (user_data.allowed_sources.length === 0) {
+            $(`#allowed_sources_options [value="all"]`).prop('checked', true);
           }
         } else {
-          $(`#allowed_sources_options`).hide()
+          $(`#allowed_sources_options`).hide();
         }
-      })
+      });
     }
   }
 
-  $('#save_roles').on("click", function () {
-    $(this).toggleClass('loading', true)
+  $('#save_roles').on('click', function () {
+    $(this).toggleClass('loading', true);
     let roles = [];
     $('#user_roles_list input:checked').each(function () {
-      roles.push($(this).val())
-    })
-    update_user( window.current_user_lookup, 'save_roles', roles).then((roles)=>{
-      user_details.roles = roles
-      setup_user_roles( user_details )
-      $(this).toggleClass('loading', false)
-    }).catch(()=>{
-      $(this).toggleClass('loading', false)
-    })
-
-  })
-  $('#save_allowed_sources').on("click", function () {
-    $(this).toggleClass('loading', true)
+      roles.push($(this).val());
+    });
+    update_user(window.current_user_lookup, 'save_roles', roles)
+      .then((roles) => {
+        user_details.roles = roles;
+        setup_user_roles(user_details);
+        $(this).toggleClass('loading', false);
+      })
+      .catch(() => {
+        $(this).toggleClass('loading', false);
+      });
+  });
+  $('#save_allowed_sources').on('click', function () {
+    $(this).toggleClass('loading', true);
     let sources = [];
     $('#allowed_sources_options input:checked').each(function () {
-      sources.push($(this).val())
-    })
-    update_user( window.current_user_lookup, 'allowed_sources', sources).then((user_data)=>{
-      user_details.allowed_sources = user_data
-      setup_user_roles( user_details )
-      $(this).toggleClass('loading', false)
-    }).catch(()=>{
-      $(this).toggleClass('loading', false)
-    })
-  })
+      sources.push($(this).val());
+    });
+    update_user(window.current_user_lookup, 'allowed_sources', sources)
+      .then((user_data) => {
+        user_details.allowed_sources = user_data;
+        setup_user_roles(user_details);
+        $(this).toggleClass('loading', false);
+      })
+      .catch(() => {
+        $(this).toggleClass('loading', false);
+      });
+  });
 
-  let date_unavailable_table = $('#unavailable-list')
-  date_unavailable_table.empty()
-  let display_dates_unavailable = (list = [] )=>{
-    date_unavailable_table.empty()
-    let rows = ``
-    list.forEach(range=>{
+  let date_unavailable_table = $('#unavailable-list');
+  date_unavailable_table.empty();
+  let display_dates_unavailable = (list = []) => {
+    date_unavailable_table.empty();
+    let rows = ``;
+    list.forEach((range) => {
       rows += `<tr>
         <td>${window.SHAREDFUNCTIONS.escapeHTML(range.start_date)}</td>
         <td>${window.SHAREDFUNCTIONS.escapeHTML(range.end_date)}</td>
-        <td><button class="button remove_dates_unavailable" data-id="${window.SHAREDFUNCTIONS.escapeHTML(range.id)}">${ escaped_translations.remove }</button></td>
-      </tr>`
-    })
-    date_unavailable_table.html(rows)
-  }
-  $( document).on( 'click', '.remove_dates_unavailable', function () {
+        <td><button class="button remove_dates_unavailable" data-id="${window.SHAREDFUNCTIONS.escapeHTML(range.id)}">${escaped_translations.remove}</button></td>
+      </tr>`;
+    });
+    date_unavailable_table.html(rows);
+  };
+  $(document).on('click', '.remove_dates_unavailable', function () {
     let id = $(this).data('id');
-    update_user( window.current_user_lookup, 'remove_unavailability', id).then((resp)=>{
-      display_dates_unavailable(resp)
-    })
-  })
+    update_user(window.current_user_lookup, 'remove_unavailability', id).then(
+      (resp) => {
+        display_dates_unavailable(resp);
+      },
+    );
+  });
 
-  $('#corresponds_to_contact_link').on( "click", function (){
-    if ( user_details.corresponds_to_contact ){
-      window.open(window.wpApiShare.site_url + "/contacts/" + user_details.corresponds_to_contact, '_blank');
+  $('#corresponds_to_contact_link').on('click', function () {
+    if (user_details.corresponds_to_contact) {
+      window.open(
+        window.wpApiShare.site_url +
+          '/contacts/' +
+          user_details.corresponds_to_contact,
+        '_blank',
+      );
     }
-  })
-  $('#wp_admin_edit_user').on( "click", function (){
-    if ( user_details.user_id ){
-      window.open(window.wpApiShare.site_url + "/wp-admin/user-edit.php?user_id=" + user_details.user_id, '_blank');
+  });
+  $('#wp_admin_edit_user').on('click', function () {
+    if (user_details.user_id) {
+      window.open(
+        window.wpApiShare.site_url +
+          '/wp-admin/user-edit.php?user_id=' +
+          user_details.user_id,
+        '_blank',
+      );
     }
-  })
-  $('#reset_user_pwd_email').on("click", function (e) {
+  });
+  $('#reset_user_pwd_email').on('click', function (e) {
     e.preventDefault();
 
     let button_icon = $('#reset_user_pwd_email_icon');
@@ -444,7 +611,10 @@ jQuery(document).ready(function($) {
     button_icon.addClass('active');
     button_icon.addClass('loading-spinner');
 
-    send_user_pwd_reset_email(user_details['user_id'], user_details['user_email']).then((response) => {
+    send_user_pwd_reset_email(
+      user_details['user_id'],
+      user_details['user_email'],
+    ).then((response) => {
       button_icon.removeClass('active');
       button_icon.removeClass('loading-spinner');
       button_icon.css('font-size', '20px');
@@ -452,7 +622,6 @@ jQuery(document).ready(function($) {
       if (response && response['sent']) {
         button_icon.addClass('mdi mdi-email-check-outline');
         button_icon.css('color', '#01d701');
-
       } else {
         button_icon.addClass('mdi mdi-email-remove-outline');
         button_icon.css('color', '#d70101');
@@ -462,152 +631,208 @@ jQuery(document).ready(function($) {
 
   let send_user_pwd_reset_email = (user_id, user_email) => {
     let data = {
-      'id': user_id,
-      'email': user_email
-    }
-    return window.makeRequest('POST', `send_pwd_reset_email`, data, 'user-management/v1/');
-  }
+      id: user_id,
+      email: user_email,
+    };
+    return window.makeRequest(
+      'POST',
+      `send_pwd_reset_email`,
+      data,
+      'user-management/v1/',
+    );
+  };
 
   /**
    * Locations
    */
-  if ( typeof window.dtMapbox === "undefined" && $('.js-typeahead-location_grid').length) {
-    let typeaheadTotals = {}
-    if (!window.Typeahead['.js-typeahead-location_grid'] ){
+  if (
+    typeof window.dtMapbox === 'undefined' &&
+    $('.js-typeahead-location_grid').length
+  ) {
+    let typeaheadTotals = {};
+    if (!window.Typeahead['.js-typeahead-location_grid']) {
       $.typeahead({
         input: '.js-typeahead-location_grid',
         minLength: 0,
         accent: true,
         searchOnFocus: true,
         maxItem: 20,
-        dropdownFilter: [{
-          key: 'group',
-          value: 'focus',
-          template: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.regions_of_focus),
-          all: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.all_locations),
-        }],
+        dropdownFilter: [
+          {
+            key: 'group',
+            value: 'focus',
+            template: window.SHAREDFUNCTIONS.escapeHTML(
+              window.wpApiShare.translations.regions_of_focus,
+            ),
+            all: window.SHAREDFUNCTIONS.escapeHTML(
+              window.wpApiShare.translations.all_locations,
+            ),
+          },
+        ],
         source: {
           focus: {
-            display: "name",
+            display: 'name',
             ajax: {
-              url: window.wpApiShare.root + 'dt/v1/mapping_module/search_location_grid_by_name',
+              url:
+                window.wpApiShare.root +
+                'dt/v1/mapping_module/search_location_grid_by_name',
               data: {
-                s: "{{query}}",
+                s: '{{query}}',
                 filter: function () {
-                  return window.lodash.get(window.Typeahead['.js-typeahead-location_grid'].filters.dropdown, 'value', 'all')
-                }
+                  return window.lodash.get(
+                    window.Typeahead['.js-typeahead-location_grid'].filters
+                      .dropdown,
+                    'value',
+                    'all',
+                  );
+                },
               },
               beforeSend: function (xhr) {
                 xhr.setRequestHeader('X-WP-Nonce', window.wpApiShare.nonce);
               },
               callback: {
                 done: function (data) {
-                  if (typeof window.typeaheadTotals !== "undefined") {
-                    window.typeaheadTotals.field = data.total
+                  if (typeof window.typeaheadTotals !== 'undefined') {
+                    window.typeaheadTotals.field = data.total;
                   }
-                  return data.location_grid
-                }
-              }
-            }
-          }
+                  return data.location_grid;
+                },
+              },
+            },
+          },
         },
-        display: "name",
-        templateValue: "{{name}}",
+        display: 'name',
+        templateValue: '{{name}}',
         dynamic: true,
         multiselect: {
-          matchOn: ["ID"],
+          matchOn: ['ID'],
           data: function () {
             return [];
-          }, callback: {
+          },
+          callback: {
             onCancel: function (node, item) {
-              update_user( window.current_user_lookup, 'remove_location', item.ID)
-            }
-          }
+              update_user(
+                window.current_user_lookup,
+                'remove_location',
+                item.ID,
+              );
+            },
+          },
         },
         callback: {
-          onClick: function(node, a, item, event){
-            update_user( window.current_user_lookup, 'add_location', item.ID)
+          onClick: function (node, a, item, event) {
+            update_user(window.current_user_lookup, 'add_location', item.ID);
           },
-          onReady(){
-            this.filters.dropdown = {key: "group", value: "focus", template: window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.regions_of_focus)}
+          onReady() {
+            this.filters.dropdown = {
+              key: 'group',
+              value: 'focus',
+              template: window.SHAREDFUNCTIONS.escapeHTML(
+                window.wpApiShare.translations.regions_of_focus,
+              ),
+            };
             this.container
-            .removeClass("filter")
-            .find("." + this.options.selector.filterButton)
-            .html(window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.translations.regions_of_focus));
+              .removeClass('filter')
+              .find('.' + this.options.selector.filterButton)
+              .html(
+                window.SHAREDFUNCTIONS.escapeHTML(
+                  window.wpApiShare.translations.regions_of_focus,
+                ),
+              );
           },
           onResult: function (node, query, result, resultCount) {
-            resultCount = typeaheadTotals.location_grid
-            let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+            resultCount = typeaheadTotals.location_grid;
+            let text = window.TYPEAHEADS.typeaheadHelpText(
+              resultCount,
+              query,
+              result,
+            );
             $('#location_grid-result-container').html(text);
           },
           onHideLayout: function () {
-            $('#location_grid-result-container').html("");
-          }
-        }
+            $('#location_grid-result-container').html('');
+          },
+        },
       });
     }
   }
 
+  $('textarea.text-input, input.text-input').change(function () {
+    const id = $(this).attr('id');
+    const val = $(this).val();
+    $(`#${id}-spinner`).addClass('active');
+    update_user(window.current_user_lookup, id, val).then(() => {
+      $(`#${id}-spinner`).removeClass('active');
+    });
+  });
+  $('select.select-field').change((e) => {
+    const id = $(e.currentTarget).attr('id');
+    const val = $(e.currentTarget).val();
+    $(`#${id}-spinner`).addClass('active');
 
-  $('textarea.text-input, input.text-input').change(function(){
-    const id = $(this).attr('id')
-    const val = $(this).val()
-    $(`#${id}-spinner`).addClass('active')
-    update_user( window.current_user_lookup, id, val ).then(()=> {
-      $(`#${id}-spinner`).removeClass('active')
-    })
-  })
-  $('select.select-field').change(e => {
-    const id = $(e.currentTarget).attr('id')
-    const val = $(e.currentTarget).val()
-    $(`#${id}-spinner`).addClass('active')
-
-    update_user( window.current_user_lookup, id, val ).then(()=> {
-      $(`#${id}-spinner`).removeClass('active')
-    })
-  })
-  $('button.dt_multi_select').on('click',function () {
-    let fieldKey = $(this).data("field-key")
-    let optionKey = $(this).attr('id')
-    $(`#${fieldKey}-spinner`).addClass("active")
-    let field = $(`[data-field-key="${fieldKey}"]#${optionKey}`)
-    field.addClass("submitting-select-button")
-    let action = "add"
-    let update_request = null
-    if (field.hasClass("selected-select-button")){
-      action = "delete"
-      update_request = update_user( window.current_user_lookup,'remove_' + fieldKey, optionKey )
+    update_user(window.current_user_lookup, id, val).then(() => {
+      $(`#${id}-spinner`).removeClass('active');
+    });
+  });
+  $('button.dt_multi_select').on('click', function () {
+    let fieldKey = $(this).data('field-key');
+    let optionKey = $(this).attr('id');
+    $(`#${fieldKey}-spinner`).addClass('active');
+    let field = $(`[data-field-key="${fieldKey}"]#${optionKey}`);
+    field.addClass('submitting-select-button');
+    let action = 'add';
+    let update_request = null;
+    if (field.hasClass('selected-select-button')) {
+      action = 'delete';
+      update_request = update_user(
+        window.current_user_lookup,
+        'remove_' + fieldKey,
+        optionKey,
+      );
     } else {
-      field.removeClass("empty-select-button")
-      field.addClass("selected-select-button")
-      update_request = update_user( window.current_user_lookup, 'add_' + fieldKey, optionKey )
+      field.removeClass('empty-select-button');
+      field.addClass('selected-select-button');
+      update_request = update_user(
+        window.current_user_lookup,
+        'add_' + fieldKey,
+        optionKey,
+      );
     }
-    update_request.then(()=>{
-      field.removeClass("submitting-select-button selected-select-button")
-      field.blur();
-      field.addClass( action === "delete" ? "empty-select-button" : "selected-select-button");
-      $(`#${fieldKey}-spinner`).removeClass("active")
-    }).catch(err=>{
-      field.removeClass("submitting-select-button selected-select-button")
-      field.addClass( action === "add" ? "empty-select-button" : "selected-select-button")
-      window.handleAjaxError(err)
-    })
-  })
+    update_request
+      .then(() => {
+        field.removeClass('submitting-select-button selected-select-button');
+        field.blur();
+        field.addClass(
+          action === 'delete'
+            ? 'empty-select-button'
+            : 'selected-select-button',
+        );
+        $(`#${fieldKey}-spinner`).removeClass('active');
+      })
+      .catch((err) => {
+        field.removeClass('submitting-select-button selected-select-button');
+        field.addClass(
+          action === 'add' ? 'empty-select-button' : 'selected-select-button',
+        );
+        window.handleAjaxError(err);
+      });
+  });
 
-
-  function day_activity_chart( days_active ) {
-    window.am4core.ready(function() {
-
+  function day_activity_chart(days_active) {
+    window.am4core.ready(function () {
       window.am4core.useTheme(window.am4themes_animated);
 
-      let chart = window.am4core.create("day_activity_chart", window.am4charts.XYChart);
+      let chart = window.am4core.create(
+        'day_activity_chart',
+        window.am4charts.XYChart,
+      );
       chart.maskBullets = false;
 
       let xAxis = chart.xAxes.push(new window.am4charts.CategoryAxis());
       let yAxis = chart.yAxes.push(new window.am4charts.CategoryAxis());
 
-      xAxis.dataFields.category = "week_start";
-      yAxis.dataFields.category = "weekday";
+      xAxis.dataFields.category = 'week_start';
+      yAxis.dataFields.category = 'weekday';
 
       // xAxis.renderer.grid.template.disabled = true;
       xAxis.renderer.minGridDistance = 100;
@@ -617,64 +842,67 @@ jQuery(document).ready(function($) {
       yAxis.renderer.minGridDistance = 10;
 
       let series = chart.series.push(new window.am4charts.ColumnSeries());
-      series.dataFields.categoryY = "weekday";
-      series.dataFields.categoryX = "week_start";
-      series.dataFields.value = "activity";
+      series.dataFields.categoryY = 'weekday';
+      series.dataFields.categoryX = 'week_start';
+      series.dataFields.value = 'activity';
       series.sequencedInterpolation = true;
       series.defaultState.transitionDuration = 3000;
 
-      let bgColor = new window.am4core.InterfaceColorSet().getFor("background");
+      let bgColor = new window.am4core.InterfaceColorSet().getFor('background');
 
       let columnTemplate = series.columns.template;
       columnTemplate.strokeWidth = 1;
       columnTemplate.strokeOpacity = 0.2;
       // columnTemplate.stroke = bgColor;
-      columnTemplate.tooltipText = "{weekday}, {day}: {activity_count}";
+      columnTemplate.tooltipText = '{weekday}, {day}: {activity_count}';
       columnTemplate.width = window.am4core.percent(100);
       columnTemplate.height = window.am4core.percent(100);
 
       series.heatRules.push({
         target: columnTemplate,
-        property: "fill",
+        property: 'fill',
         // min: window.am4core.color('#deeff8'),
         min: window.am4core.color(bgColor),
-        max: chart.colors.getIndex(0)
+        max: chart.colors.getIndex(0),
       });
 
-      chart.data = days_active
+      chart.data = days_active;
     });
   }
 
-  function status_pie_chart(contact_statuses){
-
-    if ( contact_statuses.length === 0 ) {
-      $('#status_chart_div').empty()
-      return
+  function status_pie_chart(contact_statuses) {
+    if (contact_statuses.length === 0) {
+      $('#status_chart_div').empty();
+      return;
     }
 
     window.am4core.useTheme(window.am4themes_animated);
 
-    let container = window.am4core.create("status_chart_div", window.am4core.Container);
+    let container = window.am4core.create(
+      'status_chart_div',
+      window.am4core.Container,
+    );
     container.width = window.am4core.percent(100);
     container.height = window.am4core.percent(100);
-    container.layout = "vertical";
-
+    container.layout = 'vertical';
 
     let chart = container.createChild(window.am4charts.PieChart);
 
     // Add data
-    chart.data = contact_statuses
+    chart.data = contact_statuses;
 
     // Add and configure Series
     let pieSeries = chart.series.push(new window.am4charts.PieSeries());
-    pieSeries.dataFields.value = "count";
-    pieSeries.dataFields.category = "status";
-    pieSeries.slices.template.states.getKey("active").properties.shiftRadius = 0;
-    pieSeries.labels.template.text = "{category}: {value.percent.formatNumber('#.#')}% ({value}) ";
+    pieSeries.dataFields.value = 'count';
+    pieSeries.dataFields.category = 'status';
+    pieSeries.slices.template.states.getKey('active').properties.shiftRadius =
+      0;
+    pieSeries.labels.template.text =
+      "{category}: {value.percent.formatNumber('#.#')}% ({value}) ";
 
-    pieSeries.slices.template.events.on("hit", function(event) {
+    pieSeries.slices.template.events.on('hit', function (event) {
       selectSlice(event.target.dataItem);
-    })
+    });
 
     let chart2 = container.createChild(window.am4charts.PieChart);
     chart2.width = window.am4core.percent(80);
@@ -682,26 +910,27 @@ jQuery(document).ready(function($) {
 
     // Add and configure Series
     let pieSeries2 = chart2.series.push(new window.am4charts.PieSeries());
-    pieSeries2.dataFields.value = "count";
-    pieSeries2.dataFields.category = "reason";
-    pieSeries2.slices.template.states.getKey("active").properties.shiftRadius = 0;
+    pieSeries2.dataFields.value = 'count';
+    pieSeries2.dataFields.category = 'reason';
+    pieSeries2.slices.template.states.getKey('active').properties.shiftRadius =
+      0;
     pieSeries2.labels.template.disabled = true;
     pieSeries2.ticks.template.disabled = true;
     pieSeries2.alignLabels = false;
-    pieSeries2.events.on("positionchanged", updateLines);
+    pieSeries2.events.on('positionchanged', updateLines);
 
     let interfaceColors = new window.am4core.InterfaceColorSet();
 
     let line1 = container.createChild(window.am4core.Line);
-    line1.strokeDasharray = "2,2";
+    line1.strokeDasharray = '2,2';
     line1.strokeOpacity = 0.5;
-    line1.stroke = interfaceColors.getFor("alternativeBackground");
+    line1.stroke = interfaceColors.getFor('alternativeBackground');
     line1.isMeasured = false;
 
     let line2 = container.createChild(window.am4core.Line);
-    line2.strokeDasharray = "2,2";
+    line2.strokeDasharray = '2,2';
     line2.strokeOpacity = 0.5;
-    line2.stroke = interfaceColors.getFor("alternativeBackground");
+    line2.stroke = interfaceColors.getFor('alternativeBackground');
     line2.isMeasured = false;
 
     let selectedSlice;
@@ -712,23 +941,48 @@ jQuery(document).ready(function($) {
       let count = dataItem.dataContext.reasons.length;
       pieSeries2.colors.list = [];
       for (let i = 0; i < count; i++) {
-        pieSeries2.colors.list.push(fill.brighten(i * 2 / count));
+        pieSeries2.colors.list.push(fill.brighten((i * 2) / count));
       }
       chart2.data = dataItem.dataContext.reasons;
       pieSeries2.appear();
 
       let middleAngle = selectedSlice.middleAngle;
       let firstAngle = pieSeries.slices.getIndex(0).startAngle;
-      let animation = pieSeries.animate([{ property: "startAngle", to: firstAngle - middleAngle }, { property: "endAngle", to: firstAngle - middleAngle + 360 }], 600, window.am4core.ease.sinOut);
-      animation.events.on("animationprogress", updateLines);
+      let animation = pieSeries.animate(
+        [
+          { property: 'startAngle', to: firstAngle - middleAngle },
+          { property: 'endAngle', to: firstAngle - middleAngle + 360 },
+        ],
+        600,
+        window.am4core.ease.sinOut,
+      );
+      animation.events.on('animationprogress', updateLines);
 
-      selectedSlice.events.on("transformed", updateLines);
+      selectedSlice.events.on('transformed', updateLines);
     }
 
     function updateLines() {
       if (selectedSlice) {
-        let p11 = { x: selectedSlice.radius * window.am4core.math.cos(selectedSlice.startAngle), y: selectedSlice.radius * window.am4core.math.sin(selectedSlice.startAngle) };
-        let p12 = { x: selectedSlice.radius * window.am4core.math.cos(selectedSlice.startAngle + selectedSlice.arc), y: selectedSlice.radius * window.am4core.math.sin(selectedSlice.startAngle + selectedSlice.arc) };
+        let p11 = {
+          x:
+            selectedSlice.radius *
+            window.am4core.math.cos(selectedSlice.startAngle),
+          y:
+            selectedSlice.radius *
+            window.am4core.math.sin(selectedSlice.startAngle),
+        };
+        let p12 = {
+          x:
+            selectedSlice.radius *
+            window.am4core.math.cos(
+              selectedSlice.startAngle + selectedSlice.arc,
+            ),
+          y:
+            selectedSlice.radius *
+            window.am4core.math.sin(
+              selectedSlice.startAngle + selectedSlice.arc,
+            ),
+        };
 
         p11 = window.am4core.utils.spritePointToSvg(p11, selectedSlice);
         p12 = window.am4core.utils.spritePointToSvg(p12, selectedSlice);
@@ -750,175 +1004,195 @@ jQuery(document).ready(function($) {
         line2.y2 = p22.y;
       }
     }
-
   }
 
   function write_add_user() {
-    const showOptionsButton = $('#show-hidden-fields')
-    const hideOptionsButton = $('#hide-hidden-fields')
-    const hiddenFields = $('.hidden-fields')
+    const showOptionsButton = $('#show-hidden-fields');
+    const hideOptionsButton = $('#hide-hidden-fields');
+    const hiddenFields = $('.hidden-fields');
 
-    showOptionsButton.on('click', function() {
-      hiddenFields.show()
-      showOptionsButton.hide()
-      hideOptionsButton.show()
-    })
+    showOptionsButton.on('click', function () {
+      hiddenFields.show();
+      showOptionsButton.hide();
+      hideOptionsButton.show();
+    });
 
-    hideOptionsButton.on('click', function() {
-      hiddenFields.hide()
-      showOptionsButton.show()
-      hideOptionsButton.hide()
-    })
+    hideOptionsButton.on('click', function () {
+      hiddenFields.hide();
+      showOptionsButton.show();
+      hideOptionsButton.hide();
+    });
 
-    const showOptionalFields = $('#show-optional-fields')
-    const hideOptionalFields = $('#hide-optional-fields')
-    const optionalFields = $('#optional-fields')
+    const showOptionalFields = $('#show-optional-fields');
+    const hideOptionalFields = $('#hide-optional-fields');
+    const optionalFields = $('#optional-fields');
 
-    showOptionalFields.on('click', function() {
-      showOptionalFields.hide()
-      hideOptionalFields.show()
-      optionalFields.removeClass('show-for-medium')
-    })
+    showOptionalFields.on('click', function () {
+      showOptionalFields.hide();
+      hideOptionalFields.show();
+      optionalFields.removeClass('show-for-medium');
+    });
 
-    hideOptionalFields.on('click', function() {
-      showOptionalFields.show()
-      hideOptionalFields.hide()
-      optionalFields.addClass('show-for-medium')
-    })
+    hideOptionalFields.on('click', function () {
+      showOptionalFields.show();
+      hideOptionalFields.hide();
+      optionalFields.addClass('show-for-medium');
+    });
 
-    $('#new-user-language-dropdown').html(write_language_dropdown(dt_user_management_localized.language_dropdown, dt_user_management_localized.default_language))
+    $('#new-user-language-dropdown').html(
+      write_language_dropdown(
+        dt_user_management_localized.language_dropdown,
+        dt_user_management_localized.default_language,
+      ),
+    );
 
-    let result_div = $('#result-link')
-    let submit_button = $('#create-user')
+    let result_div = $('#result-link');
+    let submit_button = $('#create-user');
 
-    $(document).on("submit", function(ev) {
+    $(document).on('submit', function (ev) {
       ev.preventDefault();
-      if ( typeof window.contact_record !== 'undefined' ) {
+      if (typeof window.contact_record !== 'undefined') {
         $('#confirm-user-upgrade').foundation('open');
       } else {
-        create_user()
+        create_user();
       }
     });
 
-    $('#continue-user-creation').on('click', function (){
-      let corresponds_to_contact = null
-      if ( typeof window.contact_record !== 'undefined' ) {
-        corresponds_to_contact = window.contact_record.ID
+    $('#continue-user-creation').on('click', function () {
+      let corresponds_to_contact = null;
+      if (typeof window.contact_record !== 'undefined') {
+        corresponds_to_contact = window.contact_record.ID;
       }
-      create_user(corresponds_to_contact)
-    })
+      create_user(corresponds_to_contact);
+    });
 
-    $('#continue-archive-comments').on('click',function (){
-      let old_corresponds_to_contact = null
-      if ( typeof window.contact_record !== 'undefined' ) {
-        old_corresponds_to_contact = window.contact_record.ID
+    $('#continue-archive-comments').on('click', function () {
+      let old_corresponds_to_contact = null;
+      if (typeof window.contact_record !== 'undefined') {
+        old_corresponds_to_contact = window.contact_record.ID;
       }
-      create_user(old_corresponds_to_contact, true)
-    })
+      create_user(old_corresponds_to_contact, true);
+    });
 
-    let create_user = (corresponds_to_contact, archive_comments = false)=>{
-
-      let name = $('#eman').val()
-      let email = $('#liame').val()
+    let create_user = (corresponds_to_contact, archive_comments = false) => {
+      let name = $('#eman').val();
+      let email = $('#liame').val();
       let locale = $('#locale').val();
 
-      const username = $('#emanresu').val()
-      const password = $('#drowssap').val()
+      const username = $('#emanresu').val();
+      const password = $('#drowssap').val();
 
-      const optionalFields = document.querySelectorAll('[data-optional=""]')
-      const optionalValues = {}
+      const optionalFields = document.querySelectorAll('[data-optional=""]');
+      const optionalValues = {};
 
       optionalFields.forEach((node) => {
         if (node.value) {
-          optionalValues[node.id] = node.value
+          optionalValues[node.id] = node.value;
         }
-      })
+      });
 
       let roles = [];
       $('#user_roles_list input:checked').each(function () {
-        roles.push($(this).val())
-      })
+        roles.push($(this).val());
+      });
 
-      if ( name !== '' && email !== '' )  {
-        $('#create-user').addClass('loading')
-        submit_button.prop('disabled', true)
+      if (name !== '' && email !== '') {
+        $('#create-user').addClass('loading');
+        submit_button.prop('disabled', true);
 
-        return window.makeRequest(
-          "POST",
-          `users/create`,
-          {
-            "user-email": email,
-            "user-display": name,
-            "user-username": username || null,
-            "user-password": password || null,
-            "user-optional-fields": optionalValues !== {} ? optionalValues : null,
-            "corresponds_to_contact": corresponds_to_contact,
-            "locale": locale,
-            'user-roles':roles,
+        return window
+          .makeRequest('POST', `users/create`, {
+            'user-email': email,
+            'user-display': name,
+            'user-username': username || null,
+            'user-password': password || null,
+            'user-optional-fields':
+              optionalValues !== {} ? optionalValues : null,
+            corresponds_to_contact: corresponds_to_contact,
+            locale: locale,
+            'user-roles': roles,
             return_contact: true,
             archive_comments: archive_comments,
           })
-        .done(response=>{
-          const { user_id, corresponds_to_contact: contact_id } = response
-          result_div.html('')
-          if ( dt_user_management_localized.has_permission ) {
-            result_div.append(`<a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/user-management/user/${window.SHAREDFUNCTIONS.escapeHTML(user_id)}">
-              ${ escaped_translations.view_new_user }</a>
-            `)
-          }
-          result_div.append(`<br /><a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/contacts/${window.SHAREDFUNCTIONS.escapeHTML(contact_id)}">
-              ${ escaped_translations.view_new_contact }</a>
-            `)
-          $('#new-user-form').empty()
-          return response
-        })
-        .catch(err=>{
-          $('#create-user').removeClass('loading')
-          submit_button.prop('disabled', false)
-          if ( err.responseJSON?.code === 'email_exists' ) {
-            result_div.html(`${ escaped_translations.email_already_in_system }`)
-          } else if ( err.responseJSON?.code === 'username_exists' ) {
-            result_div.html(`${ escaped_translations.username_in_system }`)
-          } else {
-            result_div.html(`Oops. Something went wrong.`)
-          }
-          return false;
-        })
+          .done((response) => {
+            const { user_id, corresponds_to_contact: contact_id } = response;
+            result_div.html('');
+            if (dt_user_management_localized.has_permission) {
+              result_div.append(`<a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/user-management/user/${window.SHAREDFUNCTIONS.escapeHTML(user_id)}">
+              ${escaped_translations.view_new_user}</a>
+            `);
+            }
+            result_div.append(`<br /><a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/contacts/${window.SHAREDFUNCTIONS.escapeHTML(contact_id)}">
+              ${escaped_translations.view_new_contact}</a>
+            `);
+            $('#new-user-form').empty();
+            return response;
+          })
+          .catch((err) => {
+            $('#create-user').removeClass('loading');
+            submit_button.prop('disabled', false);
+            if (err.responseJSON?.code === 'email_exists') {
+              result_div.html(
+                `${escaped_translations.email_already_in_system}`,
+              );
+            } else if (err.responseJSON?.code === 'username_exists') {
+              result_div.html(`${escaped_translations.username_in_system}`);
+            } else {
+              result_div.html(`Oops. Something went wrong.`);
+            }
+            return false;
+          });
       }
-    }
+    };
 
     function getContact(id, isUser = false, overwriteTypeahead = false) {
-      $('.loading-spinner').addClass('active')
-      window.makeRequest('GET', 'contacts/'+id, null, 'dt-posts/v2/' )
-        .done(function(response){
-
+      $('.loading-spinner').addClass('active');
+      window
+        .makeRequest('GET', 'contacts/' + id, null, 'dt-posts/v2/')
+        .done(function (response) {
           if (overwriteTypeahead) {
-            $(".js-typeahead-subassigned").val(window.SHAREDFUNCTIONS.escapeHTML(response.name))
+            $('.js-typeahead-subassigned').val(
+              window.SHAREDFUNCTIONS.escapeHTML(response.name),
+            );
           }
-          if ( isUser || ( response.corresponds_to_user >= 0 ) ) {
-            $('#name').val( window.SHAREDFUNCTIONS.escapeHTML(response.name) )
-            if ( response.contact_email && response.contact_email.length > 0 ) {
-              $('#email').val( window.SHAREDFUNCTIONS.escapeHTML(response.contact_email[0].value) )
+          if (isUser || response.corresponds_to_user >= 0) {
+            $('#name').val(window.SHAREDFUNCTIONS.escapeHTML(response.name));
+            if (response.contact_email && response.contact_email.length > 0) {
+              $('#email').val(
+                window.SHAREDFUNCTIONS.escapeHTML(
+                  response.contact_email[0].value,
+                ),
+              );
             }
-            $('#contact-result').html(escaped_translations.already_user)
-            if ( window.dt_user_management_localized.has_permission ) {
-              $('#contact-result').append(`<br /> <a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/user-management/user/${window.SHAREDFUNCTIONS.escapeHTML(response.corresponds_to_user)}">${escaped_translations.view_user}</a>`)
+            $('#contact-result').html(escaped_translations.already_user);
+            if (window.dt_user_management_localized.has_permission) {
+              $('#contact-result').append(
+                `<br /> <a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/user-management/user/${window.SHAREDFUNCTIONS.escapeHTML(response.corresponds_to_user)}">${escaped_translations.view_user}</a>`,
+              );
             }
-            $('#contact-result').append(`<br /> <a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/contacts/${id}">${escaped_translations.view_contact}</a>`)
+            $('#contact-result').append(
+              `<br /> <a href="${window.SHAREDFUNCTIONS.escapeHTML(window.wpApiShare.site_url)}/contacts/${id}">${escaped_translations.view_contact}</a>`,
+            );
           } else {
-            window.contact_record = response
-            submit_button.prop('disabled', false)
-            $('#name').val( window.SHAREDFUNCTIONS.escapeHTML(response.title) )
-            if ( response.contact_email && response.contact_email[0] !== 'undefined' ) {
-              $('#email').val( window.SHAREDFUNCTIONS.escapeHTML(response.contact_email[0].value) )
+            window.contact_record = response;
+            submit_button.prop('disabled', false);
+            $('#name').val(window.SHAREDFUNCTIONS.escapeHTML(response.title));
+            if (
+              response.contact_email &&
+              response.contact_email[0] !== 'undefined'
+            ) {
+              $('#email').val(
+                window.SHAREDFUNCTIONS.escapeHTML(
+                  response.contact_email[0].value,
+                ),
+              );
             }
-
           }
-          $('.loading-spinner').removeClass('active')
-        })
+          $('.loading-spinner').removeClass('active');
+        });
     }
 
-    ["subassigned"].forEach(field_id=>{
+    ['subassigned'].forEach((field_id) => {
       $.typeahead({
         input: `.js-typeahead-${field_id}`,
         minLength: 0,
@@ -927,49 +1201,51 @@ jQuery(document).ready(function($) {
         searchOnFocus: true,
         template: window.TYPEAHEADS.contactListRowTemplate,
         source: window.TYPEAHEADS.typeaheadContactsSource(),
-        display: "name",
-        templateValue: "{{name}}",
+        display: 'name',
+        templateValue: '{{name}}',
         dynamic: true,
         callback: {
-          onClick: function(node, a, item, event){
-            submit_button.prop('disabled', true)
+          onClick: function (node, a, item, event) {
+            submit_button.prop('disabled', true);
 
-            getContact(item.ID, item.user)
+            getContact(item.ID, item.user);
           },
           onResult: function (node, query, result, resultCount) {
-            let text = window.TYPEAHEADS.typeaheadHelpText(resultCount, query, result)
+            let text = window.TYPEAHEADS.typeaheadHelpText(
+              resultCount,
+              query,
+              result,
+            );
             $(`#${field_id}-result-container`).html(text);
-            submit_button.prop('disabled', false)
-            $('#contact-result').html(``)
+            submit_button.prop('disabled', false);
+            $('#contact-result').html(``);
           },
           onHideLayout: function () {
-            $(`#${field_id}-result-container`).html("");
+            $(`#${field_id}-result-container`).html('');
           },
           onReady: function () {
-            if (field_id === "subassigned"){
+            if (field_id === 'subassigned') {
             }
           },
-          onShowLayout (){
-          }
-        }
-      })
-    })
+          onShowLayout() {},
+        },
+      });
+    });
 
     // Prefill the form if contact_id is in the query params
-    const url = new URL(window.location.href)
-    let contactId = url.searchParams.get('contact_id')
-    if ( contactId !== null && contactId !== '' && !isNaN(contactId) ) {
-      getContact(parseInt(contactId), false, true)
+    const url = new URL(window.location.href);
+    let contactId = url.searchParams.get('contact_id');
+    if (contactId !== null && contactId !== '' && !isNaN(contactId)) {
+      getContact(parseInt(contactId), false, true);
     }
   }
 
   function write_language_dropdown(translations, default_language) {
-      let select = '<select name="locale" id="locale">';
-      for ( const translation in translations ) {
-        select += `<option value="${window.SHAREDFUNCTIONS.escapeHTML(translations[translation].language )}" ${(translations[translation].language === default_language) ? 'selected' : '' } > ${(translations[translation].flag ? translations[translation].flag + ' ' : '')} ${window.SHAREDFUNCTIONS.escapeHTML( translations[translation].native_name )}</option>`
-      }
-      select += '</select>'
-      return select;
+    let select = '<select name="locale" id="locale">';
+    for (const translation in translations) {
+      select += `<option value="${window.SHAREDFUNCTIONS.escapeHTML(translations[translation].language)}" ${translations[translation].language === default_language ? 'selected' : ''} > ${translations[translation].flag ? translations[translation].flag + ' ' : ''} ${window.SHAREDFUNCTIONS.escapeHTML(translations[translation].native_name)}</option>`;
+    }
+    select += '</select>';
+    return select;
   }
-
-})
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "browser-sync": "^2.27.5",
         "cssnano": "^5.0.8",
         "eslint": "^8.18.0",
+        "eslint-config-prettier": "^9.1.0",
         "foundation-sites": "^6.7.2",
         "gulp": "^4.0.2",
         "gulp-autoprefixer": "^8.0.0",
@@ -42,6 +43,7 @@
         "jquery": "^3.6.0",
         "lint-staged": "^12.4.1",
         "motion-ui": "^2.0.3",
+        "prettier": "3.2.5",
         "sass": "^1.39.0",
         "what-input": "^5.2.10"
       }
@@ -3450,6 +3452,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -8804,6 +8818,21 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-hrtime": {
@@ -14239,6 +14268,13 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "dev": true,
+      "requires": {}
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -18240,6 +18276,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+    },
+    "prettier": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "dev": true
     },
     "pretty-hrtime": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "browser-sync": "^2.27.5",
     "cssnano": "^5.0.8",
     "eslint": "^8.18.0",
+    "eslint-config-prettier": "^9.1.0",
     "foundation-sites": "^6.7.2",
     "gulp": "^4.0.2",
     "gulp-autoprefixer": "^8.0.0",
@@ -32,6 +33,7 @@
     "jquery": "^3.6.0",
     "lint-staged": "^12.4.1",
     "motion-ui": "^2.0.3",
+    "prettier": "3.2.5",
     "sass": "^1.39.0",
     "what-input": "^5.2.10"
   },
@@ -46,16 +48,19 @@
     "styles": "gulp styles",
     "watch": "gulp watch",
     "browsersync": "gulp browsersync",
+    "lint": "npx eslint",
+    "prettier": "npx prettier --write .",
     "update-foundation": "npm install foundation-sites",
     "prepare": "husky install",
-    "pre-commit": "lint-staged"
+    "pre-commit": "npx lint-staged"
   },
   "lint-staged": {
     "*.php": [
       "./phpcbf.sh"
     ],
     "*.js": [
-      "eslint"
+      "eslint",
+      "prettier --write --ignore-unknown"
     ]
   },
   "eslintIgnore": [

--- a/tests/test_eslint.sh
+++ b/tests/test_eslint.sh
@@ -2,14 +2,8 @@
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../"
 
-printf 'eslint version: %s\n' "$(eslint --version)"
+printf 'eslint version: %s\n' "$(npx eslint --version)"
 
-eval eslint \
-    --ignore-pattern vendor/ \
-    --ignore-pattern node_modules/ \
-    --ignore-pattern gulpfile.js \
-    --ignore-pattern dt-core/dependencies/ \
-    --ignore-pattern dt-core/libraries/ \
-    --ignore-pattern '*.min.js' \
-    --ignore-pattern dt-core/admin/multi-role/js/min/ \
-    .
+eval npx eslint .
+
+eval npx prettier --check .


### PR DESCRIPTION
Resolves #2423 

This adds Prettier code linting/formatting to the existing eslint configuration and setup. It is added to `lint-staged` so that it should automatically be run pre-commit. It is added to the `test_eslint.sh` so that it is also run in CI.

Some key formatting that it enforces:
- Semicolons after every line
- Use of single quotes
- Trailing commas whenever possible
- Spacing inside brackets
- Splitting long function calls or objects to new lines for readability
- Tab spacing

The ignore lists for eslint and prettier are updated so that you can just run either against the whole project without having to manually exclude directories or file types.

Two new npm scripts are added for easily using either tool:
- `npm run lint`: `npx eslint` - runs eslint over the whole project
- `npm run prettier`: `npx prettier --write .` - runs prettier over the whole project and writes updates to the files