### PR TITLE
Option to disable site link HTTPS check

### DIFF
--- a/dt-core/admin/menu/tabs/tab-security.php
+++ b/dt-core/admin/menu/tabs/tab-security.php
@@ -51,6 +51,7 @@ class Disciple_Tools_Security_Tab extends Disciple_Tools_Abstract_Menu_Base
             self::template( 'begin', 1 );
 
             $this->save_settings();
+            $this->security_headers_box();
             $this->security_enable_box();
 
 
@@ -73,7 +74,7 @@ class Disciple_Tools_Security_Tab extends Disciple_Tools_Abstract_Menu_Base
         }
     }
 
-    public function security_enable_box() {
+    public function security_headers_box() {
         $this->box( 'top', 'Enable and Configure Security Headers' );
 
         $xss_disabled = get_option( 'dt_disable_header_xss' );
@@ -117,6 +118,31 @@ class Disciple_Tools_Security_Tab extends Disciple_Tools_Abstract_Menu_Base
         $this->box( 'bottom' );
     }
 
+
+    public function security_enable_box() {
+        $this->box( 'top', 'Security Settings' );
+
+        $disable_site_link_https_check = get_option( 'dt_disable_site_link_https_check', false );
+        ?>
+        <p></p>
+
+        <form method="POST" action="">
+            <?php wp_nonce_field( 'security_settings', 'security_settings_nonce' ); ?>
+            <table class="form-table">
+                <tr>
+                    <th>Site link HTTPS check</th>
+                    <td><input name="site_link_https_check" type="checkbox" value="1" <?php echo $disable_site_link_https_check ? '' : 'checked' ?>></td>
+                    <td>Uncheck to support localhost instances and instances behind VPNs</td>
+                </tr>
+            </table>
+
+            <button type="submit" class="button button-primary">Save Changes</button>
+        </form>
+
+        <?php
+        $this->box( 'bottom' );
+    }
+
     public function save_settings(){
         if ( !empty( $_POST ) ){
             if ( isset( $_POST['security_headers_nonce'] ) && wp_verify_nonce( sanitize_key( $_POST['security_headers_nonce'] ), 'security_headers' ) ) {
@@ -128,6 +154,10 @@ class Disciple_Tools_Security_Tab extends Disciple_Tools_Abstract_Menu_Base
 
             if ( isset( $_POST['usage_data_nonce'] ) && wp_verify_nonce( sanitize_key( $_POST['usage_data_nonce'] ), 'usage_data' ) ) {
                 update_option( 'dt_disable_usage_data', isset( $_POST['usage'] ) ? '1' : '0' );
+            }
+
+            if ( isset( $_POST['security_settings_nonce'] ) && wp_verify_nonce( sanitize_key( $_POST['security_settings_nonce'] ), 'security_settings' ) ) {
+                update_option( 'dt_disable_site_link_https_check', isset( $_POST['site_link_https_check'] ) ? '0' : '1' );
             }
         }
     }

--- a/dt-core/admin/menu/tabs/tab-security.php
+++ b/dt-core/admin/menu/tabs/tab-security.php
@@ -51,7 +51,6 @@ class Disciple_Tools_Security_Tab extends Disciple_Tools_Abstract_Menu_Base
             self::template( 'begin', 1 );
 
             $this->save_settings();
-            $this->security_headers_box();
             $this->security_enable_box();
 
 
@@ -74,7 +73,7 @@ class Disciple_Tools_Security_Tab extends Disciple_Tools_Abstract_Menu_Base
         }
     }
 
-    public function security_headers_box() {
+    public function security_enable_box() {
         $this->box( 'top', 'Enable and Configure Security Headers' );
 
         $xss_disabled = get_option( 'dt_disable_header_xss' );
@@ -118,31 +117,6 @@ class Disciple_Tools_Security_Tab extends Disciple_Tools_Abstract_Menu_Base
         $this->box( 'bottom' );
     }
 
-
-    public function security_enable_box() {
-        $this->box( 'top', 'Security Settings' );
-
-        $disable_site_link_https_check = get_option( 'dt_disable_site_link_https_check', false );
-        ?>
-        <p></p>
-
-        <form method="POST" action="">
-            <?php wp_nonce_field( 'security_settings', 'security_settings_nonce' ); ?>
-            <table class="form-table">
-                <tr>
-                    <th>Site link HTTPS check</th>
-                    <td><input name="site_link_https_check" type="checkbox" value="1" <?php echo $disable_site_link_https_check ? '' : 'checked' ?>></td>
-                    <td>Uncheck to support localhost instances and instances behind VPNs</td>
-                </tr>
-            </table>
-
-            <button type="submit" class="button button-primary">Save Changes</button>
-        </form>
-
-        <?php
-        $this->box( 'bottom' );
-    }
-
     public function save_settings(){
         if ( !empty( $_POST ) ){
             if ( isset( $_POST['security_headers_nonce'] ) && wp_verify_nonce( sanitize_key( $_POST['security_headers_nonce'] ), 'security_headers' ) ) {
@@ -154,10 +128,6 @@ class Disciple_Tools_Security_Tab extends Disciple_Tools_Abstract_Menu_Base
 
             if ( isset( $_POST['usage_data_nonce'] ) && wp_verify_nonce( sanitize_key( $_POST['usage_data_nonce'] ), 'usage_data' ) ) {
                 update_option( 'dt_disable_usage_data', isset( $_POST['usage'] ) ? '1' : '0' );
-            }
-
-            if ( isset( $_POST['security_settings_nonce'] ) && wp_verify_nonce( sanitize_key( $_POST['security_settings_nonce'] ), 'security_settings' ) ) {
-                update_option( 'dt_disable_site_link_https_check', isset( $_POST['site_link_https_check'] ) ? '0' : '1' );
             }
         }
     }

--- a/dt-core/admin/site-link-post-type.php
+++ b/dt-core/admin/site-link-post-type.php
@@ -207,14 +207,17 @@ if ( ! class_exists( 'Site_Link_System' ) ) {
              */
             // challenge https connection
             if ( WP_DEBUG !== true ) {
-                if ( !isset( $_SERVER['HTTPS'] ) ) {
-                    dt_write_log( __METHOD__ . ': Server does not have the HTTPS parameter set.' );
+                $disable_site_link_https_check = get_option( 'dt_disable_site_link_https_check', false );
+                if ( empty( $disable_site_link_https_check ) ){
+                    if ( !isset( $_SERVER['HTTPS'] ) ){
+                        dt_write_log( __METHOD__ . ': Server does not have the HTTPS parameter set.' );
 
-                    return false;
-                } elseif ( !( 'on' === $_SERVER['HTTPS'] ) ) {
-                    dt_write_log( __METHOD__ . ': Failed https challenge' );
+                        return false;
+                    } elseif ( !( 'on' === $_SERVER['HTTPS'] ) ){
+                        dt_write_log( __METHOD__ . ': Failed https challenge' );
 
-                    return false;
+                        return false;
+                    }
                 }
             }
 

--- a/dt-core/admin/site-link-post-type.php
+++ b/dt-core/admin/site-link-post-type.php
@@ -208,6 +208,7 @@ if ( ! class_exists( 'Site_Link_System' ) ) {
             // challenge https connection
             if ( WP_DEBUG !== true ) {
                 $disable_site_link_https_check = get_option( 'dt_disable_site_link_https_check', false );
+                $disable_site_link_https_check = add_filter( 'dt_disable_site_link_https_check', $disable_site_link_https_check );
                 if ( empty( $disable_site_link_https_check ) ){
                     if ( !isset( $_SERVER['HTTPS'] ) ){
                         dt_write_log( __METHOD__ . ': Server does not have the HTTPS parameter set.' );

--- a/dt-core/admin/site-link-post-type.php
+++ b/dt-core/admin/site-link-post-type.php
@@ -207,8 +207,7 @@ if ( ! class_exists( 'Site_Link_System' ) ) {
              */
             // challenge https connection
             if ( WP_DEBUG !== true ) {
-                $disable_site_link_https_check = get_option( 'dt_disable_site_link_https_check', false );
-                $disable_site_link_https_check = add_filter( 'dt_disable_site_link_https_check', $disable_site_link_https_check );
+                $disable_site_link_https_check = add_filter( 'dt_disable_site_link_https_check', false );
                 if ( empty( $disable_site_link_https_check ) ){
                     if ( !isset( $_SERVER['HTTPS'] ) ){
                         dt_write_log( __METHOD__ . ': Server does not have the HTTPS parameter set.' );


### PR DESCRIPTION
This will let site links work on instances behind a VPN that are set up as localhost.
Or with local dev when debug is false.

<img width="1215" alt="image" src="https://github.com/user-attachments/assets/711e8eef-da8e-4b8e-afc9-e14e542d2deb">

