### PR TITLE
Add cache buster function for magic links

### DIFF
--- a/dt-reports/magic-url-base.php
+++ b/dt-reports/magic-url-base.php
@@ -458,4 +458,21 @@ abstract class DT_Magic_Url_Base {
         }
         return $apps_list;
     }
+
+    /**
+     * Sets a cookie to prevent caching of the page by WPEngine
+     */
+    public function prevent_page_caching() {
+        // Problem: WPEngine caches pages heavily if users aren't logged in.
+        //   They don't provide any programmatic way to exclude pages from caching besides contacting
+        //   support to set up exclusions.
+        // See https://wpengine.com/support/cache/#Cache_Exclusions
+        // Solution: They exclude pages that have a cookie starting with wordress_
+        //   presumably to prevent caching when a user is logged in and a user cookie is set.
+        //   This hacks on that exception a little to set a random cookie starting with wordpress_
+        //   so that the magic link doesn't get cached.
+        if ( ! isset( $_COOKIE['wordpress_skipwpecache'] ) ) {
+            setcookie( 'wordpress_skipwpecache', '1', time() + WEEK_IN_SECONDS );
+        }
+    }
 }


### PR DESCRIPTION
Problem: 
WPEngine caches pages heavily if users aren't logged in. They don't provide any programmatic way to exclude pages from caching besides contacting support to set up exclusions.

See https://wpengine.com/support/cache/#Cache_Exclusions

Solution: 
They exclude pages that have a cookie starting with wordress_ presumably to prevent caching when a user is logged in and a user cookie is set. This hacks on that exception a little to set a random cookie starting with wordpress_ so that the magic link doesn't get cached.

I have tested this on a live site hosted on WPE and found it to prevent the caching I was seeing of magic link templates.

This just provides a function that individual magic links can choose to utilize if they want to prevent caching. So this doesn't immediately affect all magic links unless they use this utility method. A separate PR on the magic link plugin will do that for those magic links.