### PR TITLE
Apply filter to notify all for different comment types

### DIFF
--- a/dt-notifications/notifications-comments.php
+++ b/dt-notifications/notifications-comments.php
@@ -30,7 +30,8 @@ class Disciple_Tools_Notifications_Comments
         }
 
         $comment_with_users = self::match_mention( $comment->comment_content ); // fail if no match for mention found
-        if ( ( $comment->comment_type === 'comment' ) || ( isset( $comment_with_users['user_ids'] ) && ( count( $comment_with_users['user_ids'] ) > 0 ) ) ) {
+        $comment_types_to_notify = apply_filters( 'dt_filter_comment_types_receiving_comment_notification', [ 'comment' ] );
+        if ( ( in_array( $comment->comment_type, $comment_types_to_notify ) ) || ( isset( $comment_with_users['user_ids'] ) && ( count( $comment_with_users['user_ids'] ) > 0 ) ) ) {
             $comment->comment_content = $comment_with_users['comment'];
             $mentioned_user_ids = $comment_with_users['user_ids'];
             $post_id = $comment->comment_post_ID;


### PR DESCRIPTION
**Problem:**
When a plugin or external system creates a comment that is not type "comment" and a user has selected in their profile to "receive a notification for any update that happens in the system", that user will not be notified. Those notifications are only triggered on comments with a type of "comment"

**Solution:**
This adds a filter to include other comment types in the list of those that should be notified. So in a plugin that creates a different comment type, it can include that comment type in this filtered list to indicate that it should also trigger notifications.