### PR TITLE
Create filter for custom actions to indicate if they're already executed

### DIFF
--- a/dt-workflows/workflows-execution-handler.php
+++ b/dt-workflows/workflows-execution-handler.php
@@ -476,6 +476,9 @@ class Disciple_Tools_Workflows_Execution_Handler {
                 case 'remove':
                     $already_executed[] = ! $current_state;
                     break;
+                case 'custom': // custom actions
+                    $already_executed[] = apply_filters( $action->value . '__already_executed', false, $action, $post );
+                    break;
             }
         }
 


### PR DESCRIPTION
When creating a custom action for workflows, it never was getting executed because it couldn't be determined if it had already been executed. This adds another filter so that custom logic for that can be added along with the custom action. It also defaults the value to `false` so that it works even without implementing the new filter.