### PR TITLE
Connection types

### DIFF
--- a/dt-contacts/access-module.php
+++ b/dt-contacts/access-module.php
@@ -108,7 +108,7 @@ class DT_Contacts_Access extends DT_Module_Base {
                 'tile'        => 'status',
                 'icon' => get_template_directory_uri() . '/dt-assets/images/assigned-to.svg?v=2',
                 'show_in_table' => 25,
-                'only_for_types' => [ 'access', 'user', 'access_placeholder' ],
+                'only_for_types' => [ 'access', 'user' ],
                 'custom_display' => false
             ];
             $fields['seeker_path'] = [
@@ -190,7 +190,7 @@ class DT_Contacts_Access extends DT_Module_Base {
                 'custom_display' => true,
                 'icon' => get_template_directory_uri() . '/dt-assets/images/status.svg?v=2',
                 'show_in_table' => 10,
-                'only_for_types' => [ 'access', 'access_placeholder' ],
+                'only_for_types' => [ 'access' ],
                 'select_cannot_be_empty' => true
             ];
 
@@ -771,6 +771,13 @@ class DT_Contacts_Access extends DT_Module_Base {
         if ( !isset( $fields['type'] ) && get_current_user_id() === 0 ){
             $fields['type'] = 'access';
         }
+
+        /**
+         * Stop here if the type is not "access"
+         */
+        if ( !isset( $fields['type'] ) || $fields['type'] !== 'access' ){
+            return $fields;
+        }
         if ( !isset( $fields['overall_status'] ) ){
             if ( get_current_user_id() ){
                 $fields['overall_status'] = 'active';
@@ -795,13 +802,6 @@ class DT_Contacts_Access extends DT_Module_Base {
                     $fields['assigned_to'] = sprintf( 'user-%d', $base_id );
                 }
             }
-        }
-
-        /**
-         * Stop here if the type is not "access"
-         */
-        if ( !isset( $fields['type'] ) || $fields['type'] !== 'access' ){
-            return $fields;
         }
         if ( !isset( $fields['seeker_path'] ) ){
             $fields['seeker_path'] = 'none';

--- a/dt-contacts/access-module.php
+++ b/dt-contacts/access-module.php
@@ -100,25 +100,6 @@ class DT_Contacts_Access extends DT_Module_Base {
             if ( isset( $fields['type']['default']['personal'] ) ){
                 $fields['type']['default']['personal']['default'] = false;
             }
-            $fields['type']['default']['access'] = [
-                'label' => __( 'Standard Contact', 'disciple_tools' ),
-                'color' => '#2196F3',
-                'description' => __( 'A contact to collaborate on', 'disciple_tools' ),
-                'visibility' => __( 'Me and project leadership', 'disciple_tools' ),
-                'icon' => get_template_directory_uri() . '/dt-assets/images/share.svg?v=2',
-                'order' => 20,
-                'default' => true,
-            ];
-            $fields['type']['default']['access_placeholder'] = [
-                'label' => __( 'Connection', 'disciple_tools' ),
-                'color' => '#FF9800',
-                'description' => __( 'Connected to a contact, or generational fruit', 'disciple_tools' ),
-                'icon' => get_template_directory_uri() . '/dt-assets/images/share.svg?v=2',
-                'order' => 40,
-                'visibility' => __( 'Collaborators', 'disciple_tools' ),
-                'in_create_form' => false,
-            ];
-
             $fields['assigned_to'] = [
                 'name'        => __( 'Assigned To', 'disciple_tools' ),
                 'description' => __( 'Select the main person who is responsible for reporting on this contact.', 'disciple_tools' ),
@@ -777,7 +758,7 @@ class DT_Contacts_Access extends DT_Module_Base {
         }
         if ( isset( $fields['additional_meta']['created_from'] ) ){
             $from_post = DT_Posts::get_post( 'contacts', $fields['additional_meta']['created_from'], true, false );
-            if ( !is_wp_error( $from_post ) && isset( $from_post['type']['key'] ) && $from_post['type']['key'] === 'access' ){
+            if ( !is_wp_error( $from_post ) && isset( $from_post['type']['key'] ) && in_array( $from_post['type']['key'], [ 'access', 'access_placeholder', 'user' ] ) ){
                 $fields['type'] = 'access_placeholder';
             }
         }

--- a/dt-contacts/access-module.php
+++ b/dt-contacts/access-module.php
@@ -108,7 +108,7 @@ class DT_Contacts_Access extends DT_Module_Base {
                 'tile'        => 'status',
                 'icon' => get_template_directory_uri() . '/dt-assets/images/assigned-to.svg?v=2',
                 'show_in_table' => 25,
-                'only_for_types' => [ 'access', 'user' ],
+                'only_for_types' => [ 'access', 'user', 'access_placeholder' ],
                 'custom_display' => false
             ];
             $fields['seeker_path'] = [
@@ -190,7 +190,7 @@ class DT_Contacts_Access extends DT_Module_Base {
                 'custom_display' => true,
                 'icon' => get_template_directory_uri() . '/dt-assets/images/status.svg?v=2',
                 'show_in_table' => 10,
-                'only_for_types' => [ 'access' ],
+                'only_for_types' => [ 'access', 'access_placeholder' ],
                 'select_cannot_be_empty' => true
             ];
 
@@ -771,11 +771,12 @@ class DT_Contacts_Access extends DT_Module_Base {
         if ( !isset( $fields['type'] ) && get_current_user_id() === 0 ){
             $fields['type'] = 'access';
         }
-        if ( !isset( $fields['type'] ) || $fields['type'] !== 'access' ){
-            return $fields;
-        }
-        if ( !isset( $fields['seeker_path'] ) ){
-            $fields['seeker_path'] = 'none';
+        if ( !isset( $fields['overall_status'] ) ){
+            if ( get_current_user_id() ){
+                $fields['overall_status'] = 'active';
+            } else {
+                $fields['overall_status'] = 'new';
+            }
         }
         if ( !isset( $fields['assigned_to'] ) ){
             if ( get_current_user_id() ) {
@@ -795,13 +796,17 @@ class DT_Contacts_Access extends DT_Module_Base {
                 }
             }
         }
-        if ( !isset( $fields['overall_status'] ) ){
-            if ( get_current_user_id() ){
-                $fields['overall_status'] = 'active';
-            } else {
-                $fields['overall_status'] = 'new';
-            }
+
+        /**
+         * Stop here if the type is not "access"
+         */
+        if ( !isset( $fields['type'] ) || $fields['type'] !== 'access' ){
+            return $fields;
         }
+        if ( !isset( $fields['seeker_path'] ) ){
+            $fields['seeker_path'] = 'none';
+        }
+
         if ( !isset( $fields['sources'] ) ) {
             $fields['sources'] = [ 'values' => [ [ 'value' => 'personal' ] ] ];
         }

--- a/dt-contacts/base-setup.php
+++ b/dt-contacts/base-setup.php
@@ -129,6 +129,24 @@ class DT_Contacts_Base {
                         'hidden' => !$private_contacts_enabled,
                         'default' => true
                     ],
+                    'access' => [
+                        'label' => __( 'Standard Contact', 'disciple_tools' ),
+                        'color' => '#2196F3',
+                        'description' => __( 'A contact to collaborate on', 'disciple_tools' ),
+                        'visibility' => __( 'Me and project leadership', 'disciple_tools' ),
+                        'icon' => get_template_directory_uri() . '/dt-assets/images/share.svg?v=2',
+                        'order' => 20,
+                        'default' => true,
+                    ],
+                    'access_placeholder' => [
+                        'label' => __( 'Connection', 'disciple_tools' ),
+                        'color' => '#FF9800',
+                        'description' => __( 'Connected to a contact, or generational fruit', 'disciple_tools' ),
+                        'icon' => get_template_directory_uri() . '/dt-assets/images/share.svg?v=2',
+                        'order' => 40,
+                        'visibility' => __( 'Collaborators', 'disciple_tools' ),
+                        'in_create_form' => false,
+                    ]
                 ],
                 'description' => 'See full documentation here: https://disciple.tools/user-docs/getting-started-info/contacts/contact-types',
                 'icon' => get_template_directory_uri() . '/dt-assets/images/circle-square-triangle.svg?v=2',
@@ -467,8 +485,25 @@ class DT_Contacts_Base {
     //Add, remove or modify fields before the fields are processed in post create
     public function dt_post_create_fields( $fields, $post_type ){
         if ( $post_type === 'contacts' ){
+            if ( !isset( $fields['type'] ) && isset( $fields['additional_meta']['created_from'] ) ){
+                $from_post = DT_Posts::get_post( 'contacts', $fields['additional_meta']['created_from'], true, false );
+                if ( !is_wp_error( $from_post ) && isset( $from_post['type']['key'] ) ){
+                    switch ( $from_post['type']['key'] ){
+                        case 'personal':
+                        case 'placeholder':
+                            $fields['type'] = 'placeholder';
+                            break;
+                        case 'access':
+                        case 'access_placeholder':
+                        case 'user':
+                            $fields['type'] = 'access_placeholder';
+                            break;
+                    }
+                }
+            }
+
             if ( !isset( $fields['type'] ) ){
-                $fields['type'] = 'personal';
+                $fields['type'] = 'access';
             }
         }
         return $fields;

--- a/dt-contacts/base-setup.php
+++ b/dt-contacts/base-setup.php
@@ -106,7 +106,8 @@ class DT_Contacts_Base {
                 'tile' => 'details',
                 'icon' => get_template_directory_uri() . '/dt-assets/images/nametag.svg?v=2',
             ];
-            $contact_preferences = get_option( 'dt_contact_preferences', [] );
+            $post_type_settings = get_option( 'dt_custom_post_types', [] );
+            $private_contacts_enabled = $post_type_settings['contacts']['enable_private_contacts'] ?? false;
             $fields['type'] = [
                 'name'        => __( 'Contact Type', 'disciple_tools' ),
                 'type'        => 'key_select',
@@ -125,7 +126,7 @@ class DT_Contacts_Base {
                         'visibility' => __( 'Only me', 'disciple_tools' ),
                         'icon' => get_template_directory_uri() . '/dt-assets/images/locked.svg?v=2',
                         'order' => 50,
-                        'hidden' => !empty( $contact_preferences['hide_personal_contact_type'] ),
+                        'hidden' => !$private_contacts_enabled,
                         'default' => true
                     ],
                 ],

--- a/dt-contacts/dmm-module.php
+++ b/dt-contacts/dmm-module.php
@@ -330,11 +330,8 @@ class DT_Contacts_DMM  extends DT_Module_Base {
     //Add, remove or modify fields before the fields are processed in post create
     public function dt_post_create_fields( $fields, $post_type ){
         if ( $post_type === 'contacts' ){
-            if ( !isset( $fields['type'] ) ){
-                $fields['type'] = 'placeholder';
-            }
             //mark a new user contact as being coached be the user who added the new user.
-            if ( $fields['type'] === 'user' ){
+            if ( isset( $fields['type'] ) && $fields['type'] === 'user' ){
                 $current_user_contact = Disciple_Tools_Users::get_contact_for_user( get_current_user_id() );
                 if ( $current_user_contact && !is_wp_error( $current_user_contact ) ){
                     $fields['coached_by'] = [ 'values' => [ [ 'value' => $current_user_contact ] ] ];

--- a/dt-contacts/dmm-module.php
+++ b/dt-contacts/dmm-module.php
@@ -44,7 +44,7 @@ class DT_Contacts_DMM  extends DT_Module_Base {
     public function dt_custom_fields_settings( $fields, $post_type ){
         $declared_fields = $fields;
         if ( $post_type === 'contacts' ){
-            $contact_preferences = get_option( 'dt_contact_preferences', [] );
+            $private_contacts_enabled = $post_type_settings['contacts']['enable_private_contacts'] ?? false;
             $fields['type']['default']['placeholder'] = [
                 'label' => __( 'Private Connection', 'disciple_tools' ),
                 'color' => '#FF9800',
@@ -53,7 +53,7 @@ class DT_Contacts_DMM  extends DT_Module_Base {
                 'order' => 40,
                 'visibility' => __( 'Only me', 'disciple_tools' ),
                 'in_create_form' => false,
-                'hidden' => !empty( $contact_preferences['hide_personal_contact_type'] ),
+                'hidden' => !$private_contacts_enabled,
             ];
             $fields['milestones'] = [
                 'name'    => __( 'Faith Milestones', 'disciple_tools' ),

--- a/dt-core/admin/menu/tabs/tab-general.php
+++ b/dt-core/admin/menu/tabs/tab-general.php
@@ -829,27 +829,31 @@ class Disciple_Tools_General_Tab extends Disciple_Tools_Abstract_Menu_Base
         if ( isset( $_POST['dt_contact_preferences_nonce'] ) &&
             wp_verify_nonce( sanitize_key( wp_unslash( $_POST['dt_contact_preferences_nonce'] ) ), 'dt_contact_preferences' . get_current_user_id() ) ) {
 
-            $contact_preferences = get_option( 'dt_contact_preferences' );
-            if ( isset( $_POST['hide_personal_contact_type'] ) && ! empty( $_POST['hide_personal_contact_type'] ) ) {
-                $contact_preferences['hide_personal_contact_type'] = false;
-            } else {
-                $contact_preferences['hide_personal_contact_type'] = true;
-            }
+            $post_type_settings = get_option( 'dt_custom_post_types', [] );
+            $contact_preferences = $post_type_settings['contacts'] ?? [];
 
-            update_option( 'dt_contact_preferences', $contact_preferences, true );
+            if ( isset( $_POST['private_contacts_enabled'] ) && ! empty( $_POST['private_contacts_enabled'] ) ) {
+                $contact_preferences['enable_private_contacts'] = true;
+            } else {
+                $contact_preferences['enable_private_contacts'] = false;
+            }
+            $post_type_settings['contacts'] = $contact_preferences;
+
+            update_option( 'dt_custom_post_types', $post_type_settings, true );
         }
 
     }
 
     public function show_dt_contact_preferences(){
-        $contact_preferences = get_option( 'dt_contact_preferences', [] );
+        $post_type_settings = get_option( 'dt_custom_post_types', [] );
+        $private_contacts_enabled = $post_type_settings['contacts']['enable_private_contacts'] ?? false;
         ?>
         <form method="post" >
             <table class="widefat">
                 <tr>
                     <td>
                         <label>
-                            <input type="checkbox" name="hide_personal_contact_type" <?php echo empty( $contact_preferences['hide_personal_contact_type'] ) ? 'checked' : '' ?> /> Personal Contact Type Enabled
+                            <input type="checkbox" name="private_contacts_enabled" <?php echo $private_contacts_enabled ? 'checked' : '' ?> /> Private Contact Type Enabled. See <a href="https://disciple.tools/user-docs/getting-started-info/contacts/contact-types/" target="_blank">Contact Types Documentation</a>
                         </label>
                     </td>
                 </tr>

--- a/dt-core/configuration/class-migration-engine.php
+++ b/dt-core/configuration/class-migration-engine.php
@@ -12,7 +12,7 @@ if ( !defined( 'ABSPATH' ) ) {
 class Disciple_Tools_Migration_Engine
 {
 
-    public static $migration_number = 56;
+    public static $migration_number = 57;
 
     protected static $migrations = null;
 

--- a/dt-core/migrations/0057-enabled-private-contacts.php
+++ b/dt-core/migrations/0057-enabled-private-contacts.php
@@ -1,0 +1,35 @@
+<?php
+if ( !defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly
+
+/**
+ * Class Disciple_Tools_Migration_0057
+ *
+ * move the hide_personal_contact_type option to the contacts post type settings
+ */
+class Disciple_Tools_Migration_0057 extends Disciple_Tools_Migration {
+    public function up() {
+        //skip this migration on a new install
+        if ( dt_get_initial_install_meta( 'migration_number' ) >= 57 ){
+            return;
+        }
+
+        $contact_preferences = get_option( 'dt_contact_preferences', [] );
+        $hide_personal_contact_type = $contact_preferences['hide_personal_contact_type'] ?? false;
+
+        $post_type_custom_settings = $custom_settings['contacts'] ?? [];
+        $post_type_custom_settings['enable_private_contacts'] = !$hide_personal_contact_type;
+        $custom_settings['contacts'] = $post_type_custom_settings;
+        update_option( 'dt_custom_post_types', $custom_settings );
+        delete_option( 'dt_contact_preferences' );
+    }
+
+    public function down() {
+    }
+
+    public function test() {
+    }
+
+    public function get_expected_tables(): array {
+        return [];
+    }
+}


### PR DESCRIPTION
Make private contacts an opt-in feature for new instances. Nothing will change on old ones.
This will help with multipliers accidentally creating contacts that should be collaboration contacts.

Fix an issue where contacts were created with the "private connection" type off of a "connection" contact.