### PR TITLE
Refactor dt_excerpt_more to remove global $post usage

### DIFF
--- a/dt-assets/functions/cleanup.php
+++ b/dt-assets/functions/cleanup.php
@@ -24,9 +24,6 @@ function dt_start() {
     // Clean up gallery output in wp
     add_filter( 'gallery_style', 'dt_gallery_style' );
 
-    // Cleaning up excerpt
-    add_filter( 'excerpt_more', 'dt_excerpt_more' );
-
     // Removes WP sticky class in favor or foundations sticky class
     add_filter( 'post_class', 'dt_remove_sticky_class' );
 
@@ -74,18 +71,6 @@ function dt_gallery_style( $css ) {
     return preg_replace( "!<style type='text/css'>(.*?)</style>!s", '', $css );
 }
 
-/**
- * This removes the annoying […] to a Read More link
- *
- * @param $more
- *
- * @return string
- */
-function dt_excerpt_more( $more ) {
-    $post_id = get_the_ID();
-    $title = get_the_title( $post_id );
-    return '<a class="excerpt-read-more" href="' . get_permalink( $post_id ) . '" title="Read ' . esc_html( $title ) . '"> ... Read more &raquo; </a>';
-}
 
 /**
  * Stop WordPress from using the sticky class (which conflicts with Foundation), and style WordPress sticky posts using the .wp-sticky class instead


### PR DESCRIPTION
Updated the dt_excerpt_more function to use get_the_ID() and get_the_title() instead of relying on the global $post variable. This improves code clarity and reduces dependency on global state.

Fixes bug found in the excerpt for the prayer campaign repo