### PR TITLE
Fix `/login` 404 status code

### DIFF
--- a/dt-login/login-template.php
+++ b/dt-login/login-template.php
@@ -22,6 +22,7 @@ nocache_headers();
 // Fix for page title
 global $wp_query;
 $wp_query->is_404 = false;
+status_header( 200 );
 
 
 

--- a/dt-login/pages/base.php
+++ b/dt-login/pages/base.php
@@ -15,6 +15,7 @@ class DT_Login_Page_Base
     }
 
     public function theme_redirect() {
+        status_header( 200 );
         $path = get_theme_file_path( 'template-blank.php' );
         include( $path );
         die();


### PR DESCRIPTION
When enabling the SSO custom login page, although the page loads correctly, it technically returns a 404 status code. The same is true of the privacy and terms pages. This resolves that by setting a 200 status for those pages.
