### PR TITLE
Re-layout masonry when fields are resized

### DIFF
--- a/dt-assets/js/details.js
+++ b/dt-assets/js/details.js
@@ -1,3 +1,6 @@
+/*
+global ResizeObserver
+ */
 'use strict';
 jQuery(document).ready(function ($) {
   let post_id = window.detailsSettings.post_id;
@@ -1248,6 +1251,22 @@ jQuery(document).ready(function ($) {
     );
     service.initialize();
     window.componentService = service;
+  }
+
+  // When components are resized, re-layout the masonry grid
+  const targetElement = document.querySelectorAll('.grid .bordered-box .cell');
+  let resizeTimeout;
+  const resizeObserver = new ResizeObserver((entries) => {
+    for (let entry of entries) {
+      // many of these can be triggered on initial load, so debounce them with a timeout
+      clearTimeout(resizeTimeout);
+      resizeTimeout = setTimeout(() => {
+        window.masonGrid.masonry('layout');
+      }, 100);
+    }
+  });
+  for (let element of targetElement) {
+    resizeObserver.observe(element);
   }
 });
 


### PR DESCRIPTION
https://github.com/DiscipleTools/disciple-tools-theme/issues/2898

Related to https://github.com/DiscipleTools/disciple-tools-web-components/pull/198 which removes the resize observer inside dt-file-upload, since this branch puts in in the theme js