### PR TITLE
Safeguard Against ValueError Bcrypt Null Chars Exceptions

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -89,21 +89,6 @@ if ( version_compare( phpversion(), '7.4', '<' ) ) {
         }
     } );
 
-    /** Setup key for JWT authentication */
-    if ( !defined( 'JWT_AUTH_SECRET_KEY' ) ) {
-        if ( get_option( 'my_jwt_key' ) ) {
-            define( 'JWT_AUTH_SECRET_KEY', get_option( 'my_jwt_key' ) );
-        } else {
-            try {
-                $iv = password_hash( random_bytes_no_null( 16 ), PASSWORD_DEFAULT );
-                update_option( 'my_jwt_key', $iv );
-                define( 'JWT_AUTH_SECRET_KEY', $iv );
-            } catch ( Exception $e ) {
-                dt_write_log( $e->getMessage() );
-            }
-        }
-    }
-
     /**
      * Intended to avoid restrictions with passing null-containing strings to bcrypt functions like password_hash.
      *
@@ -125,6 +110,21 @@ if ( version_compare( phpversion(), '7.4', '<' ) ) {
         }
 
         return substr( $str, 0, $length );
+    }
+
+    /** Setup key for JWT authentication */
+    if ( !defined( 'JWT_AUTH_SECRET_KEY' ) ) {
+        if ( get_option( 'my_jwt_key' ) ) {
+            define( 'JWT_AUTH_SECRET_KEY', get_option( 'my_jwt_key' ) );
+        } else {
+            try {
+                $iv = password_hash( random_bytes_no_null( 16 ), PASSWORD_DEFAULT );
+                update_option( 'my_jwt_key', $iv );
+                define( 'JWT_AUTH_SECRET_KEY', $iv );
+            } catch ( Exception $e ) {
+                dt_write_log( $e->getMessage() );
+            }
+        }
     }
 
     /**

--- a/functions.php
+++ b/functions.php
@@ -98,7 +98,7 @@ if ( version_compare( phpversion(), '7.4', '<' ) ) {
                 $iv = password_hash( random_bytes_no_null( 16 ), PASSWORD_DEFAULT );
                 update_option( 'my_jwt_key', $iv );
                 define( 'JWT_AUTH_SECRET_KEY', $iv );
-            } catch ( ValueError $e ) {
+            } catch ( Exception $e ) {
                 dt_write_log( $e->getMessage() );
             }
         }

--- a/functions.php
+++ b/functions.php
@@ -10,7 +10,6 @@
 if ( !defined( 'ABSPATH' ) ) {
     exit;
 } // Exit if accessed directly
-use Random\RandomException;
 use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
 
 /**
@@ -99,7 +98,7 @@ if ( version_compare( phpversion(), '7.4', '<' ) ) {
                 $iv = password_hash( random_bytes_no_null( 16 ), PASSWORD_DEFAULT );
                 update_option( 'my_jwt_key', $iv );
                 define( 'JWT_AUTH_SECRET_KEY', $iv );
-            } catch ( RandomException | ValueError $e ) {
+            } catch ( ValueError $e ) {
                 dt_write_log( $e->getMessage() );
             }
         }
@@ -113,7 +112,6 @@ if ( version_compare( phpversion(), '7.4', '<' ) ) {
      *
      * @param int $length
      * @return string
-     * @throws RandomException
      *
      * @since 1.67.0
      */


### PR DESCRIPTION
Implemented `random_bytes_no_null()` wrapper function, to ensure `random_bytes()` do not contain null characters; which cause a `ValueError` exception; following the addition of the [Bcrypt password must not contain null character](https://github.com/php/php-src/commit/6a5c04d01d#diff-97027f2a7f32316e1a9d2317ecd1abd1eca58b9bb9c30c7929c7a33b93df5ad5R184) check.

![Screenshot 2024-09-27 at 13 40 49](https://github.com/user-attachments/assets/5a286b12-d0f4-4b71-9698-629a6971bdbe)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208382720655232