### PR TITLE
Allow fetching magic link lang from request header

### DIFF
--- a/dt-reports/magic-url-base.php
+++ b/dt-reports/magic-url-base.php
@@ -140,6 +140,16 @@ abstract class DT_Magic_Url_Base {
         return '';
     }
 
+    public function fetch_incoming_browser_lang() {
+        $lang_header = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
+        if ( !empty( $lang_header ) ) {
+            $lang_parts = explode( ',', $lang_header );
+            if ( count( $lang_parts ) > 0 ) {
+                return str_replace( '-', '_', $lang_parts[0] );
+            }
+        }
+    }
+
     /**
      * Determine language locale to be adopted; based on translatable flags
      *
@@ -164,6 +174,9 @@ abstract class DT_Magic_Url_Base {
                         break;
                     case 'contact':
                         $lang = $this->fetch_incoming_contact_lang( $parts );
+                        break;
+                    case 'browser':
+                        $lang = $this->fetch_incoming_browser_lang();
                         break;
                 }
                 $flag_satisfied = ! empty( $lang );

--- a/dt-reports/magic-url-base.php
+++ b/dt-reports/magic-url-base.php
@@ -141,13 +141,14 @@ abstract class DT_Magic_Url_Base {
     }
 
     public function fetch_incoming_browser_lang() {
-        $lang_header = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
-        if ( !empty( $lang_header ) ) {
+        if ( isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) && !empty( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) {
+            $lang_header = sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) );
             $lang_parts = explode( ',', $lang_header );
             if ( count( $lang_parts ) > 0 ) {
                 return str_replace( '-', '_', $lang_parts[0] );
             }
         }
+        return '';
     }
 
     /**


### PR DESCRIPTION
Magic links can currently pull the locale from query, contact, or user. This adds another option to pull from the `HTTP_ACCEPT_LANGUAGE` [request header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept-Language) which indicates the user's browser language and thus their preferred language.

Since the base class looks at the `translatable` array for which locations to look for the locale, this is completely an opt-in value and shouldn't affect any existing magic links.