### PR TITLE
Option to only install location grid once on a multisite.

### DIFF
--- a/dt-mapping/class-migration-engine.php
+++ b/dt-mapping/class-migration-engine.php
@@ -74,6 +74,12 @@ class DT_Mapping_Module_Migration_Engine
         if ( $target_migration_number >= count( self::get_migrations() ) ) {
             throw new Exception( "Migration number $target_migration_number does not exist" );
         }
+        global $wpdb;
+        //makes sure tables are set up
+        if ( !isset( $wpdb->dt_location_grid ) ){
+            $wpdb->dt_location_grid = apply_filters( 'dt_location_grid_table', $wpdb->prefix . 'dt_location_grid' );
+        }
+
         while ( true ) {
             $current_migration_number = get_option( 'dt_mapping_module_migration_number' );
             if ( $current_migration_number === false ) {

--- a/dt-mapping/globals.php
+++ b/dt-mapping/globals.php
@@ -191,7 +191,7 @@ $GLOBALS['dt_mapping'] = $dt_mapping;
 
 /** Add location grid database name */
 global $wpdb;
-$wpdb->dt_location_grid = $wpdb->prefix .'dt_location_grid';
+$wpdb->dt_location_grid = apply_filters( 'dt_location_grid_table', $wpdb->prefix . 'dt_location_grid' );
 $wpdb->dt_location_grid_meta = $wpdb->prefix . 'dt_location_grid_meta';
 
 /*******************************************************************************************************************

--- a/dt-mapping/location-grid-list-api.php
+++ b/dt-mapping/location-grid-list-api.php
@@ -42,7 +42,7 @@ if ( file_exists( $mapping_url . 'geocode-api/location-grid-geocoder.php' ) ) {
 
 // register global database
 global $wpdb;
-$wpdb->dt_location_grid = $wpdb->prefix . 'dt_location_grid';
+$wpdb->dt_location_grid = apply_filters( 'dt_location_grid_table', $wpdb->prefix . 'dt_location_grid' );
 $wpdb->dt_location_grid_meta = $wpdb->prefix . 'dt_location_grid_meta';
 
 

--- a/dt-mapping/mapping-admin.php
+++ b/dt-mapping/mapping-admin.php
@@ -1509,7 +1509,7 @@ if ( ! class_exists( 'DT_Mapping_Module_Admin' ) ) {
             global $wpdb;
             $wpdb->query("
                 INSERT INTO {$wpdb->prefix}dt_location_grid_upgrade
-                SELECT * FROM {$wpdb->prefix}dt_location_grid WHERE grid_id >= 1000000000
+                SELECT * FROM $wpdb->dt_location_grid WHERE grid_id >= 1000000000
             ");
 
             return true;
@@ -1518,10 +1518,10 @@ if ( ! class_exists( 'DT_Mapping_Module_Admin' ) ) {
             dt_write_log( __METHOD__ );
             global $wpdb;
             $wpdb->query("
-                DROP TABLE IF EXISTS `{$wpdb->prefix}dt_location_grid`
+                DROP TABLE IF EXISTS `$wpdb->dt_location_grid`
             ");
             $wpdb->query("
-                RENAME TABLE `{$wpdb->prefix}dt_location_grid_upgrade` TO `{$wpdb->prefix}dt_location_grid`;
+                RENAME TABLE `{$wpdb->prefix}dt_location_grid_upgrade` TO `$wpdb->dt_location_grid`;
             ");
             $wpdb->query( "UPDATE $wpdb->dt_location_grid SET level = '0' WHERE level is NULL AND level_name = 'admin0'" );
             return true;
@@ -2796,7 +2796,7 @@ if ( ! class_exists( 'DT_Mapping_Module_Admin' ) ) {
         public function migrations_reset_and_rerun() {
             global $wpdb;
             // drop tables
-            $wpdb->dt_location_grid = $wpdb->prefix . 'dt_location_grid';
+            $wpdb->dt_location_grid = apply_filters( 'dt_location_grid_table', $wpdb->prefix . 'dt_location_grid' );
             $wpdb->query( "DROP TABLE IF EXISTS $wpdb->dt_location_grid" );
 
             // delete

--- a/dt-mapping/mapping-admin.php
+++ b/dt-mapping/mapping-admin.php
@@ -400,16 +400,18 @@ if ( ! class_exists( 'DT_Mapping_Module_Admin' ) ) {
                         <?php echo esc_attr( ( $tab == 'geocoding' ) ? 'nav-tab-active' : '' ); ?>">
                         <?php esc_attr_e( 'Geocoding', 'disciple_tools' ) ?>
                     </a>
-                    <!-- Names Tab -->
-                    <a href="<?php echo esc_attr( $link ) . 'names' ?>" class="nav-tab
-                        <?php echo esc_attr( ( $tab == 'names' ) ? 'nav-tab-active' : '' ); ?>">
-                        <?php esc_attr_e( 'Locations List', 'disciple_tools' ) ?>
-                    </a>
-                    <!-- Add Migration -->
-                    <a href="<?php echo esc_attr( $link ) . 'migration' ?>" class="nav-tab
-                        <?php echo esc_attr( ( $tab == 'migration' ) ? 'nav-tab-active' : '' ); ?>">
-                        <?php esc_attr_e( 'Migration', 'disciple_tools' ) ?>
-                    </a>
+                    <?php if ( !apply_filters( 'dt_using_multisite_location_grid_table', false ) ) : ?>
+                      <!-- Names Tab -->
+                      <a href="<?php echo esc_attr( $link ) . 'names' ?>" class="nav-tab
+                          <?php echo esc_attr( ( $tab == 'names' ) ? 'nav-tab-active' : '' ); ?>">
+                          <?php esc_attr_e( 'Locations List', 'disciple_tools' ) ?>
+                      </a>
+                      <!-- Add Migration -->
+                      <a href="<?php echo esc_attr( $link ) . 'migration' ?>" class="nav-tab
+                          <?php echo esc_attr( ( $tab == 'migration' ) ? 'nav-tab-active' : '' ); ?>">
+                          <?php esc_attr_e( 'Migration', 'disciple_tools' ) ?>
+                      </a>
+                    <?php endif; ?>
 
                     <!-- Add Locations Explorer -->
                     <a href="<?php echo esc_attr( $link ) . 'credits' ?>" class="nav-tab

--- a/dt-mapping/mapping-queries.php
+++ b/dt-mapping/mapping-queries.php
@@ -1184,34 +1184,34 @@ class Disciple_Tools_Mapping_Queries {
             GROUP BY t5.admin5_grid_id;
             ",
                 // 0
-                $wpdb->prefix .'user_status',
+                $wpdb->prefix . 'user_status',
                 $status,
-                $wpdb->prefix .'location_grid',
+                $wpdb->prefix . 'location_grid',
                 $status,
                 // 1
-                $wpdb->prefix .'user_status',
+                $wpdb->prefix . 'user_status',
                 $status,
-                $wpdb->prefix .'location_grid',
+                $wpdb->prefix . 'location_grid',
                 $status,
                 // 2
-                $wpdb->prefix .'user_status',
+                $wpdb->prefix . 'user_status',
                 $status,
-                $wpdb->prefix .'location_grid',
+                $wpdb->prefix . 'location_grid',
                 $status,
                 // 3
-                $wpdb->prefix .'user_status',
+                $wpdb->prefix . 'user_status',
                 $status,
-                $wpdb->prefix .'location_grid',
+                $wpdb->prefix . 'location_grid',
                 $status,
                 // 4
-                $wpdb->prefix .'user_status',
+                $wpdb->prefix . 'user_status',
                 $status,
-                $wpdb->prefix .'location_grid',
+                $wpdb->prefix . 'location_grid',
                 $status,
                 // 5
-                $wpdb->prefix .'user_status',
+                $wpdb->prefix . 'user_status',
                 $status,
-                $wpdb->prefix .'location_grid',
+                $wpdb->prefix . 'location_grid',
                 $status
             ), ARRAY_A );
 

--- a/dt-mapping/migrations/0004-location-grid-table.php
+++ b/dt-mapping/migrations/0004-location-grid-table.php
@@ -43,9 +43,10 @@ class DT_Mapping_Module_Migration_0004 extends DT_Mapping_Module_Migration {
     public function get_expected_tables(): array {
         global $wpdb;
         $charset_collate = $wpdb->get_charset_collate();
+        $location_grid_table_name = apply_filters( 'dt_location_grid_table', $wpdb->prefix . 'dt_location_grid' );
         return array(
-            "{$wpdb->prefix}dt_location_grid" =>
-                "CREATE TABLE IF NOT EXISTS `{$wpdb->prefix}dt_location_grid` (
+            "{$location_grid_table_name}" =>
+                "CREATE TABLE IF NOT EXISTS `{$location_grid_table_name}` (
                   `grid_id` bigint(20) NOT NULL AUTO_INCREMENT,
                   `name` varchar(200) NOT NULL DEFAULT '',
                   `level` int(1) DEFAULT NULL,

--- a/dt-mapping/migrations/0004-location-grid-table.php
+++ b/dt-mapping/migrations/0004-location-grid-table.php
@@ -2,6 +2,7 @@
 if ( ! defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly
 /**
  * Class DT_Mapping_Module_Migration_0004
+ * Setup dt_location_grid table if it does not exist.
  * @version_added 0.22.1
  */
 class DT_Mapping_Module_Migration_0004 extends DT_Mapping_Module_Migration {

--- a/dt-mapping/migrations/0004-location-grid-table.php
+++ b/dt-mapping/migrations/0004-location-grid-table.php
@@ -43,10 +43,9 @@ class DT_Mapping_Module_Migration_0004 extends DT_Mapping_Module_Migration {
     public function get_expected_tables(): array {
         global $wpdb;
         $charset_collate = $wpdb->get_charset_collate();
-        $location_grid_table_name = apply_filters( 'dt_location_grid_table', $wpdb->prefix . 'dt_location_grid' );
         return array(
-            "{$location_grid_table_name}" =>
-                "CREATE TABLE IF NOT EXISTS `{$location_grid_table_name}` (
+            "{$wpdb->dt_location_grid}" =>
+                "CREATE TABLE IF NOT EXISTS `{$wpdb->dt_location_grid}` (
                   `grid_id` bigint(20) NOT NULL AUTO_INCREMENT,
                   `name` varchar(200) NOT NULL DEFAULT '',
                   `level` int(1) DEFAULT NULL,

--- a/dt-mapping/migrations/0005-prepare-location-grid-data.php
+++ b/dt-mapping/migrations/0005-prepare-location-grid-data.php
@@ -12,6 +12,16 @@ if ( ! defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly
 class DT_Mapping_Module_Migration_0005 extends DT_Mapping_Module_Migration {
 
     public function up() {
+        global $wpdb;
+        if ( ! isset( $wpdb->dt_location_grid ) ) {
+            $wpdb->dt_location_grid = apply_filters( 'dt_location_grid_table', $wpdb->prefix . 'dt_location_grid' );
+        }
+        $rows = (int) $wpdb->get_var( "SELECT count(*) FROM $wpdb->dt_location_grid" );
+        if ( $rows >= 1 ) {
+            /* Test if database is already created */
+            error_log( 'database already installed' );
+            return;
+        }
 
         // get uploads director
         $dir = wp_upload_dir();
@@ -85,6 +95,10 @@ class DT_Mapping_Module_Migration_0005 extends DT_Mapping_Module_Migration {
      * @throws \Exception Did not find files.
      */
     public function test() {
+        if ( apply_filters( 'dt_using_multisite_location_grid_table', false ) ) {
+            return;
+        }
+
         $dir = wp_upload_dir();
         $uploads_dir = trailingslashit( $dir['basedir'] );
 

--- a/dt-mapping/migrations/0005-prepare-location-grid-data.php
+++ b/dt-mapping/migrations/0005-prepare-location-grid-data.php
@@ -13,9 +13,6 @@ class DT_Mapping_Module_Migration_0005 extends DT_Mapping_Module_Migration {
 
     public function up() {
         global $wpdb;
-        if ( ! isset( $wpdb->dt_location_grid ) ) {
-            $wpdb->dt_location_grid = apply_filters( 'dt_location_grid_table', $wpdb->prefix . 'dt_location_grid' );
-        }
         $rows = (int) $wpdb->get_var( "SELECT count(*) FROM $wpdb->dt_location_grid" );
         if ( $rows >= 1 ) {
             /* Test if database is already created */

--- a/dt-mapping/migrations/0006-add-grid-to-db.php
+++ b/dt-mapping/migrations/0006-add-grid-to-db.php
@@ -13,7 +13,7 @@ class DT_Mapping_Module_Migration_0006 extends DT_Mapping_Module_Migration {
     public function up() {
         global $wpdb;
         if ( ! isset( $wpdb->dt_location_grid ) ) {
-            $wpdb->dt_location_grid = $wpdb->prefix . 'dt_location_grid';
+            $wpdb->dt_location_grid = apply_filters( 'dt_location_grid_table', $wpdb->prefix . 'dt_location_grid' );
         }
 
         $file = 'dt_location_grid.tsv';

--- a/dt-mapping/migrations/0006-add-grid-to-db.php
+++ b/dt-mapping/migrations/0006-add-grid-to-db.php
@@ -12,9 +12,6 @@ class DT_Mapping_Module_Migration_0006 extends DT_Mapping_Module_Migration {
      */
     public function up() {
         global $wpdb;
-        if ( ! isset( $wpdb->dt_location_grid ) ) {
-            $wpdb->dt_location_grid = apply_filters( 'dt_location_grid_table', $wpdb->prefix . 'dt_location_grid' );
-        }
 
         $file = 'dt_location_grid.tsv';
         $expected = 48000;

--- a/dt-mapping/migrations/0010-add-location-grid-meta-tb.php
+++ b/dt-mapping/migrations/0010-add-location-grid-meta-tb.php
@@ -3,6 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly
 
 /**
  * Class DT_Mapping_Module_Migration_0010
+ * Install the location_grid_meta table.
  * @version_added 0.30.0
  */
 class DT_Mapping_Module_Migration_0010 extends DT_Mapping_Module_Migration {

--- a/dt-mapping/migrations/0013-v2-options-upgrade.php
+++ b/dt-mapping/migrations/0013-v2-options-upgrade.php
@@ -3,6 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly
 
 /**
  * Class DT_Mapping_Module_Migration_0013
+ * Setup location grid mirror urls
  *
  * @version_added 1.30.2
  */

--- a/dt-mapping/migrations/0014-v2-db-upgrade-optional.php
+++ b/dt-mapping/migrations/0014-v2-db-upgrade-optional.php
@@ -13,7 +13,6 @@ class DT_Mapping_Module_Migration_0014 extends DT_Mapping_Module_Migration {
      */
     public function up() {
         global $wpdb;
-        $wpdb->dt_location_grid = apply_filters( 'dt_location_grid_table', $wpdb->prefix . 'dt_location_grid' );
         // test for a specific feature that was changed in v2 to see if the v2 dataset was installed in 0006. This will be true for installs after 1.30.2, and not true installs before 1.30.2.
         $is_v2 = $wpdb->get_var( "SELECT grid_id FROM $wpdb->dt_location_grid WHERE grid_id = 100364199 AND latitude LIKE '%39.8097%'" );
         if ( empty( $is_v2 ) ) {

--- a/dt-mapping/migrations/0014-v2-db-upgrade-optional.php
+++ b/dt-mapping/migrations/0014-v2-db-upgrade-optional.php
@@ -3,7 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly
 
 /**
  * Class DT_Mapping_Module_Migration_0014
- *
+ * fix location grid data for installs before D.T v1.30.2 by rerunning the setup migrations
+ * next migration copies custom data back.
  * @version_added 1.30.2
  */
 class DT_Mapping_Module_Migration_0014 extends DT_Mapping_Module_Migration {
@@ -12,6 +13,10 @@ class DT_Mapping_Module_Migration_0014 extends DT_Mapping_Module_Migration {
      * @throws \Exception  Got error when creating table $name.
      */
     public function up() {
+        if ( version_compare( dt_get_initial_install_meta( 'theme_version' ), '1.31.0', '>=' ) ){
+            return;
+        }
+
         global $wpdb;
         // test for a specific feature that was changed in v2 to see if the v2 dataset was installed in 0006. This will be true for installs after 1.30.2, and not true installs before 1.30.2.
         $is_v2 = $wpdb->get_var( "SELECT grid_id FROM $wpdb->dt_location_grid WHERE grid_id = 100364199 AND latitude LIKE '%39.8097%'" );

--- a/dt-mapping/migrations/0014-v2-db-upgrade-optional.php
+++ b/dt-mapping/migrations/0014-v2-db-upgrade-optional.php
@@ -13,17 +13,17 @@ class DT_Mapping_Module_Migration_0014 extends DT_Mapping_Module_Migration {
      */
     public function up() {
         global $wpdb;
+        $wpdb->dt_location_grid = apply_filters( 'dt_location_grid_table', $wpdb->prefix . 'dt_location_grid' );
         // test for a specific feature that was changed in v2 to see if the v2 dataset was installed in 0006. This will be true for installs after 1.30.2, and not true installs before 1.30.2.
-        $is_v2 = $wpdb->get_var( "SELECT grid_id FROM {$wpdb->prefix}dt_location_grid WHERE grid_id = 100364199 AND latitude LIKE '%39.8097%'" );
+        $is_v2 = $wpdb->get_var( "SELECT grid_id FROM $wpdb->dt_location_grid WHERE grid_id = 100364199 AND latitude LIKE '%39.8097%'" );
         if ( empty( $is_v2 ) ) {
             global $wpdb;
             // drop tables
-            $wpdb->dt_location_grid = $wpdb->prefix . 'dt_location_grid';
             $wpdb->query("
                 DROP TABLE IF EXISTS `{$wpdb->prefix}dt_location_grid_upgrade`
             ");
             $wpdb->query("
-                RENAME TABLE `{$wpdb->prefix}dt_location_grid` TO `{$wpdb->prefix}dt_location_grid_upgrade`;
+                RENAME TABLE `$wpdb->dt_location_grid` TO `{$wpdb->prefix}dt_location_grid_upgrade`;
             ");
 
             // delete

--- a/dt-mapping/migrations/0015-v2-migrate-custom-locations.php
+++ b/dt-mapping/migrations/0015-v2-migrate-custom-locations.php
@@ -16,8 +16,9 @@ class DT_Mapping_Module_Migration_0015 extends DT_Mapping_Module_Migration
         global $wpdb;
         $has_upgrade_table = $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->prefix}dt_location_grid_upgrade';" );
         $location_grid_rows = (int) $wpdb->get_var( "SELECT count(*) FROM $wpdb->dt_location_grid" );
+        $location_grid_table_name = apply_filters( 'dt_location_grid_table', $wpdb->prefix . 'dt_location_grid' );
         if ( !empty( $has_upgrade_table ) && !empty( $location_grid_rows ) ) {
-            $wpdb->query( "INSERT INTO `{$wpdb->prefix}dt_location_grid` SELECT * FROM `{$wpdb->prefix}dt_location_grid_upgrade` WHERE grid_id > 1000000000;" );
+            $wpdb->query( "INSERT INTO `{$location_grid_table_name}` SELECT * FROM `{$wpdb->prefix}dt_location_grid_upgrade` WHERE grid_id > 1000000000;" );
             $wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}dt_location_grid_upgrade`;" );
         }
     }

--- a/dt-mapping/migrations/0015-v2-migrate-custom-locations.php
+++ b/dt-mapping/migrations/0015-v2-migrate-custom-locations.php
@@ -3,6 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly
 
 /**
  * Class DT_Mapping_Module_Migration_0015
+ * 2nd step: copy custom data back to location grid table
  *
  * @version_added 1.30.2
  */
@@ -13,6 +14,10 @@ class DT_Mapping_Module_Migration_0015 extends DT_Mapping_Module_Migration
      * @throws \Exception  Got error when creating table $name.
      */
     public function up() {
+        if ( version_compare( dt_get_initial_install_meta( 'theme_version' ), '1.31.0', '>=' ) ){
+            return;
+        }
+
         global $wpdb;
         $has_upgrade_table = $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->prefix}dt_location_grid_upgrade';" );
         $location_grid_rows = (int) $wpdb->get_var( "SELECT count(*) FROM $wpdb->dt_location_grid" );

--- a/dt-mapping/migrations/0015-v2-migrate-custom-locations.php
+++ b/dt-mapping/migrations/0015-v2-migrate-custom-locations.php
@@ -16,9 +16,8 @@ class DT_Mapping_Module_Migration_0015 extends DT_Mapping_Module_Migration
         global $wpdb;
         $has_upgrade_table = $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->prefix}dt_location_grid_upgrade';" );
         $location_grid_rows = (int) $wpdb->get_var( "SELECT count(*) FROM $wpdb->dt_location_grid" );
-        $location_grid_table_name = apply_filters( 'dt_location_grid_table', $wpdb->prefix . 'dt_location_grid' );
         if ( !empty( $has_upgrade_table ) && !empty( $location_grid_rows ) ) {
-            $wpdb->query( "INSERT INTO `{$location_grid_table_name}` SELECT * FROM `{$wpdb->prefix}dt_location_grid_upgrade` WHERE grid_id > 1000000000;" );
+            $wpdb->query( "INSERT INTO $wpdb->dt_location_grid SELECT * FROM `{$wpdb->prefix}dt_location_grid_upgrade` WHERE grid_id > 1000000000;" );
             $wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}dt_location_grid_upgrade`;" );
         }
     }

--- a/dt-mapping/migrations/0016-restore-table.php
+++ b/dt-mapping/migrations/0016-restore-table.php
@@ -13,6 +13,9 @@ class DT_Mapping_Module_Migration_0016 extends DT_Mapping_Module_Migration
      * @throws \Exception  Got error when creating table $name.
      */
     public function up() {
+        if ( version_compare( dt_get_initial_install_meta( 'theme_version' ), '1.31.0', '>=' ) ){
+            return;
+        }
         global $wpdb;
         $location_grid_rows = (int) $wpdb->get_var( "SELECT count(*) FROM $wpdb->dt_location_grid WHERE grid_id < 1000000000;" );
         if ( empty( $location_grid_rows ) ) {

--- a/dt-mapping/migrations/0018-check-east-west.php
+++ b/dt-mapping/migrations/0018-check-east-west.php
@@ -11,6 +11,9 @@ class DT_Mapping_Module_Migration_0018 extends DT_Mapping_Module_Migration {
      * @throws \Exception  Got error when creating table $name.
      */
     public function up() {
+        if ( version_compare( dt_get_initial_install_meta( 'theme_version' ), '1.67.0', '>=' ) ){
+            return;
+        }
         global $wpdb;
 
         $count = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->dt_location_grid WHERE east_longitude < west_longitude" );

--- a/dt-mapping/migrations/0018-check-east-west.php
+++ b/dt-mapping/migrations/0018-check-east-west.php
@@ -13,7 +13,7 @@ class DT_Mapping_Module_Migration_0018 extends DT_Mapping_Module_Migration {
     public function up() {
         global $wpdb;
         if ( ! isset( $wpdb->dt_location_grid ) ) {
-            $wpdb->dt_location_grid = $wpdb->prefix . 'dt_location_grid';
+            $wpdb->dt_location_grid = apply_filters( 'dt_location_grid_table', $wpdb->prefix . 'dt_location_grid' );
         }
 
         $count = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->dt_location_grid WHERE east_longitude < west_longitude" );

--- a/dt-mapping/migrations/0018-check-east-west.php
+++ b/dt-mapping/migrations/0018-check-east-west.php
@@ -12,9 +12,6 @@ class DT_Mapping_Module_Migration_0018 extends DT_Mapping_Module_Migration {
      */
     public function up() {
         global $wpdb;
-        if ( ! isset( $wpdb->dt_location_grid ) ) {
-            $wpdb->dt_location_grid = apply_filters( 'dt_location_grid_table', $wpdb->prefix . 'dt_location_grid' );
-        }
 
         $count = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->dt_location_grid WHERE east_longitude < west_longitude" );
         if ( !empty( $count ) ) {

--- a/dt-mapping/migrations/0019-level-is-null.php
+++ b/dt-mapping/migrations/0019-level-is-null.php
@@ -13,7 +13,7 @@ class DT_Mapping_Module_Migration_0019 extends DT_Mapping_Module_Migration {
     public function up() {
         global $wpdb;
         if ( ! isset( $wpdb->dt_location_grid ) ) {
-            $wpdb->dt_location_grid = $wpdb->prefix . 'dt_location_grid';
+            $wpdb->dt_location_grid = apply_filters( 'dt_location_grid_table', $wpdb->prefix . 'dt_location_grid' );
         }
 
         $wpdb->query( "UPDATE $wpdb->dt_location_grid SET level = '0' WHERE level is NULL AND level_name = 'admin0'" );

--- a/dt-mapping/migrations/0019-level-is-null.php
+++ b/dt-mapping/migrations/0019-level-is-null.php
@@ -12,9 +12,6 @@ class DT_Mapping_Module_Migration_0019 extends DT_Mapping_Module_Migration {
      */
     public function up() {
         global $wpdb;
-        if ( ! isset( $wpdb->dt_location_grid ) ) {
-            $wpdb->dt_location_grid = apply_filters( 'dt_location_grid_table', $wpdb->prefix . 'dt_location_grid' );
-        }
 
         $wpdb->query( "UPDATE $wpdb->dt_location_grid SET level = '0' WHERE level is NULL AND level_name = 'admin0'" );
     }

--- a/dt-mapping/migrations/0019-level-is-null.php
+++ b/dt-mapping/migrations/0019-level-is-null.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly
 
 /**
  * Class DT_Mapping_Module_Migration_0017
- * checks east and west are installed correctly
+ * make sure level is 0 instead of null
  */
 class DT_Mapping_Module_Migration_0019 extends DT_Mapping_Module_Migration {
 

--- a/functions.php
+++ b/functions.php
@@ -595,7 +595,7 @@ if ( version_compare( phpversion(), '7.4', '<' ) ) {
         $wpdb->dt_notifications = $wpdb->prefix . 'dt_notifications';
         $wpdb->dt_notifications_queue = $wpdb->prefix . 'dt_notifications_queue';
         $wpdb->dt_post_user_meta = $wpdb->prefix . 'dt_post_user_meta';
-        $wpdb->dt_location_grid = $wpdb->prefix . 'dt_location_grid';
+        $wpdb->dt_location_grid = apply_filters( 'dt_location_grid_table', $wpdb->prefix . 'dt_location_grid' );
         $wpdb->dt_location_grid_meta = $wpdb->prefix . 'dt_location_grid_meta';
 
         $more_tables = apply_filters( 'dt_custom_tables', [] );


### PR DESCRIPTION
Add this to a mu-plugin:
```
add_filter( 'dt_location_grid_table', function ( $table_name ){
    global $wpdb;
    return $wpdb->base_prefix . 'location_grid';
} );
add_filter( 'dt_using_multisite_location_grid_table', '__return_true' );
```
and save 10 to 15MB per subsite by only using one location grid table

To get an sql statement to drop all the location_grid tables:
```
SELECT CONCAT( 'DROP TABLE ', GROUP_CONCAT(table_name) , ';' ) 
    AS statement FROM information_schema.tables 
    WHERE table_name LIKE '%dt_location_grid';
```