### PR TITLE
Users in contacts list

### DIFF
--- a/dt-contacts/base-setup.php
+++ b/dt-contacts/base-setup.php
@@ -679,7 +679,23 @@ class DT_Contacts_Base {
                     ]
                 ],
                 'query' => [
+                    'type' => [ '-user' ],
                     'sort' => '-post_date',
+                ],
+            ];
+            $filters['filters'][] = [
+                'ID' => 'users',
+                'tab' => 'default',
+                'name' => sprintf( __( 'Users', 'disciple_tools' ), $post_label_plural ),
+                'labels' =>[
+                    [
+                        'id' => 'users',
+                        'name' => sprintf( __( 'Users', 'disciple_tools' ), $post_label_plural ),
+                    ]
+                ],
+                'query' => [
+                    'type' => [ 'user' ],
+                    'sort' => 'name'
                 ],
             ];
 

--- a/dt-contacts/module-access.php
+++ b/dt-contacts/module-access.php
@@ -859,7 +859,6 @@ class DT_Contacts_Access extends DT_Module_Base {
                             [ 'name' => __( 'Sub-assigned to me', 'disciple_tools' ), 'field' => 'subassigned', 'id' => 'me' ],
                         ],
                         'count' => $status_counts[$status_key] ?? '',
-                        'subfilter' => 1
                     ];
                     if ( $status_key === 'active' ){
                         if ( ( $update_needed ?? 0 ) > 0 ){

--- a/dt-contacts/module-coaching.php
+++ b/dt-contacts/module-coaching.php
@@ -35,7 +35,6 @@ class DT_Contacts_Coaching extends DT_Module_Base {
 
         //hooks
         add_action( 'post_connection_added', [ $this, 'post_connection_added' ], 10, 4 );
-        add_filter( 'dt_post_create_fields', [ $this, 'dt_post_create_fields' ], 10, 2 );
 
         //list
         add_filter( 'dt_user_list_filters', [ $this, 'dt_user_list_filters' ], 10, 2 );
@@ -76,20 +75,6 @@ class DT_Contacts_Coaching extends DT_Module_Base {
                 }
             }
         }
-    }
-
-    //Add, remove or modify fields before the fields are processed in post create
-    public function dt_post_create_fields( $fields, $post_type ){
-        if ( $post_type === 'contacts' ){
-            //mark a new user contact as being coached be the user who added the new user.
-            if ( isset( $fields['type'] ) && $fields['type'] === 'user' ){
-                $current_user_contact = Disciple_Tools_Users::get_contact_for_user( get_current_user_id() );
-                if ( $current_user_contact && !is_wp_error( $current_user_contact ) ){
-                    $fields['coached_by'] = [ 'values' => [ [ 'value' => $current_user_contact ] ] ];
-                }
-            }
-        }
-        return $fields;
     }
 
 


### PR DESCRIPTION
Disable this: When in adding a new user, the new user contact record would automatically be marked as coached by the user who invited them. This ins't always accurate or wanted. Better place for a workflow.

Filters:

Add new "users" line to the filters list.

By default the All contacts doesn't show users:

<img width="803" height="567" alt="image" src="https://github.com/user-attachments/assets/405bcbbf-b40f-4554-aec3-c70ea824d307" />

Users will be show in the the Users filter.

<img width="805" height="565" alt="image" src="https://github.com/user-attachments/assets/12b1feb1-3867-447b-8da0-db99f53ba949" />

The rest of the filters don't exclude or include users specifically. 


Fixes https://github.com/DiscipleTools/disciple-tools-theme/issues/2348
Fixes https://github.com/DiscipleTools/disciple-tools-theme/issues/2767

