### PR TITLE
fix connection AddNew error

### DIFF
--- a/dt-assets/js/details.js
+++ b/dt-assets/js/details.js
@@ -548,6 +548,10 @@ jQuery(document).ready(function ($) {
       $('.js-create-record-button')
         .attr('disabled', false)
         .removeClass('alert');
+      $('.button-cancel').on('click', function () {
+        document.querySelector(`#${e.detail.field}`).value =
+          e.detail.newValue.filter((y) => !y.isNew);
+      });
       $('.reveal-after-record-create').hide();
       $('.hide-after-record-create').show();
       $('.js-create-record input[name=title]').val(newPost.label);


### PR DESCRIPTION
@cairocoder01 fixed bug when creating new connection in a connection field. If the window is closed/cancelled before creating the record, the value would still be stored in the newValue array, which would cause the Create popup to appear after any action on the field.