### PR TITLE
fix magic url base to not redirect keyless links to expired page

### DIFF
--- a/dt-reports/magic-url-base.php
+++ b/dt-reports/magic-url-base.php
@@ -48,7 +48,7 @@ abstract class DT_Magic_Url_Base {
         }
 
         $this->magic->determine_post_id( $this->parts );
-        if ( empty( $this->parts['post_id'] ) ){
+        if ( !empty( $this->parts['public_key'] ) && empty( $this->parts['post_id'] ) ){
             $this->magic->redirect_to_expired_landing_page();
         }
 


### PR DESCRIPTION
restore public_key guard removed in befbd76ba so redirect-only magic links (e.g. newest/map) are not killed before child constructors run