### PR TITLE
Check for create_users permission when displaying Add User submenu

### DIFF
--- a/dt-users/user-management.php
+++ b/dt-users/user-management.php
@@ -133,7 +133,7 @@ class DT_User_Management
 
     public function add_menu( $content ) {
         $content .= '<li><a href="'. site_url( '/user-management/users/' ) .'" >' .  esc_html__( 'Users', 'disciple_tools' ) . '</a></li>';
-        if ( current_user_can( 'manage_dt' ) ){
+        if ( current_user_can( 'manage_dt' ) || current_user_can( 'create_users' ) ){
             $content .= '<li><a href="'. esc_url( site_url( '/user-management/add-user/' ) ) .'" >' .  esc_html__( 'Add User', 'disciple_tools' ) . '</a></li>';
         }
         return $content;


### PR DESCRIPTION
I found that when giving a multiplier user the User Manager role, they weren't seeing a link on the User Management page to Add Users. I found it was because the code was only checking for `manage_dt` instead of `create_users`, so I added that to the permission check. User Managers who are not DT Admins can now see the Add User link.