### PR TITLE
fix: change variable ui to newUi to prevent name clash

### DIFF
--- a/dt-login/login-shortcodes.php
+++ b/dt-login/login-shortcodes.php
@@ -128,9 +128,9 @@ function dt_firebase_login_ui( $atts ) {
 
 
     <script>
-      let ui
+      let newUi
       if (hasASignInProvider) {
-        ui = new firebaseui.auth.AuthUI(firebase.auth());
+        newUi = new firebaseui.auth.AuthUI(firebase.auth());
         showLoader()
       }
       let rest_url = '<?php echo esc_url( rest_url( 'dt/v1' ) ) ?>';
@@ -217,7 +217,7 @@ function dt_firebase_login_ui( $atts ) {
       }
 
       function startUI() {
-        ui.start('#firebaseui-auth-container', uiConfig);
+        newUi.start('#firebaseui-auth-container', uiConfig);
       }
 
       function showErrorMessage(message) {


### PR DESCRIPTION
couldn't figure out what this was clashing with, but was getting this error on the login screen in zume

![image](https://github.com/DiscipleTools/disciple-tools-theme/assets/9816214/7e7e789c-b9cf-4e69-8713-922833a22444)

changing the variable name from ui --> newUi fixed the issue