### PR TITLE
Added wildcard character compatibility for DT API Whitelist

### DIFF
--- a/dt-core/configuration/restrict-rest-api.php
+++ b/dt-core/configuration/restrict-rest-api.php
@@ -109,6 +109,14 @@ function dt_dra_only_allow_logged_in_rest_access( $access ) {
         $authorized = true;
     }
 
+    foreach ( $allowed_paths as $allowed_path ) {
+        if ( substr( $allowed_path, -1 ) === '*' ) {
+            if ( strpos( $path, substr( $allowed_path, 0, -1 ) ) === 0 ) {
+                $authorized = true;
+            }
+        }
+    }
+
     $authorized = apply_filters( 'dt_allow_rest_access', $authorized );
 
     // validate site to site transfer token


### PR DESCRIPTION
Currently, a user could only whitelist endpoints with static paths. This meant that if the endpoint passes a parameter through the URL, it couldn't be whitelisted.

This upgrade allows users to use the star (*) wildcard character in order to whitelist dynamic rest api endpoint paths.

**Screenshot**
<img width="601" alt="Screenshot 2024-04-03 at 12 37 24" src="https://github.com/DiscipleTools/disciple-tools-theme/assets/36511666/8d498889-21cc-4c14-b5c3-b885f7e461f8">