### PR TITLE
#2587 - Display All Metric User Key Select Options

### DIFF
--- a/dt-metrics/counters/counter-post-stats.php
+++ b/dt-metrics/counters/counter-post-stats.php
@@ -218,7 +218,9 @@ class DT_Counter_Post_Stats extends Disciple_Tools_Counter_Base
                                 ORDER BY all_combinations.time_unit ASC, all_combinations.selection
                             ";
 
+                    // phpcs:disable
                     $added_post_changes = $wpdb->get_results( $wpdb->remove_placeholder_escape( $wpdb->prepare( $sql_query, ...$prepare_values ) ) );
+                    // phpcs:enable
                 }
 
                 break;

--- a/dt-metrics/counters/counter-post-stats.php
+++ b/dt-metrics/counters/counter-post-stats.php
@@ -170,8 +170,8 @@ class DT_Counter_Post_Stats extends Disciple_Tools_Counter_Base
                         [ $time_unit_sql, $post_type, $field, $field, $field_type, $start, $end ]
                     );
 
-                    $added_post_changes = $wpdb->get_results( $wpdb->remove_placeholder_escape( $wpdb->prepare(
-                        "
+                    // Build the complete SQL query string
+                    $sql_query = "
                                 SELECT
                                     all_combinations.time_unit,
                                     all_combinations.selection,
@@ -216,8 +216,9 @@ class DT_Counter_Post_Stats extends Disciple_Tools_Counter_Base
                                     GROUP BY posts.selection, posts.time_unit
                                 ) data ON all_combinations.time_unit = data.time_unit AND all_combinations.selection = data.selection
                                 ORDER BY all_combinations.time_unit ASC, all_combinations.selection
-                            ", ...$prepare_values
-                    ) ) );
+                            ";
+
+                    $added_post_changes = $wpdb->get_results( $wpdb->remove_placeholder_escape( $wpdb->prepare( $sql_query, ...$prepare_values ) ) );
                 }
 
                 break;

--- a/dt-metrics/counters/counter-post-stats.php
+++ b/dt-metrics/counters/counter-post-stats.php
@@ -186,7 +186,7 @@ class DT_Counter_Post_Stats extends Disciple_Tools_Counter_Base
                                     CROSS JOIN (
                                         SELECT selection FROM (
                                             SELECT %s AS selection
-                                            " . str_repeat( " UNION ALL SELECT %s", count( $all_key_values ) - 1 ) . "
+                                            " . str_repeat( ' UNION ALL SELECT %s', count( $all_key_values ) - 1 ) . " -- phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
                                         ) all_vals
                                     ) all_selections
                                 ) all_combinations

--- a/dt-metrics/counters/counter-post-stats.php
+++ b/dt-metrics/counters/counter-post-stats.php
@@ -157,8 +157,12 @@ class DT_Counter_Post_Stats extends Disciple_Tools_Counter_Base
                             ", $time_unit_sql, $post_type, $field, $field, $field_type, $start, $end
                     ) ) );
                 } else {
-                    // Build query using the actual key_select values to ensure all options are included
-                    $value_placeholders = implode( ',', array_fill( 0, count( $all_key_values ), '%s' ) );
+                    // Build UNION query for all key_select values
+                    $union_parts = [];
+                    foreach ( $all_key_values as $value ) {
+                        $union_parts[] = 'SELECT %s AS selection';
+                    }
+                    $union_query = implode( ' UNION ALL ', $union_parts );
 
                     $prepare_values = array_merge(
                         [ $time_unit_sql, $post_type, $field, $start, $end ],
@@ -185,8 +189,7 @@ class DT_Counter_Post_Stats extends Disciple_Tools_Counter_Base
                                     ) time_units
                                     CROSS JOIN (
                                         SELECT selection FROM (
-                                            SELECT %s AS selection
-                                            " . str_repeat( ' UNION ALL SELECT %s', count( $all_key_values ) - 1 ) . " -- phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+                                            $union_query
                                         ) all_vals
                                     ) all_selections
                                 ) all_combinations

--- a/dt-metrics/records/time-charts.js
+++ b/dt-metrics/records/time-charts.js
@@ -279,24 +279,33 @@ function createCharts() {
     });
   } else {
     let keys = getDataKeys(data);
-    
+
     // For key_select fields, ensure all possible options are included in the legend
     if (fieldType === 'key_select') {
       const { field } = window.dtMetricsProject.state;
       const fieldSettings = window.dtMetricsProject.field_settings[field];
-      const defaultSettings = fieldSettings && fieldSettings.default ? fieldSettings.default : [];
-      
+      const defaultSettings =
+        fieldSettings && fieldSettings.default ? fieldSettings.default : [];
+
       if (defaultSettings && Object.keys(defaultSettings).length > 0) {
         // Get all possible option keys from field settings
         const allPossibleKeys = Object.keys(defaultSettings);
-        const allPossibleCumulativeKeys = allPossibleKeys.map(key => `${CUMULATIVE_PREFIX}${key}`);
-        
+        const allPossibleCumulativeKeys = allPossibleKeys.map(
+          (key) => `${CUMULATIVE_PREFIX}${key}`,
+        );
+
         // Merge with existing keys to ensure we don't lose any that might have data
-        const combinedKeys = [...new Set([...keys, ...allPossibleKeys, ...allPossibleCumulativeKeys])];
+        const combinedKeys = [
+          ...new Set([
+            ...keys,
+            ...allPossibleKeys,
+            ...allPossibleCumulativeKeys,
+          ]),
+        ];
         keys = combinedKeys;
       }
     }
-    
+
     const totalKeys = keys.filter((key) => !key.includes('cumulative_'));
     const cumulativeKeys = keys.filter((key) => key.includes('cumulative_'));
     createChart('stacked-chart', cumulativeKeys);
@@ -565,7 +574,7 @@ function initialiseChart(id) {
 
   const valueAxis = chart.yAxes.push(new window.am4charts.ValueAxis());
   valueAxis.maxPrecision = 0;
-  
+
   // Ensure the Y-axis starts from 0 to properly show zero values
   valueAxis.min = 0;
   valueAxis.strictMinMax = false;
@@ -618,11 +627,11 @@ function createColumnSeries(chart, field, name, hidden = false) {
   series.dataFields.categoryX = chart_view;
   series.name = name;
   series.columns.template.tooltipText = `[#fff font-size: 12px]${tooltipLabel}:\n[/][#fff font-size: 15px]{valueY}[/] [#fff]{additional}[/]`;
-  
+
   // Ensure zero values are included in the chart
   series.includeZeroValues = true;
   series.baseValue = 0;
-  
+
   if (hidden) {
     series.hide();
   }
@@ -1288,13 +1297,14 @@ function formatCompoundYearData(yearlyData) {
   if (yearlyData.length === 0) return yearlyData;
 
   let keys = getDataKeys(yearlyData);
-  
+
   // For key_select fields, ensure all possible options are included
   const { fieldType, field } = window.dtMetricsProject.state;
   if (fieldType === 'key_select') {
     const fieldSettings = window.dtMetricsProject.field_settings[field];
-    const defaultSettings = fieldSettings && fieldSettings.default ? fieldSettings.default : [];
-    
+    const defaultSettings =
+      fieldSettings && fieldSettings.default ? fieldSettings.default : [];
+
     if (defaultSettings && Object.keys(defaultSettings).length > 0) {
       const allPossibleKeys = Object.keys(defaultSettings);
       keys = [...new Set([...keys, ...allPossibleKeys])];
@@ -1310,13 +1320,12 @@ function formatCompoundYearData(yearlyData) {
   const formattedYearlyData = [];
   let i = 0;
   for (let year = minYear; year < maxYear + 1; year++, i++) {
-    const yearData = yearlyData.find(
-      (data) => String(data.year) === String(year),
-    ) || {};
+    const yearData =
+      yearlyData.find((data) => String(data.year) === String(year)) || {};
 
     // Initialize missing keys with 0 for key_select fields
     if (fieldType === 'key_select') {
-      keys.forEach(key => {
+      keys.forEach((key) => {
         if (!(key in yearData)) {
           yearData[key] = 0;
         }
@@ -1395,13 +1404,14 @@ function formatSimpleMonthData(monthlyData) {
 function formatCompoundMonthData(monthlyData) {
   const monthLabels = window.SHAREDFUNCTIONS.get_months_labels();
   let keys = getDataKeys(monthlyData);
-  
+
   // For key_select fields, ensure all possible options are included
   const { fieldType, field } = window.dtMetricsProject.state;
   if (fieldType === 'key_select') {
     const fieldSettings = window.dtMetricsProject.field_settings[field];
-    const defaultSettings = fieldSettings && fieldSettings.default ? fieldSettings.default : [];
-    
+    const defaultSettings =
+      fieldSettings && fieldSettings.default ? fieldSettings.default : [];
+
     if (defaultSettings && Object.keys(defaultSettings).length > 0) {
       const allPossibleKeys = Object.keys(defaultSettings);
       keys = [...new Set([...keys, ...allPossibleKeys])];
@@ -1432,16 +1442,16 @@ function formatCompoundMonthData(monthlyData) {
       monthlyData.find(
         (mData) => String(mData.month) === String(monthNumber),
       ) || {};
-    
+
     // Initialize missing keys with 0 for key_select fields
     if (fieldType === 'key_select') {
-      keys.forEach(key => {
+      keys.forEach((key) => {
         if (!(key in monthData)) {
           monthData[key] = 0;
         }
       });
     }
-    
+
     cumulativeTotals = calculateCumulativeTotals(
       keys,
       monthData,

--- a/dt-metrics/records/time-charts.js
+++ b/dt-metrics/records/time-charts.js
@@ -278,7 +278,25 @@ function createCharts() {
       graphType: 'line',
     });
   } else {
-    const keys = getDataKeys(data);
+    let keys = getDataKeys(data);
+    
+    // For key_select fields, ensure all possible options are included in the legend
+    if (fieldType === 'key_select') {
+      const { field } = window.dtMetricsProject.state;
+      const fieldSettings = window.dtMetricsProject.field_settings[field];
+      const defaultSettings = fieldSettings && fieldSettings.default ? fieldSettings.default : [];
+      
+      if (defaultSettings && Object.keys(defaultSettings).length > 0) {
+        // Get all possible option keys from field settings
+        const allPossibleKeys = Object.keys(defaultSettings);
+        const allPossibleCumulativeKeys = allPossibleKeys.map(key => `${CUMULATIVE_PREFIX}${key}`);
+        
+        // Merge with existing keys to ensure we don't lose any that might have data
+        const combinedKeys = [...new Set([...keys, ...allPossibleKeys, ...allPossibleCumulativeKeys])];
+        keys = combinedKeys;
+      }
+    }
+    
     const totalKeys = keys.filter((key) => !key.includes('cumulative_'));
     const cumulativeKeys = keys.filter((key) => key.includes('cumulative_'));
     createChart('stacked-chart', cumulativeKeys);
@@ -547,6 +565,10 @@ function initialiseChart(id) {
 
   const valueAxis = chart.yAxes.push(new window.am4charts.ValueAxis());
   valueAxis.maxPrecision = 0;
+  
+  // Ensure the Y-axis starts from 0 to properly show zero values
+  valueAxis.min = 0;
+  valueAxis.strictMinMax = false;
 
   // Adjust data shape accordingly based on field type.
   switch (field_type) {
@@ -596,6 +618,11 @@ function createColumnSeries(chart, field, name, hidden = false) {
   series.dataFields.categoryX = chart_view;
   series.name = name;
   series.columns.template.tooltipText = `[#fff font-size: 12px]${tooltipLabel}:\n[/][#fff font-size: 15px]{valueY}[/] [#fff]{additional}[/]`;
+  
+  // Ensure zero values are included in the chart
+  series.includeZeroValues = true;
+  series.baseValue = 0;
+  
   if (hidden) {
     series.hide();
   }
@@ -642,6 +669,10 @@ function createLineSeries(chart, field, name, hidden = false) {
   lineSeries.name = name;
   lineSeries.dataFields.valueY = field;
   lineSeries.dataFields.categoryX = chart_view;
+
+  // Ensure zero values are included in the chart
+  lineSeries.includeZeroValues = true;
+  lineSeries.baseValue = 0;
 
   if (
     (field_type === 'connection' && field === 'disconnected') ||
@@ -1256,7 +1287,19 @@ function formatSimpleYearData(yearlyData) {
 function formatCompoundYearData(yearlyData) {
   if (yearlyData.length === 0) return yearlyData;
 
-  const keys = getDataKeys(yearlyData);
+  let keys = getDataKeys(yearlyData);
+  
+  // For key_select fields, ensure all possible options are included
+  const { fieldType, field } = window.dtMetricsProject.state;
+  if (fieldType === 'key_select') {
+    const fieldSettings = window.dtMetricsProject.field_settings[field];
+    const defaultSettings = fieldSettings && fieldSettings.default ? fieldSettings.default : [];
+    
+    if (defaultSettings && Object.keys(defaultSettings).length > 0) {
+      const allPossibleKeys = Object.keys(defaultSettings);
+      keys = [...new Set([...keys, ...allPossibleKeys])];
+    }
+  }
 
   let cumulativeTotals = {};
   const cumulativeKeys = makeCumulativeKeys(keys);
@@ -1269,7 +1312,16 @@ function formatCompoundYearData(yearlyData) {
   for (let year = minYear; year < maxYear + 1; year++, i++) {
     const yearData = yearlyData.find(
       (data) => String(data.year) === String(year),
-    );
+    ) || {};
+
+    // Initialize missing keys with 0 for key_select fields
+    if (fieldType === 'key_select') {
+      keys.forEach(key => {
+        if (!(key in yearData)) {
+          yearData[key] = 0;
+        }
+      });
+    }
 
     cumulativeTotals = calculateCumulativeTotals(
       keys,
@@ -1342,7 +1394,19 @@ function formatSimpleMonthData(monthlyData) {
 
 function formatCompoundMonthData(monthlyData) {
   const monthLabels = window.SHAREDFUNCTIONS.get_months_labels();
-  const keys = getDataKeys(monthlyData);
+  let keys = getDataKeys(monthlyData);
+  
+  // For key_select fields, ensure all possible options are included
+  const { fieldType, field } = window.dtMetricsProject.state;
+  if (fieldType === 'key_select') {
+    const fieldSettings = window.dtMetricsProject.field_settings[field];
+    const defaultSettings = fieldSettings && fieldSettings.default ? fieldSettings.default : [];
+    
+    if (defaultSettings && Object.keys(defaultSettings).length > 0) {
+      const allPossibleKeys = Object.keys(defaultSettings);
+      keys = [...new Set([...keys, ...allPossibleKeys])];
+    }
+  }
 
   const cumulative_offsets = window.dtMetricsProject.cumulative_offset;
   let cumulativeTotals = {};
@@ -1368,6 +1432,16 @@ function formatCompoundMonthData(monthlyData) {
       monthlyData.find(
         (mData) => String(mData.month) === String(monthNumber),
       ) || {};
+    
+    // Initialize missing keys with 0 for key_select fields
+    if (fieldType === 'key_select') {
+      keys.forEach(key => {
+        if (!(key in monthData)) {
+          monthData[key] = 0;
+        }
+      });
+    }
+    
     cumulativeTotals = calculateCumulativeTotals(
       keys,
       monthData,
@@ -1406,10 +1480,9 @@ function calculateCumulativeTotals(
     const count =
       typeof data !== 'undefined' && data[key] ? parseInt(data[key]) : 0;
     const cumulativeKey = cumulativeKeys[key];
-    if (!cumulativeTotals[cumulativeKey] && count > 0) {
+    if (!cumulativeTotals[cumulativeKey]) {
       cumulativeTotals[cumulativeKey] = count;
-      return;
-    } else if (cumulativeTotals[cumulativeKey] && count > 0) {
+    } else {
       cumulativeTotals[cumulativeKey] = cumulativeTotals[cumulativeKey] + count;
     }
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3402,9 +3402,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001689",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001689.tgz",
-      "integrity": "sha512-CmeR2VBycfa+5/jOfnp/NpWPGd06nf1XYiefUvhXFfZE4GkRc9jv+eGPS4nT558WS/8lYCzV8SlANCIPvbWP1g==",
+      "version": "1.0.30001723",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001723.tgz",
+      "integrity": "sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
- fixes: #2587 
---

All Key Select options are now displayed, even if newly created, with no value.

![Screenshot 2025-06-18 at 10 54 14](https://github.com/user-attachments/assets/c9b04e6c-70c0-4bf9-8d0d-bd465ec193e8)

![Screenshot 2025-06-18 at 13 02 52](https://github.com/user-attachments/assets/e4e2c39a-7ff0-4d28-afdb-78b20a23de09)

![Screenshot 2025-06-18 at 13 03 12](https://github.com/user-attachments/assets/7c802511-cc0d-4a5e-8a95-6954898925a9)
