### PR TITLE
Home app - Support for not requiring login

### DIFF
--- a/dt-apps/dt-home/assets/js/home-app.js
+++ b/dt-apps/dt-home/assets/js/home-app.js
@@ -7,7 +7,7 @@ class HomeApp {
   constructor() {
     // Check authentication before loading content
     // If user is not authenticated, they will be redirected by PHP before this JavaScript runs
-    if (jsObject.user_id === 0) {
+    if (jsObject.user_id === 0 && jsObject.require_login) {
       // This should not happen as PHP redirects unauthenticated users
       // But as a fallback, redirect to login
       const currentUrl = window.location.href;

--- a/dt-apps/dt-home/frontend/partials/launcher-bottom-nav.php
+++ b/dt-apps/dt-home/frontend/partials/launcher-bottom-nav.php
@@ -6,6 +6,7 @@
  * Only shown on app-type pages (not home screen or link-type apps).
  *
  * @var array $apps Array of all apps for the apps selector
+ * @var int $user_id The current user ID based on the magic link key
  * @var bool $is_wrapper_context Optional. If true, uses wrapper-specific class names to avoid conflicts.
  */
 
@@ -46,7 +47,7 @@ error_log( 'DT Home Launcher Nav: Filtered app-type apps: ' . count( $filtered_a
             <i class="mdi mdi-apps"></i>
             <?php esc_html_e( 'Apps', 'disciple_tools' ); ?>
         </button>
-        <a href="<?php echo esc_url( dt_home_magic_url( '' ) ); ?>" class="nav-item nav-item-home" aria-label="<?php esc_attr_e( 'Home', 'disciple_tools' ); ?>">
+        <a href="<?php echo esc_url( dt_home_magic_url( '', '', $user_id ) ); ?>" class="nav-item nav-item-home" aria-label="<?php esc_attr_e( 'Home', 'disciple_tools' ); ?>">
             <i class="mdi mdi-home"></i>
         </a>
         <a href="<?php echo esc_url( dt_home_get_logout_url() ); ?>" class="nav-item nav-item-logout" aria-label="<?php esc_attr_e( 'Log Out', 'disciple_tools' ); ?>">

--- a/dt-apps/dt-home/frontend/partials/launcher-wrapper.php
+++ b/dt-apps/dt-home/frontend/partials/launcher-wrapper.php
@@ -7,6 +7,7 @@
  *
  * @var string $target_app_url The URL of the target app (without launcher parameter)
  * @var array $apps Array of all apps for the apps selector
+ * @var int $user_id Current user ID
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -15,10 +16,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Include helper functions
 require_once get_template_directory() . '/dt-apps/dt-home/includes/class-home-helpers.php';
-
-// Get all apps for the apps selector
-$apps_manager = DT_Home_Apps::instance();
-$apps = $apps_manager->get_apps_for_user( get_current_user_id() );
 
 // Mark iframe requests so nested pages can detect they are inside the launcher
 $iframe_target_app_url = add_query_arg( 'launcher_iframe', '1', $target_app_url );

--- a/dt-apps/dt-home/includes/class-home-helpers.php
+++ b/dt-apps/dt-home/includes/class-home-helpers.php
@@ -17,15 +17,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @param string $action Optional. The action to append to the URL (e.g., 'app/{slug}', 'logout').
  * @param string $key Optional. The magic link key. If not provided, uses current user's key.
+ * @param int|null $user_id Optional. The user ID. Defaults to current user.
  * @return string The generated magic URL.
  */
-function dt_home_magic_url( $action = '', $key = '' ) {
+function dt_home_magic_url( $action = '', $key = '', $user_id = null ) {
     // Get the home screen app instance
     $home_app = DT_Home_Magic_Link_App::instance();
 
     if ( ! $key ) {
         // Get current user's magic link key
-        $user_id = get_current_user_id();
+        $user_id = $user_id ?? get_current_user_id();
         if ( ! $user_id ) {
             return '';
         }

--- a/dt-apps/dt-home/magic-link-home-app.php
+++ b/dt-apps/dt-home/magic-link-home-app.php
@@ -230,6 +230,7 @@ class DT_Home_Magic_Link_App extends DT_Magic_Url_Base {
                 'nonce'                   => wp_create_nonce( 'wp_rest' ),
                 'parts'                   => $this->parts,
                 'user_id'                 => get_current_user_id(),
+                'require_login'           => function_exists( 'homescreen_require_login' ) ? homescreen_require_login() : true,
                 'invite_enabled'          => function_exists( 'homescreen_invite_users_enabled' ) ? homescreen_invite_users_enabled() : false,
                 'translations'            => [
                     'welcome' => __( 'Welcome to your Home Screen', 'disciple_tools' ),

--- a/dt-apps/dt-home/magic-link-home-app.php
+++ b/dt-apps/dt-home/magic-link-home-app.php
@@ -132,7 +132,7 @@ class DT_Home_Magic_Link_App extends DT_Magic_Url_Base {
         // Enqueue menu toggle JavaScript
         wp_enqueue_script( 'dt-home-menu-toggle', get_template_directory_uri() . '/dt-apps/dt-home/assets/js/menu-toggle.js', [], '1.0.0', true );
 
-        wp_enqueue_script( 'dt-home-app', get_template_directory_uri() . '/dt-apps/dt-home/assets/js/home-app.js', [], '1.0.0', true );
+        wp_enqueue_script( 'dt-home-app', get_template_directory_uri() . '/dt-apps/dt-home/assets/js/home-app.js', [], '1.0.1', true );
 
         // Pass logout URL and invite settings to menu toggle script
         if ( function_exists( 'dt_home_get_logout_url' ) ) {

--- a/dt-apps/dt-home/magic-link-home-app.php
+++ b/dt-apps/dt-home/magic-link-home-app.php
@@ -508,8 +508,6 @@ class DT_Home_Magic_Link_App extends DT_Magic_Url_Base {
         // Update logged-in user state if required accordingly, based on their sys_type
         if ( !is_user_logged_in() ) {
             DT_ML_Helper::update_user_logged_in_state();
-            $current_user = wp_get_current_user();
-            $current_user->add_cap( 'access_contacts' ); // give access to get contact id from user id
         }
 
         // Handle different actions

--- a/dt-apps/dt-home/magic-link-home-app.php
+++ b/dt-apps/dt-home/magic-link-home-app.php
@@ -505,11 +505,6 @@ class DT_Home_Magic_Link_App extends DT_Magic_Url_Base {
         $user_id = (int) $params['parts']['post_id'];
         $action = $params['action'];
 
-        // Update logged-in user state if required accordingly, based on their sys_type
-        if ( !is_user_logged_in() ) {
-            DT_ML_Helper::update_user_logged_in_state();
-        }
-
         // Handle different actions
         if ( $action === 'get_apps' ) {
             // Get apps only (filtered by user permissions)

--- a/dt-reports/magic-url-base.php
+++ b/dt-reports/magic-url-base.php
@@ -46,24 +46,10 @@ abstract class DT_Magic_Url_Base {
         if ( $this->type !== $this->parts['type'] ){
             return;
         }
-        if ( !empty( $this->parts['public_key'] ) ){
-            if ( $this->parts['post_type'] === 'user' ){
-                // if user
-                $user_id = $this->magic->get_user_id( $this->parts['meta_key'], $this->parts['public_key'] );
-                if ( ! $user_id ){ // fail if no post id for public key
-                    $this->magic->redirect_to_expired_landing_page();
-                } else {
-                    $this->parts['post_id'] = $user_id;
-                }
-            } else {
-                // get post_id
-                $post_id = $this->magic->get_post_id( $this->parts['meta_key'], $this->parts['public_key'] );
-                if ( ! $post_id ){ // fail if no post id for public key
-                    $this->magic->redirect_to_expired_landing_page();
-                } else {
-                    $this->parts['post_id'] = $post_id;
-                }
-            }
+
+        $this->magic->determine_post_id( $this->parts );
+        if ( empty( $this->parts['post_id'] ) ){
+            $this->magic->redirect_to_expired_landing_page();
         }
 
 

--- a/dt-reports/magic-url-class.php
+++ b/dt-reports/magic-url-class.php
@@ -377,6 +377,29 @@ if ( ! class_exists( 'DT_Magic_URL' ) ) {
             return $return_parts ? $parts : true;
         }
 
+        /**
+         * Determine the post ID based on the magic URL parts.
+         * @param array $parts The magic URL parts.
+         * @return void
+         */
+        public function determine_post_id( &$parts ) {
+            if ( !empty( $parts['public_key'] ) ){
+                if ( $parts['post_type'] === 'user' ){
+                    // if user
+                    $user_id = $this->get_user_id( $parts['meta_key'], $parts['public_key'] );
+                    if ( $user_id ) {
+                        $parts['post_id'] = $user_id;
+                    }
+                } else {
+                    // get post_id
+                    $post_id = $this->get_post_id( $parts['meta_key'], $parts['public_key'] );
+                    if ( $post_id ) {
+                        $parts['post_id'] = $post_id;
+                    }
+                }
+            }
+        }
+
         public function get_post_id( string $meta_key, string $public_key ){
             global $wpdb;
             $result = $wpdb->get_var( $wpdb->prepare( "
@@ -404,6 +427,29 @@ if ( ! class_exists( 'DT_Magic_URL' ) ) {
                 return $result;
             }
             return false;
+        }
+
+        /**
+         * Get the current user ID from the magic link parts or the currently logged-in user
+         * @param $parts string[] Links parts with post_id and post_type set
+         * @return int
+         */
+        public static function get_current_user_id( array $parts ) {
+            $user_id = get_current_user_id();
+
+            if ( isset( $parts['post_id'], $parts['post_id'] ) ) {
+                $post_id = $parts['post_id'];
+                $post_type = $parts['post_type'];
+                if ( $post_type === 'user' && !empty( $post_id ) ) {
+                    $user_id = (int) $post_id;
+                } else if ( $post_type === 'contacts' && !empty( $post_id ) ) {
+                    $contact_user_id = Disciple_Tools_Users::get_user_for_contact( $post_id );
+                    if ( !empty( $contact_user_id ) && !is_wp_error( $contact_user_id ) ) {
+                        $user_id = (int) $contact_user_id;
+                    }
+                }
+            }
+            return $user_id;
         }
 
         public function is_valid_base_url( string $type ) {

--- a/dt-reports/magic-url-class.php
+++ b/dt-reports/magic-url-class.php
@@ -437,7 +437,7 @@ if ( ! class_exists( 'DT_Magic_URL' ) ) {
         public static function get_current_user_id( array $parts ) {
             $user_id = get_current_user_id();
 
-            if ( isset( $parts['post_id'], $parts['post_id'] ) ) {
+            if ( isset( $parts['post_id'], $parts['post_type'] ) ) {
                 $post_id = $parts['post_id'];
                 $post_type = $parts['post_type'];
                 if ( $post_type === 'user' && !empty( $post_id ) ) {


### PR DESCRIPTION
Currently, the new home app doesn't respect the setting to not require login. It still redirects users through the login. This resolves that an fixes subsequent issues for getting the proper app URLs based on the magic link user instead of the current user.

Some added AI summary from my second commit, which is the bulk of the changes:

>Ensures correct user identification when using magic URLs, especially in scenarios where the user is not explicitly logged in.
>
>This change centralizes user ID retrieval using `DT_Magic_URL::get_current_user_id` to consistently determine the user based on the magic link's `post_id` and `post_type`. This prevents issues where the wrong user context was being applied, for example when generating the "Home" link or when determining which apps to display.
>
>It also updates the launcher to pass the user ID to the magic URL generation functions, so that the correct home link is displayed for the user.

This affects the URLs that are used on the main home app screen as well as the app links in the launcher nav and home button. Hopefully there aren't other things I missed, but I'm not entirely sure.