### PR TITLE
Convert base user field to typeahead for better scalability

### DIFF
--- a/dt-core/admin/menu/tabs/tab-general.php
+++ b/dt-core/admin/menu/tabs/tab-general.php
@@ -351,7 +351,7 @@ class Disciple_Tools_General_Tab extends Disciple_Tools_Abstract_Menu_Base
     public function process_base_user() {
         if ( isset( $_POST['base_user_nonce'] ) && wp_verify_nonce( sanitize_key( wp_unslash( $_POST['base_user_nonce'] ) ), 'base_user' ) ) {
             if ( isset( $_POST['base_user_select'] ) ) {
-                $base_user_data = wp_unslash( $_POST['base_user_select'] );
+                $base_user_data = sanitize_text_field( wp_unslash( $_POST['base_user_select'] ) );
                 // dt-users-connection component returns JSON string
                 if ( is_string( $base_user_data ) ) {
                     $user_id = $this->parse_user_selection_json( $base_user_data );


### PR DESCRIPTION
## Summary
- Replace simple select dropdown with dt-users-connection web component
- Remove hardcoded 200 user limit
- Support systems with thousands of users

## Changes
- Updated `dt-core/admin/menu/tabs/tab-general.php` to use typeahead component
- Modified data processing to handle JSON format from web component
- Applied to both main base user and source-specific assignments

Fixes #2526

🤖 Generated with [Claude Code](https://claude.ai/code)