### PR TITLE
fix string concatenation of number fields in advanced charts

### DIFF
--- a/dt-metrics/records/time-charts.js
+++ b/dt-metrics/records/time-charts.js
@@ -1049,7 +1049,7 @@ function getData() {
         default: {
           window.dtMetricsProject.cumulative_offset =
             response.cumulative_offset !== undefined
-              ? response.cumulative_offset
+              ? parseInt(response.cumulative_offset)
               : 0;
           window.dtMetricsProject.data = isAllTime
             ? formatYearData(data)


### PR DESCRIPTION
In Metrics -> Project -> Advanced Charts, if you selected a number field (e.g. Member Count on Groups), the bar chart would end up showing very high values. This was a result of a string value returned from the API not being parsed as an INT and thus causing string concatenation instead of integer addition.

This parses the needed field in the API response as an INT to fix the issue.