### PR TITLE
Reset health circle option icon when alternate set

### DIFF
--- a/dt-core/admin/admin-settings-endpoints.php
+++ b/dt-core/admin/admin-settings-endpoints.php
@@ -975,14 +975,14 @@ class Disciple_Tools_Admin_Settings_Endpoints {
                     'description' => $new_field_option_description,
                 ];
 
-            if ( $field_option_icon ){
+            if ( $field_option_icon ) {
                 $field_option_icon = strtolower( trim( $field_option_icon ) );
                 $icon_key = ( strpos( $field_option_icon, 'mdi' ) !== 0 ) ? 'icon' : 'font-icon';
-                $custom_field_options[$post_type][$field_key]['default'][$new_field_option_key][$icon_key] = $field_option_icon;
+                $null_icon_key = ( $icon_key === 'font-icon' ) ? 'icon' : 'font-icon';
 
-                if ( $icon_key == 'font-icon' ){
-                    $custom_field_options[$post_type][$field_key]['default'][$new_field_option_key]['icon'] = '';
-                }
+                // reset unused icon key
+                $custom_field_options[ $post_type ][ $field_key ]['default'][ $new_field_option_key ][ $icon_key ]      = $field_option_icon;
+                $custom_field_options[ $post_type ][ $field_key ]['default'][ $new_field_option_key ][ $null_icon_key ] = null;
             }
 
             update_option( 'dt_field_customizations', $custom_field_options );
@@ -1021,17 +1021,14 @@ class Disciple_Tools_Admin_Settings_Endpoints {
             $custom_field_option['description'] = $new_field_option_description;
         }
 
-        if ( $field_option_icon && strpos( $field_option_icon, 'undefined' ) === false ){
+        if ( $field_option_icon && strpos( $field_option_icon, 'undefined' ) === false ) {
             $field_option_icon = strtolower( trim( $field_option_icon ) );
             $icon_key = ( strpos( $field_option_icon, 'mdi' ) !== 0 ) ? 'icon' : 'font-icon';
+            $null_icon_key = ( $icon_key === 'font-icon' ) ? 'icon' : 'font-icon';
 
-            if ( $field_option_icon !== $field_option[$icon_key] ){
-                $custom_field_option[$icon_key] = $field_option_icon;
-            }
-
-            if ( $icon_key == 'font-icon' ){
-                $custom_field_option['icon'] = '';
-            }
+            // reset unused icon key
+            $custom_field_option[ $icon_key ]      = $field_option_icon;
+            $custom_field_option[ $null_icon_key ] = null;
         }
 
         // Create default_name to store the default field option label if it changed

--- a/dt-core/admin/menu/tabs/tab-custom-fields.php
+++ b/dt-core/admin/menu/tabs/tab-custom-fields.php
@@ -1036,7 +1036,8 @@ class Disciple_Tools_Tab_Custom_Fields extends Disciple_Tools_Abstract_Menu_Base
             //restore field icon
             if ( isset( $post_submission['restore_field_icon'] ) ) {
                 $restore_icon_defaults = apply_filters( 'dt_custom_fields_settings', [], $post_type );
-                $custom_field['icon']  = $restore_icon_defaults[ $field_key ]['icon'];
+                $custom_field['icon'] = $restore_icon_defaults[ $field_key ]['icon'] ?? '';
+                $custom_field['font-icon'] = $restore_icon_defaults[ $field_key ]['font-icon'] ?? null;
             }
 
             // number field options
@@ -1138,10 +1139,8 @@ class Disciple_Tools_Tab_Custom_Fields extends Disciple_Tools_Abstract_Menu_Base
                                 $null_icon_key = ( $icon_key === 'font-icon' ) ? 'icon' : 'font-icon';
 
                                 // Update icon accordingly and nullify alternative
-                                if ( ! isset( $field_options[ $option_key ][ $icon_key ] ) || $field_options[ $option_key ][ $icon_key ] != $val ) {
-                                    $custom_field['default'][ $option_key ][ $icon_key ]      = $val;
-                                    $custom_field['default'][ $option_key ][ $null_icon_key ] = null;
-                                }
+                                $custom_field['default'][ $option_key ][ $icon_key ]      = $val;
+                                $custom_field['default'][ $option_key ][ $null_icon_key ] = null;
                                 $field_options[ $option_key ][ $icon_key ] = $val;
                             }
                         } else {
@@ -1179,14 +1178,23 @@ class Disciple_Tools_Tab_Custom_Fields extends Disciple_Tools_Abstract_Menu_Base
                 }
                 //delete icon
                 if ( isset( $post_submission['delete_icon'] ) ) {
-                    $custom_field['default'][ $post_submission['delete_icon'] ]['icon'] = '';
-                    $field_options[ $post_submission['delete_icon'] ]['icon']           = '';
+                    $option_key = $post_submission['delete_icon'];
+                    $custom_field['default'][ $option_key ]['icon'] = null;
+                    $custom_field['default'][ $option_key ]['font-icon'] = null;
+                    $field_options[ $option_key ]['icon'] = null;
+                    $field_options[ $option_key ]['font-icon'] = null;
                 }
                 //restore icon
                 if ( isset( $post_submission['restore_icon'] ) ) {
-                    $restore_icon_defaults                                               = apply_filters( 'dt_custom_fields_settings', [], $post_type );
-                    $custom_field['default'][ $post_submission['restore_icon'] ]['icon'] = $restore_icon_defaults[ $field_key ]['default'][ $post_submission['restore_icon'] ]['icon'];
-                    $field_options[ $post_submission['restore_icon'] ]['icon']           = $restore_icon_defaults[ $field_key ]['default'][ $post_submission['restore_icon'] ]['icon'];
+                    $option_key = $post_submission['restore_icon'];
+                    $restore_icon_defaults = apply_filters( 'dt_custom_fields_settings', [], $post_type );
+                    $default_icon = $restore_icon_defaults[ $field_key ]['default'][ $option_key ]['icon'] ?? '';
+                    $default_font_icon = $restore_icon_defaults[ $field_key ]['default'][ $option_key ]['font-icon'] ?? null;
+
+                    $custom_field['default'][ $option_key ]['icon'] = $default_icon;
+                    $custom_field['default'][ $option_key ]['font-icon'] = $default_font_icon;
+                    $field_options[ $option_key ]['icon'] = $default_icon;
+                    $field_options[ $option_key ]['font-icon'] = $default_font_icon;
                 }
                 //delete option
                 if ( isset( $post_submission['delete_option'] ) ){

--- a/dt-core/admin/menu/tabs/tab-custom-fields.php
+++ b/dt-core/admin/menu/tabs/tab-custom-fields.php
@@ -1036,7 +1036,7 @@ class Disciple_Tools_Tab_Custom_Fields extends Disciple_Tools_Abstract_Menu_Base
             //restore field icon
             if ( isset( $post_submission['restore_field_icon'] ) ) {
                 $restore_icon_defaults = apply_filters( 'dt_custom_fields_settings', [], $post_type );
-                $custom_field['icon'] = $restore_icon_defaults[ $field_key ]['icon'] ?? '';
+                $custom_field['icon'] = $restore_icon_defaults[ $field_key ]['icon'] ?? null;
                 $custom_field['font-icon'] = $restore_icon_defaults[ $field_key ]['font-icon'] ?? null;
             }
 


### PR DESCRIPTION
User reported that after creating a custom health circle icon with MDI icon and trying to change it to a custom image, the MDI icon continued to show. I found that the `font-icon` property wasn't cleared when and `icon` was added. This resolves that by clearing the other property when one of them is set.