### PR TITLE
Replace lodash functions with ES6 equivalents in settings.js

### DIFF
--- a/dt-assets/js/settings.js
+++ b/dt-assets/js/settings.js
@@ -262,7 +262,6 @@ jQuery('#add_unavailable_dates').on('click', function () {
 let display_dates_unavailable = (list = [], first_run) => {
   let date_unavailable_table = jQuery('#unavailable-list');
   let rows = ``;
-  // Sort the list by start_date in descending order using native JavaScript sort
   list = [...list].sort((a, b) => {
     return new Date(b.start_date) - new Date(a.start_date);
   });
@@ -298,7 +297,6 @@ let color_workload_buttons = (name) => {
   if (name) {
     let selected = jQuery(`.status-button[name=${name}]`);
     selected.removeClass('hollow');
-    // Use optional chaining and nullish coalescing instead of lodash.get
     const color =
       window.wpApiSettingsPage?.workload_status_options?.[name]?.color ?? '';
     selected.css('background-color', color);

--- a/dt-assets/js/settings.js
+++ b/dt-assets/js/settings.js
@@ -299,7 +299,8 @@ let color_workload_buttons = (name) => {
     let selected = jQuery(`.status-button[name=${name}]`);
     selected.removeClass('hollow');
     // Use optional chaining and nullish coalescing instead of lodash.get
-    const color = window.wpApiSettingsPage?.workload_status_options?.[name]?.color ?? '';
+    const color =
+      window.wpApiSettingsPage?.workload_status_options?.[name]?.color ?? '';
     selected.css('background-color', color);
     selected.blur();
   }

--- a/dt-assets/js/settings.js
+++ b/dt-assets/js/settings.js
@@ -262,7 +262,10 @@ jQuery('#add_unavailable_dates').on('click', function () {
 let display_dates_unavailable = (list = [], first_run) => {
   let date_unavailable_table = jQuery('#unavailable-list');
   let rows = ``;
-  list = window.lodash.orderBy(list, ['start_date'], 'desc');
+  // Sort the list by start_date in descending order using native JavaScript sort
+  list = [...list].sort((a, b) => {
+    return new Date(b.start_date) - new Date(a.start_date);
+  });
   list.forEach((range) => {
     rows += `<tr>
         <td>${window.SHAREDFUNCTIONS.escapeHTML(range.start_date)}</td>
@@ -295,13 +298,9 @@ let color_workload_buttons = (name) => {
   if (name) {
     let selected = jQuery(`.status-button[name=${name}]`);
     selected.removeClass('hollow');
-    selected.css(
-      'background-color',
-      window.lodash.get(
-        window.wpApiSettingsPage,
-        `workload_status_options.${name}.color`,
-      ),
-    );
+    // Use optional chaining and nullish coalescing instead of lodash.get
+    const color = window.wpApiSettingsPage?.workload_status_options?.[name]?.color ?? '';
+    selected.css('background-color', color);
     selected.blur();
   }
 };


### PR DESCRIPTION
## Description
This PR replaces lodash functions with ES6 equivalents in the settings.js file:

- Replace `lodash.orderBy` with native JavaScript sort
- Replace `lodash.get` with optional chaining and nullish coalescing operators

Fixes #2398

## Related Issues
Resolves #2398
Part of the larger effort in #2361 to replace lodash functions with vanilla JS/ES6 functions