### PR TITLE
Create hooks to load plugins and for when the theme is ready.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -27,10 +27,36 @@ if ( version_compare( phpversion(), '7.4', '<' ) ) {
     add_action( 'admin_notices', 'dt_theme_admin_notice_required_php_version' );
 } else {
 
+
+    /**
+     * Load the Disciple Tools Theme
+     * Note: This will be moved before of the after_setup_theme hook
+     */
+    add_action( 'after_setup_theme', 'dt_theme_load', 5 );
+
+
+    /**
+     * The disciple_tools_load_plugins hook
+     * Set up hook for loading plugins
+     */
+    add_action( 'after_setup_theme', function (){
+        do_action( 'disciple_tools_load_plugins' );
+    }, 30 );
+
+    /**
+     * The disciple_tools_loaded hook
+     * Disciple.Tools theme and plugins are loaded.
+     * It is now safe to us the Disciple.Tools API, run actions and views
+     */
+    add_action( 'init', function (){
+        do_action( 'disciple_tools_loaded' );
+    }, 10 );
+
+
     /**
      * Adds the Disciple_Tools Class and runs database and roles version checks.
      */
-    function dt_theme_loaded() {
+    function dt_theme_load() {
         /** We want to make sure roles are up-to-date. */
         require_once( 'dt-core/configuration/class-roles.php' );
         Disciple_Tools_Roles::instance()->set_roles_if_needed();
@@ -44,7 +70,6 @@ if ( version_compare( phpversion(), '7.4', '<' ) ) {
          */
         load_theme_textdomain( 'disciple_tools', get_template_directory() . '/dt-assets/translation' );
     }
-    add_action( 'after_setup_theme', 'dt_theme_loaded', 5 );
 
 
     /**


### PR DESCRIPTION
Introducing 2 new actions.

`disciple_tools_load_plugins`

This is where plugins are to be loaded. 
This action is called after the theme is loaded so we can use classes and functions from the theme (but not the DT_Posts API).

`disciple_tools_loaded`

This action is called after the theme and plugins have loaded.
It is now safe to call the DT_Posts API. We will be moving the DT_Posts API to only be available after all the theme and all the plugins have loaded. This is to avoid accidentally using the function too early and getting errors during runtime or only getting a partial return of data. 

Example: using `DT_Posts::get_post_field_settings()` and only getting the theme fields and not any from the plugins. 