### PR TITLE
Move `dt_home_screen_apps` option init so it doesn't reset value

### DIFF
--- a/dt-apps/dt-home/includes/class-home-apps.php
+++ b/dt-apps/dt-home/includes/class-home-apps.php
@@ -29,9 +29,6 @@ class DT_Home_Apps {
     }
 
     public function __construct() {
-        // Initialize with default apps if none exist
-        $this->initialize_default_apps();
-
         // Register init hook to handle filter timing
         add_action( 'init', [ $this, 'on_init' ], 20 );
     }
@@ -55,6 +52,9 @@ class DT_Home_Apps {
         // This is where we can safely load apps after all classes are loaded
         $this->load_magic_link_apps();
         $this->load_home_apps();
+
+        // Initialize with default apps if none exist
+        $this->initialize_default_apps();
     }
 
     /**


### PR DESCRIPTION
resolves #2885
If no custom apps are created and `dt_home_screen_apps` wp_option is empty, the init function seems to run too soon before coded apps are registered and causes the option value to be overwritten. This moves it after the hook for registering coded apps.