### PR TITLE
Fix saving enabled and disable modules.

### DIFF
--- a/dt-core/admin/admin-settings-endpoints.php
+++ b/dt-core/admin/admin-settings-endpoints.php
@@ -258,12 +258,13 @@ class Disciple_Tools_Admin_Settings_Endpoints {
         $modules_to_update = $request->get_param( 'modules' );
         $modules_to_update = dt_recursive_sanitize_array( $modules_to_update );
 
-        $modules = dt_get_option( $modules_option_name );
+        $modules = get_option( $modules_option_name );
 
-        foreach ( $modules as $key => $module ) {
-            if ( array_key_exists( $key, $modules_to_update ) ) {
-                $modules[$key]['enabled'] = !empty( $modules_to_update[$key] ) ? true : false;
+        foreach ( $modules_to_update as $key => $enabled ){
+            if ( !isset( $modules[$key] ) ){
+                $modules[$key] = [];
             }
+            $modules[$key]['enabled'] = !empty( $enabled );
         }
 
         update_option( $modules_option_name, $modules );


### PR DESCRIPTION
Previously it was getting the full modules details (name, description, etc) and saving it to the option.
We only want the 'enabled' param to be saved to the options.

We want the code to be driving the module descriptions and name instead of it coming from the options table.