### PR TITLE
Fix errors saving dropdown option translations

### DIFF
--- a/dt-core/admin/admin-settings-endpoints.php
+++ b/dt-core/admin/admin-settings-endpoints.php
@@ -607,52 +607,36 @@ class Disciple_Tools_Admin_Settings_Endpoints {
 
             switch ( $post_submission['translation_type'] ) {
                 case 'tile-label':
-                    $translated_element = $tile_options[$post_type][$tile_key];
-                    break;
-
                 case 'tile-description':
                     $translated_element = $tile_options[$post_type][$tile_key];
                     break;
 
                 case 'field-label':
-                    if ( !isset( $post_submission['field_key'] ) ) {
-                        return false;
-                    }
-                    $field_key = $post_submission['field_key'];
-                    $translated_element = $field_customizations[$post_type][$field_key];
-                    break;
-
                 case 'field-description':
                     if ( !isset( $post_submission['field_key'] ) ) {
                         return false;
                     }
                     $field_key = $post_submission['field_key'];
                     $translated_element = $field_customizations[$post_type][$field_key];
-                        break;
-
-                case 'field-option-label':
-                    if ( !isset( $post_submission['field_key'] ) || !isset( $post_submission['field_option_key'] ) ) {
-                        return false;
-                    }
-                    $field_key = $post_submission['field_key'];
-                    $field_option_key = $post_submission['field_option_key'];
-                    $translated_element = $field_customizations[$post_type][$field_key]['default'][$field_option_key];
                     break;
 
+                case 'field-option-label':
                 case 'field-option-description':
                     if ( !isset( $post_submission['field_key'] ) || !isset( $post_submission['field_option_key'] ) ) {
                         return false;
                     }
                     $field_key = $post_submission['field_key'];
                     $field_option_key = $post_submission['field_option_key'];
-                    $translated_element = $field_customizations[$post_type][$field_key]['default'][$field_option_key];
+                    $translated_element = $field_customizations[$post_type][$field_key]['default'][$field_option_key] ?? [];
                     break;
             }
-
             // Check if translation is a description
             $translations_element_key = 'translations';
             if ( strpos( $post_submission['translation_type'], 'description' ) ) {
                 $translations_element_key = 'description_translations';
+            }
+            if ( empty( $translated_element ) ) {
+                $translated_element = [ $translations_element_key => [] ];
             }
 
             foreach ( $translations as $lang_key => $translation_val ) {
@@ -663,30 +647,18 @@ class Disciple_Tools_Admin_Settings_Endpoints {
 
             switch ( $post_submission['translation_type'] ) {
                 case 'tile-label':
-                    $tile_options[$post_type][$tile_key] = $translated_element;
-                    update_option( 'dt_custom_tiles', $tile_options );
-                    break;
-
                 case 'tile-description':
                     $tile_options[$post_type][$tile_key] = $translated_element;
                     update_option( 'dt_custom_tiles', $tile_options );
                     break;
 
                 case 'field-label':
-                    $field_customizations[$post_type][$field_key] = $translated_element;
-                    update_option( 'dt_field_customizations', $field_customizations );
-                    break;
-
                 case 'field-description':
                     $field_customizations[$post_type][$field_key] = $translated_element;
                     update_option( 'dt_field_customizations', $field_customizations );
                     break;
 
                 case 'field-option-label':
-                    $field_customizations[$post_type][$field_key]['default'][$field_option_key] = $translated_element;
-                    update_option( 'dt_field_customizations', $field_customizations );
-                    break;
-
                 case 'field-option-description':
                     $field_customizations[$post_type][$field_key]['default'][$field_option_key] = $translated_element;
                     update_option( 'dt_field_customizations', $field_customizations );
@@ -911,16 +883,31 @@ class Disciple_Tools_Admin_Settings_Endpoints {
         $new_field_option_description = $post_submission['new_field_option_description'];
         $field_option_icon = $post_submission['field_option_icon'];
 
+        $fields = DT_Posts::get_post_field_settings( $post_type, false, true );
+        $field_options = $fields[$field_key]['default'] ?? [];
+        $field_option = $field_options[$field_option_key] ?? [];
+
         $field_customizations = dt_get_option( 'dt_field_customizations' );
-        $custom_field_option = [
-            'label' => $new_field_option_label,
-            'description' => $new_field_option_description,
-        ];
+        $custom_field_option = [];
+        if ( isset( $field_customizations[$post_type][$field_key]['default'][$field_option_key] ) ){
+            $custom_field_option = array_merge( $field_customizations[$post_type][$field_key]['default'][$field_option_key], $custom_field_option );
+        }
+        $default_label = self::get_default_field_option_label( $post_type, $field_key, $field_option_key );
+        if ( $new_field_option_label !== $default_label ){
+            $custom_field_option['label'] = $new_field_option_label;
+        }
+        $default_description = self::get_default_field_option_description( $post_type, $field_key, $field_option_key );
+        if ( $new_field_option_description !== $default_description ){
+            $custom_field_option['description'] = $new_field_option_description;
+        }
 
         if ( $field_option_icon && strpos( $field_option_icon, 'undefined' ) === false ){
             $field_option_icon = strtolower( trim( $field_option_icon ) );
             $icon_key = ( strpos( $field_option_icon, 'mdi' ) !== 0 ) ? 'icon' : 'font-icon';
-            $custom_field_option[$icon_key] = $field_option_icon;
+
+            if ( $field_option_icon !== $field_option[$icon_key] ){
+                $custom_field_option[$icon_key] = $field_option_icon;
+            }
 
             if ( $icon_key == 'font-icon' ){
                 $custom_field_option['icon'] = '';
@@ -928,7 +915,7 @@ class Disciple_Tools_Admin_Settings_Endpoints {
         }
 
         // Create default_name to store the default field option label if it changed
-        if ( self::default_field_option_label_changed( $post_type, $field_key, $field_option_key, $custom_field_option['label'] ) ) {
+        if ( self::default_field_option_label_changed( $post_type, $field_key, $field_option_key, $custom_field_option['label'] ?? '' ) ) {
             $custom_field_option['default_name'] = self::get_default_field_option_label( $post_type, $field_key, $field_option_key );
         }
 
@@ -939,7 +926,7 @@ class Disciple_Tools_Admin_Settings_Endpoints {
 
         $field_customizations[$post_type][$field_key]['default'][$field_option_key] = $custom_field_option;
         update_option( 'dt_field_customizations', $field_customizations );
-        return $custom_field_option;
+        return array_merge( $field_option, $custom_field_option );
     }
 
     public function delete_field_option( WP_REST_Request $request ) {
@@ -1007,6 +994,13 @@ class Disciple_Tools_Admin_Settings_Endpoints {
         $default_fields = apply_filters( 'dt_custom_fields_settings', [], $post_type );
         $all_non_custom_fields = array_merge( $base_fields, $default_fields );
         $default_name = $all_non_custom_fields[$field_key]['default'][$field_option_key]['label'] ?? '';
+        return $default_name;
+    }
+    public static function get_default_field_option_description( $post_type, $field_key, $field_option_key ) {
+        $base_fields = Disciple_Tools_Post_Type_Template::get_base_post_type_fields();
+        $default_fields = apply_filters( 'dt_custom_fields_settings', [], $post_type );
+        $all_non_custom_fields = array_merge( $base_fields, $default_fields );
+        $default_name = $all_non_custom_fields[$field_key]['default'][$field_option_key]['description'] ?? '';
         return $default_name;
     }
 

--- a/dt-core/admin/js/dt-options.js
+++ b/dt-core/admin/js/dt-options.js
@@ -960,7 +960,8 @@ jQuery(document).ready(function ($) {
           $(tr)
             .find("input[id^='" + option_key_prefix + "']")
             .each(function (okt_idx, okt_input) {
-              let locale = window.lodash.split($(okt_input).attr('id'), '-')[1];
+              // expected format: field_option_{option_value}_translation-{locale}
+              let locale = okt_input.id.replace(option_key_prefix, '');
               let value = $(okt_input).val();
               if (locale && value) {
                 translations['option_translations'].push({

--- a/dt-core/admin/menu/tabs/admin-endpoints.php
+++ b/dt-core/admin/menu/tabs/admin-endpoints.php
@@ -137,6 +137,9 @@ class DT_Admin_Endpoints {
 
                     if ( !empty( $option_key ) ){
                         $defaults[$option_key] = [];
+                        if ( !empty( $custom_field['default'][$option_key]['label'] ) ) {
+                            $defaults[$option_key]['label'] = $custom_field['default'][$option_key]['label'];
+                        }
                         $defaults[$option_key]['translations'] = [];
                         $defaults[$option_key]['description_translations'] = [];
 

--- a/dt-core/admin/menu/tabs/tab-custom-fields.php
+++ b/dt-core/admin/menu/tabs/tab-custom-fields.php
@@ -12,7 +12,6 @@
  * @author     Disciple.Tools
  */
 
-/**/
 
 if ( !defined( 'ABSPATH' ) ) {
     exit; // Exit if accessed directly


### PR DESCRIPTION
This fixes two issues. The second was found after I fixed the first, so I included them in one issue.

## Issue 1
Can't save option translations if the option key contains a hyphen.

- Go to Settings (D.T) -> Fields
- Edit a key_select/dropdown field
- Add an option with a hyphen (e.g. "Type - Subtype")
- Add a translation for the given option (e.g. English: "Subtype")
- Refresh page to view updated options

**Expect**: Translation is saved for given option
**Actual**: Translation is not saved. Cause is that the locale is not parsed properly because the code split on a hyphen, expecting no hyphens in the option key.

## Issue 2
Saving a translation of a custom option will clear the `label` property of the option.

- Go to Settings (D.T) -> Fields
- Edit a key_select/dropdown field
- Add any custom option (this doesn't affect default options on default fields, but does affect custom options on default fields. Won't affect faith_status->believer. WILL affect faith_status.custom_option)
- See that option is displayed with Key and Custom Label
- Add a translation for the given option (e.g. English: "Custom!!")
- Refresh page to view updated options

**Expect**: Custom label stays the same
**Actual**: Custom label is made to be blank. For custom options on default fields, this causes the option to not show up anymore. It is still in the database but never appears in the UI because it has no `label` property.