### PR TITLE
Security hardening: authorization, input validation, and logging

### DIFF
--- a/dt-apps/dt-home/magic-link-home-app.php
+++ b/dt-apps/dt-home/magic-link-home-app.php
@@ -491,12 +491,7 @@ class DT_Home_Magic_Link_App extends DT_Magic_Url_Base {
     public function endpoint_get( WP_REST_Request $request ) {
         $params = $request->get_params();
 
-        // Debug logging
-        error_log( 'DT Home Screen REST endpoint called' );
-        error_log( 'Request params: ' . print_r( $params, true ) );
-
         if ( ! isset( $params['parts'], $params['action'] ) ) {
-            error_log( 'Missing parameters - parts: ' . ( isset( $params['parts'] ) ? 'yes' : 'no' ) . ', action: ' . ( isset( $params['action'] ) ? 'yes' : 'no' ) );
             return new WP_Error( __METHOD__, 'Missing parameters', [ 'status' => 400 ] );
         }
 
@@ -511,8 +506,6 @@ class DT_Home_Magic_Link_App extends DT_Magic_Url_Base {
             $apps_manager = DT_Home_Apps::instance();
             $apps = $apps_manager->get_apps_for_user( $user_id );
 
-            error_log( 'Apps found: ' . count( $apps ) );
-
             return [
                 'success' => true,
                 'apps' => $apps,
@@ -523,8 +516,6 @@ class DT_Home_Magic_Link_App extends DT_Magic_Url_Base {
             // Get training videos only
             $training_manager = DT_Home_Training::instance();
             $training_videos = $training_manager->get_videos_for_frontend();
-
-            error_log( 'Training videos found: ' . count( $training_videos ) );
 
             return [
                 'success' => true,
@@ -540,9 +531,6 @@ class DT_Home_Magic_Link_App extends DT_Magic_Url_Base {
             // Get apps filtered by user permissions
             $apps = $apps_manager->get_apps_for_user( $user_id );
             $training_videos = $training_manager->get_videos_for_frontend();
-
-            error_log( 'Apps found: ' . count( $apps ) );
-            error_log( 'Training videos found: ' . count( $training_videos ) );
 
             return [
                 'success' => true,

--- a/dt-assets/js/comments.js
+++ b/dt-assets/js/comments.js
@@ -731,9 +731,9 @@ jQuery(document).ready(function ($) {
           );
         }
 
-        $('.revert-field').html(field || a.meta_key);
-        $('.revert-current-value').html(a.meta_value);
-        $('.revert-old-value').html(a.old_value || 0);
+        $('.revert-field').text(field || a.meta_key);
+        $('.revert-current-value').text(a.meta_value);
+        $('.revert-old-value').text(a.old_value || 0);
       })
       .catch((err) => {
         console.error(err);

--- a/dt-assets/js/details.js
+++ b/dt-assets/js/details.js
@@ -1103,7 +1103,7 @@ jQuery(document).ready(function ($) {
           onClick: function (node, a, item) {
             $('.confirm-merge-with-post').show();
             $('#confirm-merge-with-post-id').val(item.ID);
-            $('#name-of-post-to-merge').html(item.name);
+            $('#name-of-post-to-merge').text(item.name);
           },
           onResult: function (node, query, result, resultCount) {
             let text = window.TYPEAHEADS.typeaheadHelpText(

--- a/dt-assets/js/modular-list.js
+++ b/dt-assets/js/modular-list.js
@@ -667,7 +667,7 @@
         <img style="padding: 0 4px" src="${window.wpApiShare.template_dir}/dt-assets/images/trash.svg">
       </span>`);
         delete_filter.on('click', function () {
-          $(`.delete-filter-name`).html(filter.name);
+          $(`.delete-filter-name`).text(filter.name);
           $('#delete-filter-modal').foundation('open');
           filter_to_delete = filter.ID;
         });

--- a/dt-contacts/contacts-transfer.php
+++ b/dt-contacts/contacts-transfer.php
@@ -536,7 +536,11 @@ class Disciple_Tools_Contacts_Transfer {
         $lagging_meta_input = [];
         $lagging_location_meta_input = [];
         $errors             = new WP_Error();
-        $site_link_post_id  = Site_Link_System::get_post_id_by_site_key( Site_Link_System::decrypt_transfer_token( $params['transfer_token'] ) );
+        $site_link_post_id  = empty( $params['transfer_token'] ) ? false : Site_Link_System::get_post_id_by_site_key( Site_Link_System::decrypt_transfer_token( $params['transfer_token'] ) );
+        if ( empty( $site_link_post_id ) ) {
+            $errors->add( 'transfer_token_invalid', 'Invalid or missing transfer token' );
+            return $errors;
+        }
         $field_settings = DT_Posts::get_post_field_settings( $post_args['post_type'] );
 
         /**
@@ -554,7 +558,7 @@ class Disciple_Tools_Contacts_Transfer {
                 if ( $key === 'type' && $value[0] === 'media' ) {
                     $value[0] = 'access';
                 }
-                $meta_input[ $key ] = maybe_unserialize( $value[0] );
+                $meta_input[ $key ] = is_serialized( $value[0] ) ? unserialize( $value[0], [ 'allowed_classes' => false ] ) : $value[0];
             }
         }
         $post_args['meta_input'] = $meta_input;

--- a/dt-contacts/duplicates-merging.php
+++ b/dt-contacts/duplicates-merging.php
@@ -485,6 +485,11 @@ class DT_Duplicate_Checker_And_Merging {
             return $archiving_post;
         }
 
+        // A merge mutates both records, so the caller must be able to update both.
+        if ( !DT_Posts::can_update( $post_type, $primary_post_id ) || !DT_Posts::can_update( $post_type, $archiving_post_id ) ) {
+            return new WP_Error( __METHOD__, 'No permissions to merge these records', [ 'status' => 403 ] );
+        }
+
         // Ignore specified fields
         $ignored_fields = [
             'post_date'

--- a/dt-core/admin/admin-settings-endpoints.php
+++ b/dt-core/admin/admin-settings-endpoints.php
@@ -787,20 +787,37 @@ class Disciple_Tools_Admin_Settings_Endpoints {
     public function plugin_install( WP_REST_Request $request ) {
         require_once( ABSPATH . 'wp-admin/includes/file.php' );
         $params = $request->get_params();
-        $download_url = sanitize_text_field( wp_unslash( $params['download_url'] ) );
+        $download_url = sanitize_text_field( wp_unslash( $params['download_url'] ?? '' ) );
+
+        // Only fetch validated, externally-routable http(s) URLs. wp_http_validate_url() rejects
+        // loopback, private and link-local addresses, closing server-side request forgery.
+        if ( empty( $download_url )
+            || ! wp_http_validate_url( $download_url )
+            || ! in_array( wp_parse_url( $download_url, PHP_URL_SCHEME ), [ 'http', 'https' ], true ) ) {
+            return new WP_Error( 'invalid_download_url', 'Invalid download URL.', [ 'status' => 400 ] );
+        }
+
+        // wp_http_validate_url() does not cover link-local (e.g. 169.254.169.254 cloud metadata)
+        // or all reserved ranges; reject any host that resolves into a private or reserved network.
+        $resolved_ip = gethostbyname( (string) wp_parse_url( $download_url, PHP_URL_HOST ) );
+        if ( filter_var( $resolved_ip, FILTER_VALIDATE_IP )
+            && ! filter_var( $resolved_ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+            return new WP_Error( 'invalid_download_url', 'Invalid download URL.', [ 'status' => 400 ] );
+        }
+
         set_time_limit( 0 );
-        $folder_name = explode( '/', $download_url );
-        $folder_name = get_home_path() . 'wp-content/plugins/' . $folder_name[4] . '.zip';
-        if ( $folder_name != '' ) {
-            //download the zip file to plugins
-            file_put_contents( $folder_name, file_get_contents( $download_url ) );
-            // get the absolute path to $file
-            $folder_name = realpath( $folder_name );
-            //unzip
-            WP_Filesystem();
-            $unzip = unzip_file( $folder_name, realpath( get_home_path() . 'wp-content/plugins/' ) );
-            //remove the file
-            unlink( $folder_name );
+        WP_Filesystem();
+
+        // Download to a temp file through the HTTP API rather than reading the URL directly.
+        $tmp_file = download_url( $download_url );
+        if ( is_wp_error( $tmp_file ) ) {
+            return $tmp_file;
+        }
+
+        $unzip = unzip_file( $tmp_file, realpath( get_home_path() . 'wp-content/plugins/' ) );
+        unlink( $tmp_file );
+        if ( is_wp_error( $unzip ) ) {
+            return $unzip;
         }
         return true;
     }

--- a/dt-core/admin/site-link-post-type.php
+++ b/dt-core/admin/site-link-post-type.php
@@ -1419,7 +1419,7 @@ if ( ! class_exists( 'Site_Link_System' ) ) {
                  */
 
                 if ( isset( $array['token'], $array['token_as_transfer_key'] ) && $array['token_as_transfer_key'] ){
-                    if ( $array['token'] == $transfer_token ){
+                    if ( hash_equals( (string) $array['token'], (string) $transfer_token ) ){
                         return $key;
                     }
                 } else {
@@ -1429,9 +1429,9 @@ if ( ! class_exists( 'Site_Link_System' ) ) {
                     $next = gmdate( 'Y-m-dH', strtotime( current_time( 'Y-m-d H:i:s', 1 ) . '+1 hour' ) );
                     $next_hour = md5( $key . $next );
 
-                    if ( $current_hour == $transfer_token
-                        || $past_hour == $transfer_token
-                        || $next_hour == $transfer_token ){
+                    if ( hash_equals( $current_hour, (string) $transfer_token )
+                        || hash_equals( $past_hour, (string) $transfer_token )
+                        || hash_equals( $next_hour, (string) $transfer_token ) ){
 
                         return $key;
                     }

--- a/dt-core/core-endpoints.php
+++ b/dt-core/core-endpoints.php
@@ -55,8 +55,8 @@ class Disciple_Tools_Core_Endpoints {
      */
     public static function get_settings() {
         $user = wp_get_current_user();
-        if ( !$user ){
-            return new WP_Error( 'get_settings', 'Something went wrong. Are you a user?', [ 'status' => 400 ] );
+        if ( !$user->exists() ){
+            return new WP_Error( 'get_settings', 'Something went wrong. Are you a user?', [ 'status' => 401 ] );
         }
         $available_translations = dt_get_available_languages();
         $post_types = DT_Posts::get_post_types();

--- a/dt-core/dt-storage.php
+++ b/dt-core/dt-storage.php
@@ -165,12 +165,25 @@ class DT_Storage_API {
         $tmp = $upload['tmp_name'] ?? '';
         $type = $upload['type'] ?? '';
 
+        // Derive the real content type from the file's bytes rather than trusting the
+        // client-supplied value, and never store uploads as inline-executable content:
+        // anything that is not a known raster image is served as a download.
+        if ( $tmp && function_exists( 'finfo_open' ) && ( $finfo = finfo_open( FILEINFO_MIME_TYPE ) ) ) {
+            $detected = finfo_file( $finfo, $tmp );
+            finfo_close( $finfo );
+            if ( !empty( $detected ) ) {
+                $type = $detected;
+            }
+        }
+        $safe_inline_types = [ 'image/gif', 'image/jpeg', 'image/png', 'image/webp' ];
+        $content_type = in_array( strtolower( trim( $type ) ), $safe_inline_types, true ) ? $type : 'application/octet-stream';
+
         try {
             $client->putObject([
                 'Bucket' => $bucket,
                 'Key' => $key,
                 'Body' => fopen( $tmp, 'r' ),
-                'ContentType' => $type
+                'ContentType' => $content_type
             ]);
 
             $uploaded_thumbnail_key = null;

--- a/dt-core/dt-storage.php
+++ b/dt-core/dt-storage.php
@@ -168,11 +168,14 @@ class DT_Storage_API {
         // Derive the real content type from the file's bytes rather than trusting the
         // client-supplied value, and never store uploads as inline-executable content:
         // anything that is not a known raster image is served as a download.
-        if ( $tmp && function_exists( 'finfo_open' ) && ( $finfo = finfo_open( FILEINFO_MIME_TYPE ) ) ) {
-            $detected = finfo_file( $finfo, $tmp );
-            finfo_close( $finfo );
-            if ( !empty( $detected ) ) {
-                $type = $detected;
+        if ( $tmp && function_exists( 'finfo_open' ) ) {
+            $finfo = finfo_open( FILEINFO_MIME_TYPE );
+            if ( $finfo ) {
+                $detected = finfo_file( $finfo, $tmp );
+                finfo_close( $finfo );
+                if ( !empty( $detected ) ) {
+                    $type = $detected;
+                }
             }
         }
         $safe_inline_types = [ 'image/gif', 'image/jpeg', 'image/png', 'image/webp' ];

--- a/dt-core/jwt-rate-limit.php
+++ b/dt-core/jwt-rate-limit.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Brute-force throttle for the JWT authentication token endpoint.
+ *
+ * The /jwt-auth/v1/token endpoint verifies credentials with no built-in rate
+ * limiting, so it can be used for unthrottled online password guessing. This
+ * caps repeated failures from a single client IP within a time window. It is
+ * scoped to the JWT token endpoint only — wp-login and XML-RPC are untouched —
+ * so it does not overlap with login-form limiters. Sites running a dedicated
+ * security plugin (e.g. Wordfence) that already covers REST authentication can
+ * disable it with: add_filter( 'dt_enable_jwt_login_throttle', '__return_false' ).
+ */
+
+if ( !defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * The client IP used to bucket throttle counters. Defaults to the TCP peer
+ * (REMOTE_ADDR), which a request cannot spoof via headers. Sites behind a
+ * trusted reverse proxy can supply the forwarded client IP via the filter.
+ *
+ * @return string
+ */
+function dt_jwt_throttle_client_ip() {
+    $ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+    return (string) apply_filters( 'dt_jwt_throttle_client_ip', $ip );
+}
+
+/**
+ * Transient key holding the recent-failure count for the current client IP.
+ *
+ * @return string
+ */
+function dt_jwt_throttle_key() {
+    return 'dt_jwt_throttle_' . md5( dt_jwt_throttle_client_ip() );
+}
+
+/**
+ * Whether the current request targets the JWT token-mint endpoint (not /validate).
+ *
+ * @param WP_REST_Request|null $request
+ * @return bool
+ */
+function dt_is_jwt_token_request( $request = null ) {
+    if ( $request instanceof WP_REST_Request ) {
+        return $request->get_route() === '/jwt-auth/v1/token';
+    }
+    $path = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+    return strpos( $path, 'jwt-auth/v1/token' ) !== false && strpos( $path, 'token/validate' ) === false;
+}
+
+/**
+ * Reject token requests from a client IP that has exceeded the failure threshold.
+ */
+function dt_jwt_throttle_block( $result, $server, $request ) {
+    if ( $result !== null ) {
+        return $result;
+    }
+    if ( !apply_filters( 'dt_enable_jwt_login_throttle', true ) || !dt_is_jwt_token_request( $request ) ) {
+        return $result;
+    }
+    $max = (int) apply_filters( 'dt_jwt_login_throttle_max_attempts', 10 );
+    if ( (int) get_transient( dt_jwt_throttle_key() ) >= $max ) {
+        return new WP_Error(
+            'jwt_auth_too_many_attempts',
+            __( 'Too many failed login attempts. Please try again later.', 'disciple_tools' ),
+            [ 'status' => 429 ]
+        );
+    }
+    return $result;
+}
+add_filter( 'rest_pre_dispatch', 'dt_jwt_throttle_block', 10, 3 );
+
+/**
+ * Count a failed credential attempt against the client IP, for token requests only.
+ */
+function dt_jwt_throttle_record_failure() {
+    if ( !apply_filters( 'dt_enable_jwt_login_throttle', true ) || !dt_is_jwt_token_request() ) {
+        return;
+    }
+    $window = (int) apply_filters( 'dt_jwt_login_throttle_window', 15 * MINUTE_IN_SECONDS );
+    $key = dt_jwt_throttle_key();
+    set_transient( $key, (int) get_transient( $key ) + 1, $window );
+}
+add_action( 'wp_login_failed', 'dt_jwt_throttle_record_failure' );
+
+/**
+ * Clear the failure counter once a token is successfully issued.
+ */
+function dt_jwt_throttle_clear_on_success( $data, $user ) {
+    delete_transient( dt_jwt_throttle_key() );
+    return $data;
+}
+add_filter( 'jwt_auth_token_before_dispatch', 'dt_jwt_throttle_clear_on_success', 10, 2 );

--- a/dt-metrics/records/date-range-activity.php
+++ b/dt-metrics/records/date-range-activity.php
@@ -272,7 +272,7 @@ class DT_Metrics_Date_Range_Activity extends DT_Metrics_Chart_Base
 
             } elseif ( $field_type == 'user_select' ){
                 $value = $params['value'];
-                $meta_value_sql = ( !empty( $value ) ? "AND meta_value LIKE 'user-" . $value['ID'] . "'" : "AND meta_value LIKE '%'" );
+                $meta_value_sql = ( !empty( $value['ID'] ) ? "AND meta_value LIKE 'user-" . intval( $value['ID'] ) . "'" : "AND meta_value LIKE '%'" );
 
             } else {
                 $meta_value_sql = "AND meta_value LIKE '" . ( empty( $params['value'] ) ? '%' : esc_sql( $params['value'] ) ) . "'";

--- a/dt-metrics/records/dynamic-records-map.php
+++ b/dt-metrics/records/dynamic-records-map.php
@@ -220,6 +220,37 @@ class DT_Metrics_Dynamic_Records_Map extends DT_Metrics_Chart_Base
         ];
     }
 
+    /**
+     * Authorize the current user for a map query and scope the query to the records they may view.
+     *
+     * The 'records' instance is for project-wide maps: only users with all-access or project metrics
+     * permissions may query it, and their results are unscoped. The 'personal' instance requires type
+     * access and limits results to records shared with or assigned to the current user, unless the user
+     * also holds project-wide access.
+     *
+     * @param string $post_type
+     * @param array  $query
+     * @return array|WP_Error The query scoped for the current user, or a WP_Error when not permitted.
+     */
+    private function authorize_and_scope_query( $post_type, $query ) {
+        $has_all_access = current_user_can( 'dt_all_access_' . $post_type ) || current_user_can( 'view_project_metrics' );
+
+        if ( $this->base_slug === 'records' ) {
+            if ( !$has_all_access ) {
+                return new WP_Error( __METHOD__, 'You do not have permission for this.', [ 'status' => 403 ] );
+            }
+            return $query;
+        }
+
+        if ( !current_user_can( 'access_' . $post_type ) ) {
+            return new WP_Error( __METHOD__, 'You do not have permission for this.', [ 'status' => 403 ] );
+        }
+        if ( !$has_all_access ) {
+            $query['shared_with'] = [ 'me' ];
+        }
+        return $query;
+    }
+
     public function cluster_geojson( WP_REST_Request $request ) {
         $params = $request->get_json_params() ?? $request->get_body_params();
         if ( ! isset( $params['post_type'] ) || empty( $params['post_type'] ) ) {
@@ -228,6 +259,11 @@ class DT_Metrics_Dynamic_Records_Map extends DT_Metrics_Chart_Base
         $post_type = $params['post_type'];
         $query = ( isset( $params['query'] ) && !empty( $params['query'] ) ) ? $params['query'] : [];
         $query = dt_array_merge_recursive_distinct( $query, $this->base_filter );
+
+        $query = $this->authorize_and_scope_query( $post_type, $query );
+        if ( is_wp_error( $query ) ) {
+            return $query;
+        }
 
         return Disciple_Tools_Mapping_Queries::cluster_geojson( $post_type, $query );
     }
@@ -242,6 +278,11 @@ class DT_Metrics_Dynamic_Records_Map extends DT_Metrics_Chart_Base
         $post_type = $params['post_type'];
         $query = ( isset( $params['query'] ) && !empty( $params['query'] ) ) ? $params['query'] : [];
         $query = dt_array_merge_recursive_distinct( $query, $this->base_filter );
+
+        $query = $this->authorize_and_scope_query( $post_type, $query );
+        if ( is_wp_error( $query ) ) {
+            return $query;
+        }
         $results = Disciple_Tools_Mapping_Queries::query_location_grid_meta_totals( $post_type, $query );
 
         $list = [];
@@ -262,6 +303,11 @@ class DT_Metrics_Dynamic_Records_Map extends DT_Metrics_Chart_Base
         $query = ( isset( $params['query'] ) && !empty( $params['query'] ) ) ? $params['query'] : [];
         $query = dt_array_merge_recursive_distinct( $query, $this->base_filter );
 
+        $query = $this->authorize_and_scope_query( $post_type, $query );
+        if ( is_wp_error( $query ) ) {
+            return $query;
+        }
+
         return Disciple_Tools_Mapping_Queries::query_under_location_grid_meta_id( $post_type, $grid_id, $query );
     }
 
@@ -277,6 +323,11 @@ class DT_Metrics_Dynamic_Records_Map extends DT_Metrics_Chart_Base
         $post_type = $params['post_type'];
         $query = ( isset( $params['query'] ) && !empty( $params['query'] ) ) ? $params['query'] : [];
         $query = dt_array_merge_recursive_distinct( $query, $this->base_filter );
+
+        $query = $this->authorize_and_scope_query( $post_type, $query );
+        if ( is_wp_error( $query ) ) {
+            return $query;
+        }
 
         return Disciple_Tools_Mapping_Queries::points_geojson( $post_type, $query );
     }

--- a/dt-posts/dt-posts.php
+++ b/dt-posts/dt-posts.php
@@ -2321,15 +2321,20 @@ class DT_Posts extends Disciple_Tools_Posts {
     public static function remove_shared( string $post_type, int $post_id, int $user_id, $check_permissions = true ) {
         global $wpdb;
 
-        if ( $check_permissions && !self::can_update( $post_type, $post_id ) ) {
+        $assigned_to_meta = get_post_meta( $post_id, 'assigned_to', true );
+        $assigned_user_id = dt_get_user_id_from_assigned_to( $assigned_to_meta );
+        $is_self_removal  = ( get_current_user_id() === $user_id );
+
+        // A user may always remove their own share; otherwise they need update permission on the record.
+        if ( $check_permissions && !$is_self_removal && !self::can_update( $post_type, $post_id ) ) {
             return new WP_Error( __FUNCTION__, 'You do not have permission to unshare', [ 'status' => 403 ] );
         }
 
-        $assigned_to_meta = get_post_meta( $post_id, 'assigned_to', true );
-        if ( $check_permissions && !( self::can_update( $post_type, $post_id ) ||
-                 get_current_user_id() === $user_id ||
-                 dt_get_user_id_from_assigned_to( $assigned_to_meta ) === get_current_user_id() )
-        ){
+        // The assigned user's foundational share may only be removed by that user, or by someone with
+        // record-type update authority — not by a collaborator who merely holds a share on the record.
+        if ( $check_permissions && !$is_self_removal
+                && (int) $assigned_user_id === $user_id
+                && !current_user_can( 'update_any_' . $post_type ) ) {
             $name = dt_get_user_display_name( $user_id );
             return new WP_Error( __FUNCTION__, 'You do not have permission to unshare with ' . $name, [ 'status' => 403 ] );
         }

--- a/dt-posts/dt-posts.php
+++ b/dt-posts/dt-posts.php
@@ -2336,7 +2336,11 @@ class DT_Posts extends Disciple_Tools_Posts {
                 && (int) $assigned_user_id === $user_id
                 && !current_user_can( 'update_any_' . $post_type ) ) {
             $name = dt_get_user_display_name( $user_id );
-            return new WP_Error( __FUNCTION__, 'You do not have permission to unshare with ' . $name, [ 'status' => 403 ] );
+            return new WP_Error( __FUNCTION__, sprintf(
+                /* translators: %s is the assigned user's display name */
+                __( '%s is assigned to this record, so their access cannot be removed by unsharing.', 'disciple_tools' ),
+                $name
+            ), [ 'status' => 403 ] );
         }
 
 

--- a/dt-posts/dt-posts.php
+++ b/dt-posts/dt-posts.php
@@ -1775,8 +1775,8 @@ class DT_Posts extends Disciple_Tools_Posts {
     }
 
     public static function revert_post_activity_history( string $post_type, int $post_id, array $args = [] ){
-        if ( !self::can_view( $post_type, $post_id ) ){
-            return new WP_Error( __FUNCTION__, 'No permissions to read: ' . $post_type, [ 'status' => 403 ] );
+        if ( !self::can_update( $post_type, $post_id ) ){
+            return new WP_Error( __FUNCTION__, 'No permissions to update: ' . $post_type, [ 'status' => 403 ] );
         }
 
         /**

--- a/dt-posts/posts.php
+++ b/dt-posts/posts.php
@@ -1347,17 +1347,20 @@ class Disciple_Tools_Posts
                              AND meta_value LIKE '%" . esc_sql( $search ) . "%'
                 ) ";
             }
-            $post_query .= ' ) ';
-
             if ( $post_type === 'peoplegroups' ) {
 
                 $locale = get_user_locale();
 
-                $post_query .= " OR p.ID IN ( SELECT post_id
+                if ( substr( $post_query, -6 ) !== 'AND ( ' ) {
+                    $post_query .= 'OR ';
+                }
+                $post_query .= "p.ID IN ( SELECT post_id
                                   FROM $wpdb->postmeta
                                   WHERE meta_key LIKE '" . esc_sql( $locale ) . "'
-                                  AND meta_value LIKE '%" . esc_sql( $search ) . "%' )";
+                                  AND meta_value LIKE '%" . esc_sql( $search ) . "%' ) ";
             }
+
+            $post_query .= ' ) ';
         }
 
         $sort_sql = '';

--- a/dt-users/users-endpoints.php
+++ b/dt-users/users-endpoints.php
@@ -221,8 +221,6 @@ class Disciple_Tools_Users_Endpoints
 
         $user_id = get_current_user_id();
         if ( isset( $params['password'] ) && $user_id ){
-            dt_write_log( $params['password'] );
-
             wp_set_password( $params['password'], $user_id );
             wp_logout();
             wp_redirect( '/' );

--- a/functions.php
+++ b/functions.php
@@ -150,6 +150,7 @@ class Disciple_Tools
         if ( !class_exists( 'Jwt_Auth' ) ) {
             require_once( 'dt-core/libraries/wp-api-jwt-auth/jwt-auth.php' );
         }
+        require_once( 'dt-core/jwt-rate-limit.php' ); // throttles brute-force attempts against the JWT token endpoint
         require_once( 'dt-core/configuration/config-site-defaults.php' ); // Force required site configurations
         require_once( 'dt-core/wp-async-request.php' ); // Async Task Processing
         require_once( 'dt-core/configuration/restrict-rest-api.php' ); // sets authentication requirement for rest end points. Disables rest for pre-wp-4.7 sites.


### PR DESCRIPTION
## Summary

Security hardening across authorization, input validation, authentication, and logging. These came out of a focused security review of the theme. **None of these are exploitable by an unauthenticated attacker** — the global REST authentication wall (`restrict-rest-api.php`) blocks anonymous REST access, so every item below requires at least a low-privilege authenticated session; several require a specific capability. The changes are additive guards and validation with no intended behavior change for legitimate users.

## Changes by area

**Access control / authorization**
- `dynamic_records_map` metrics endpoints (`cluster_geojson` / `points_geojson` / `get_grid_totals` / `get_list_by_grid_id`) now apply the same capability + `dt_share` scoping as `post_type_geojson`, instead of returning every located record's name + coordinates to any authenticated user.
- `merge_posts` and `revert_post_activity_history` now require `can_update` (both write to records but were gated on `can_view`).
- `remove_shared` now protects the assigned user's foundational share (the previous guard was unreachable) and explicitly allows self-removal.
- People-groups locale search is moved inside the permission group so its `OR` clause no longer escapes the share/status/type filters.

**Injection**
- `date_range_activity`: cast the `user_select` value to an integer before building the meta-value clause (was concatenated into the query unescaped).
- Contact `receive-transfer`: validate the transfer token before processing, and decode incoming postmeta with `unserialize(..., ['allowed_classes' => false])` to remove a PHP object-injection sink.

**Input / upload validation**
- Object-storage uploads now derive the content type from the file's bytes (`finfo`) instead of trusting the client, and store anything that isn't a raster image as `application/octet-stream` so uploads can't be served as inline-executable content.
- `plugin-install` now rejects non-`http(s)` schemes and hosts that resolve to private/loopback/link-local/reserved ranges, and downloads via the WP HTTP API (closes a server-side request forgery vector; admin-only endpoint).

**Authentication hardening**
- Added per-IP brute-force throttling to the `jwt-auth/v1/token` endpoint (transient-based, scoped to that endpoint, disable-able via the `dt_enable_jwt_login_throttle` filter for sites that already run a security plugin).
- `get_settings` uses a real `!$user->exists()` check instead of an always-false guard.
- Site-link transfer tokens are compared with `hash_equals()` (constant-time; removes a numeric-string type-juggling edge). Token format is unchanged, so existing site links keep working.

**Sensitive data in logs**
- Removed a `dt_write_log()` call that wrote the cleartext new password on password change.
- Removed debug `error_log()` calls in the DT Home magic-link endpoint that logged the request params (including the magic-link key) on every request.

## Notes
- Site-link token format intentionally unchanged (interop with linked sites); the `md5`→HMAC and validity-window changes are left for a future versioned protocol change.
- A few items surfaced by the review were intentionally left as-is by design (e.g. cross-CRM duplicate detection, the open-registration default role) and are not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
